### PR TITLE
SDK-526: Adds Deprecation Notice for ABTesting methods

### DIFF
--- a/CleverTapSDK/CleverTap+ABTesting.h
+++ b/CleverTapSDK/CleverTap+ABTesting.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 #import "CleverTap.h"
 
+/**
+ **NOTE: Deprecation Notice - These method has been deprecated by CleverTap, this code will be removed from future versions of the CleverTap iOS SDK.
+*/
+
 typedef void (^CleverTapExperimentsUpdatedBlock)(void);
 
 @interface CleverTap (ABTesting)
@@ -17,7 +21,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  
  @param enabled  whether the editor is enabled
  */
-+ (void)setUIEditorConnectionEnabled:(BOOL)enabled;
++ (void)setUIEditorConnectionEnabled:(BOOL)enabled __attribute((deprecated()));
 
 /*!
  @method
@@ -28,7 +32,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @discussion
  Returns whether the UIEditor connection is enabled.
  */
-+ (BOOL)isUIEditorConnectionEnabled;
++ (BOOL)isUIEditorConnectionEnabled __attribute((deprecated()));
 
 /*!
  @method
@@ -36,7 +40,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a callback block when experiments are updated.
  */
-- (void)registerExperimentsUpdatedBlock:(CleverTapExperimentsUpdatedBlock _Nonnull)block;
+- (void)registerExperimentsUpdatedBlock:(CleverTapExperimentsUpdatedBlock _Nonnull)block __attribute((deprecated()));
 
 /*!
  @method
@@ -44,7 +48,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a bool dynamic variable with a specified name and default value.
  */
-- (void)registerBoolVariableWithName:(NSString* _Nonnull)name;
+- (void)registerBoolVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -52,7 +56,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a double dynamic variable with a specified name and default value.
  */
-- (void)registerDoubleVariableWithName:(NSString* _Nonnull)name;
+- (void)registerDoubleVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -60,7 +64,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a integer dynamic variable with a specified name and default value.
  */
-- (void)registerIntegerVariableWithName:(NSString* _Nonnull)name;
+- (void)registerIntegerVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -68,7 +72,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a string dynamic variable with a specified name and default value.
  */
-- (void)registerStringVariableWithName:(NSString* _Nonnull)name;
+- (void)registerStringVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -76,7 +80,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a dynamic variable of an array containing bools with a specified name and default value.
  */
-- (void)registerArrayOfBoolVariableWithName:(NSString* _Nonnull)name;
+- (void)registerArrayOfBoolVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -84,7 +88,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a dynamic variable of an array containing doubles with a specified name and default value.
  */
-- (void)registerArrayOfDoubleVariableWithName:(NSString* _Nonnull)name;
+- (void)registerArrayOfDoubleVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -92,7 +96,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a dynamic variable of an array containing integers with a specified name and default value.
  */
-- (void)registerArrayOfIntegerVariableWithName:(NSString* _Nonnull)name;
+- (void)registerArrayOfIntegerVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -100,7 +104,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a dynamic variable of an array containing strings with a specified name and default value.
  */
-- (void)registerArrayOfStringVariableWithName:(NSString* _Nonnull)name;
+- (void)registerArrayOfStringVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -108,7 +112,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a dynamic variable of an dictionary with key/value pairs of string/bool with a specified name and default value.
  */
-- (void)registerDictionaryOfBoolVariableWithName:(NSString* _Nonnull)name;
+- (void)registerDictionaryOfBoolVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -116,7 +120,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a dynamic variable of an dictionary with key/value pairs of string/double with a specified name and default value.
  */
-- (void)registerDictionaryOfDoubleVariableWithName:(NSString* _Nonnull)name;
+- (void)registerDictionaryOfDoubleVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -124,7 +128,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a dynamic variable of an dictionary with key/value pairs of string/integer with a specified name and default value.
  */
-- (void)registerDictionaryOfIntegerVariableWithName:(NSString* _Nonnull)name;
+- (void)registerDictionaryOfIntegerVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -132,7 +136,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Register a dynamic variable of an dictionary with key/value pairs of string/string with a specified name and default value.
  */
-- (void)registerDictionaryOfStringVariableWithName:(NSString* _Nonnull)name;
+- (void)registerDictionaryOfStringVariableWithName:(NSString* _Nonnull)name __attribute((deprecated()));
 
 /*!
  @method
@@ -140,7 +144,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a bool dynamic variable that has already been declared.
  */
-- (BOOL)getBoolVariableWithName:(NSString* _Nonnull)name defaultValue:(BOOL)defaultValue;
+- (BOOL)getBoolVariableWithName:(NSString* _Nonnull)name defaultValue:(BOOL)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -148,7 +152,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a double dynamic variable that has already been declared.
  */
-- (double)getDoubleVariableWithName:(NSString* _Nonnull)name defaultValue:(double)defaultValue;
+- (double)getDoubleVariableWithName:(NSString* _Nonnull)name defaultValue:(double)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -156,7 +160,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a integer dynamic variable that has already been declared.
  */
