### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ Alternatively, add the contents of the CleverTapSDK-Bridging-Header.h to your ex
 To run the example StarterProject, clone the repo, and run `pod install` from the StarterProject directory.  Then open the StarterProject.xcworkspace, add your CleverTap account credentials to the Info.plist and build and run.
 For Swift, please refer to the SwiftStarterProject. 
 
-For non-Cocoapods folks, check out the example StarterProjectManualInstall.  
+For non-CocoaPods folks, check out the example StarterProjectManualInstall.  
 For Swift, please refer to the SwiftStarterProjectManualInstall example. 
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