-- (int)getIntegerVariableWithName:(NSString* _Nonnull)name defaultValue:(int)defaultValue;
+- (int)getIntegerVariableWithName:(NSString* _Nonnull)name defaultValue:(int)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -164,7 +168,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a string dynamic variable that has already been declared.
  */
-- (NSString* _Nonnull)getStringVariableWithName:(NSString* _Nonnull)name defaultValue:(NSString * _Nonnull)defaultValue;
+- (NSString* _Nonnull)getStringVariableWithName:(NSString* _Nonnull)name defaultValue:(NSString * _Nonnull)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -172,7 +176,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a bool array dynamic variable that has already been declared.
  */
-- (NSArray<NSNumber*>* _Nonnull)getArrayOfBoolVariableWithName:(NSString* _Nonnull)name defaultValue:(NSArray<NSNumber*>* _Nonnull)defaultValue;
+- (NSArray<NSNumber*>* _Nonnull)getArrayOfBoolVariableWithName:(NSString* _Nonnull)name defaultValue:(NSArray<NSNumber*>* _Nonnull)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -180,7 +184,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a double array dynamic variable that has already been declared.
  */
-- (NSArray<NSNumber*>* _Nonnull)getArrayOfDoubleVariableWithName:(NSString* _Nonnull)name defaultValue:(NSArray<NSNumber*>* _Nonnull)defaultValue;
+- (NSArray<NSNumber*>* _Nonnull)getArrayOfDoubleVariableWithName:(NSString* _Nonnull)name defaultValue:(NSArray<NSNumber*>* _Nonnull)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -188,7 +192,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a integer array dynamic variable that has already been declared.
  */
-- (NSArray<NSNumber*>* _Nonnull)getArrayOfIntegerVariableWithName:(NSString* _Nonnull)name defaultValue:(NSArray<NSNumber*>* _Nonnull)defaultValue;
+- (NSArray<NSNumber*>* _Nonnull)getArrayOfIntegerVariableWithName:(NSString* _Nonnull)name defaultValue:(NSArray<NSNumber*>* _Nonnull)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -196,7 +200,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a string array dynamic variable that has already been declared.
  */
-- (NSArray<NSString*>* _Nonnull)getArrayOfStringVariableWithName:(NSString* _Nonnull)name defaultValue:(NSArray<NSString*>* _Nonnull)defaultValue;
+- (NSArray<NSString*>* _Nonnull)getArrayOfStringVariableWithName:(NSString* _Nonnull)name defaultValue:(NSArray<NSString*>* _Nonnull)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -204,7 +208,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a bool dictionary dynamic variable that has already been declared.
  */
-- (NSDictionary<NSString*, NSNumber*>* _Nonnull)getDictionaryOfBoolVariableWithName:(NSString* _Nonnull)name defaultValue:(NSDictionary<NSString*, NSNumber*>* _Nonnull)defaultValue;
+- (NSDictionary<NSString*, NSNumber*>* _Nonnull)getDictionaryOfBoolVariableWithName:(NSString* _Nonnull)name defaultValue:(NSDictionary<NSString*, NSNumber*>* _Nonnull)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -212,7 +216,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a double dictionary dynamic variable that has already been declared.
  */
-- (NSDictionary<NSString*, NSNumber*>* _Nonnull)getDictionaryOfDoubleVariableWithName:(NSString* _Nonnull)name defaultValue:(NSDictionary<NSString*, NSNumber*>* _Nonnull)defaultValue;
+- (NSDictionary<NSString*, NSNumber*>* _Nonnull)getDictionaryOfDoubleVariableWithName:(NSString* _Nonnull)name defaultValue:(NSDictionary<NSString*, NSNumber*>* _Nonnull)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -220,7 +224,7 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a integer dictionary dynamic variable that has already been declared.
  */
-- (NSDictionary<NSString*, NSNumber*>* _Nonnull)getDictionaryOfIntegerVariableWithName:(NSString* _Nonnull)name defaultValue:(NSDictionary<NSString*, NSNumber*>* _Nonnull)defaultValue;
+- (NSDictionary<NSString*, NSNumber*>* _Nonnull)getDictionaryOfIntegerVariableWithName:(NSString* _Nonnull)name defaultValue:(NSDictionary<NSString*, NSNumber*>* _Nonnull)defaultValue __attribute((deprecated()));
 
 /*!
  @method
@@ -228,6 +232,6 @@ typedef void (^CleverTapExperimentsUpdatedBlock)(void);
  @abstract
  Retrieve a string dictionary dynamic variable that has already been declared.
  */
-- (NSDictionary<NSString*, NSString*>* _Nonnull)getDictionaryOfStringVariableWithName:(NSString* _Nonnull)name defaultValue:(NSDictionary<NSString*, NSString*>* _Nonnull)defaultValue;
+- (NSDictionary<NSString*, NSString*>* _Nonnull)getDictionaryOfStringVariableWithName:(NSString* _Nonnull)name defaultValue:(NSDictionary<NSString*, NSString*>* _Nonnull)defaultValue __attribute((deprecated()));
 
 @end


### PR DESCRIPTION
- Deprecates Dynamic Variable and Screen AB methods.