### PR TITLE
device/platform name fetch crash fix

### DIFF
--- a/CleverTapSDK/CTDeviceInfo.m
+++ b/CleverTapSDK/CTDeviceInfo.m
@@ -142,7 +142,75 @@ static void CleverTapReachabilityHandler(SCNetworkReachabilityRef target, SCNetw
     struct utsname systemInfo;
     uname(&systemInfo);
     
-    return [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+    NSString* code = [NSString stringWithCString:systemInfo.machine
+                                        encoding:NSUTF8StringEncoding];
+    
+    if (!deviceNamesByCode) {
+        deviceNamesByCode = @{@"i386" : @"iPhone Simulator",
+                              @"x86_64" : @"iPhone Simulator",
+                              @"iPhone1,1" : @"iPhone",
+                              @"iPhone1,2" : @"iPhone 3G",
+                              @"iPhone2,1" : @"iPhone 3GS",
+                              @"iPhone3,1" : @"iPhone 4",
+                              @"iPhone3,2" : @"iPhone 4 GSM Rev A",
+                              @"iPhone3,3" : @"iPhone 4 CDMA",
+                              @"iPhone4,1" : @"iPhone 4S",
+                              @"iPhone5,1" : @"iPhone 5 (GSM)",
+                              @"iPhone5,2" : @"iPhone 5 (GSM+CDMA)",
+                              @"iPhone5,3" : @"iPhone 5C (GSM)",
+                              @"iPhone5,4" : @"iPhone 5C (Global)",
+                              @"iPhone6,1" : @"iPhone 5S (GSM)",
+                              @"iPhone6,2" : @"iPhone 5S (Global)",
+                              @"iPhone7,1" : @"iPhone 6 Plus",
+                              @"iPhone7,2" : @"iPhone 6",
+                              @"iPhone8,1" : @"iPhone 6s",
+                              @"iPhone8,2" : @"iPhone 6s Plus",
+                              @"iPhone8,4" : @"iPhone SE (GSM)",
+                              @"iPhone9,1" : @"iPhone 7",
+                              @"iPhone9,2" : @"iPhone 7 Plus",
+                              @"iPhone9,3" : @"iPhone 7",
+                              @"iPhone9,4" : @"iPhone 7 Plus",
+                              @"iPhone10,1" : @"iPhone 8",
+                              @"iPhone10,2" : @"iPhone 8 Plus",
+                              @"iPhone10,3" : @"iPhone X Global",
+                              @"iPhone10,4" : @"iPhone 8",
+                              @"iPhone10,5" : @"iPhone 8 Plus",
+                              @"iPhone10,6" : @"iPhone X GSM",
+                              @"iPhone11,2" : @"iPhone XS",
+                              @"iPhone11,4" : @"iPhone XS Max",
+                              @"iPhone11,6" : @"iPhone XS Max Global",
+                              @"iPhone11,8" : @"iPhone XR",
+                              @"iPhone12,1" : @"iPhone 11",
+                              @"iPhone12,3" : @"iPhone 11 Pro",
+                              @"iPhone12,5" : @"iPhone 11 Pro Max",
+                              @"iPhone12,8" : @"iPhone SE 2nd Gen",
+                              @"iPhone13,1" : @"iPhone 12 Mini",
+                              @"iPhone13,2" : @"iPhone 12",
+                              @"iPhone13,3" : @"iPhone 12 Pro",
+                              @"iPhone13,4" : @"iPhone 12 Pro Max"
+                              };
+    }
+    
+    NSString* deviceName = [deviceNamesByCode objectForKey:code];
+    
+    if (!deviceName) {
+        // Not found on database. At least guess main device type from string contents:
+        
+        if ([code rangeOfString:@"iPod"].location != NSNotFound) {
+            deviceName = @"iPod Touch";
+        }
+        else if([code rangeOfString:@"iPad"].location != NSNotFound) {
+            deviceName = @"iPad";
+        }
+        else if([code rangeOfString:@"iPhone"].location != NSNotFound){
+            deviceName = @"iPhone";
+        }
+        else {
+            deviceName = code;
+        }
+    }
+    
+    return deviceName;
 }
 
 - (void)initDeviceID:(NSString *)cleverTapID {

--- a/CleverTapSDK/CTDeviceInfo.m
+++ b/CleverTapSDK/CTDeviceInfo.m
@@ -61,6 +61,7 @@ static CTTelephonyNetworkInfo *_networkInfo;
 
 @synthesize deviceId =_deviceId;
 @synthesize validationErrors =_validationErrors;
+static NSDictionary* deviceNamesByCode;
 
 static dispatch_queue_t backgroundQueue;
 #if !CLEVERTAP_NO_REACHABILITY_SUPPORT

--- a/CleverTapSDK/CTDeviceInfo.m
+++ b/CleverTapSDK/CTDeviceInfo.m
@@ -194,7 +194,6 @@ static void CleverTapReachabilityHandler(SCNetworkReachabilityRef target, SCNetw
     NSString* deviceName = [deviceNamesByCode objectForKey:code];
     
     if (!deviceName) {
-        // Not found on database. At least guess main device type from string contents:
         
         if ([code rangeOfString:@"iPod"].location != NSNotFound) {
             deviceName = @"iPod Touch";


### PR DESCRIPTION
This is in reference to this thread : https://github.com/CleverTap/clevertap-ios-sdk/issues/103

> Based on the stack trace below:
> 
> 
> Crashed: com.apple.main-thread
> 0  libobjc.A.dylib                0x1ac8b0ed0 objc_retain + 16
> 1  CoreFoundation                 0x19775eeb4 -[__NSDictionaryM setObject:forKeyedSubscript:] + 388
> 2  CleverTapSDK                   0x1054198a0 -[CleverTap generateAppFields] + 1080 (CleverTap.m:1080)
> 3  CleverTapSDK                   0x10541b260 -[CleverTap recordAppLaunched:] + 1341 (CleverTap.m:1341)
> 4  CleverTapSDK                   0x10541ae9c -[CleverTap _appEnteredForeground] + 1300 (CleverTap.m:1300)
> 5  CleverTapSDK                   0x10541ac58 -[CleverTap _appEnteredForegroundWithLaunchingOptions:] + 1278 (CleverTap.m:1278)
> 6  CleverTapSDK                   0x105427868 -[CleverTap notifyApplicationLaunchedWithOptions:] + 3259 (CleverTap.m:3259)
> 7  CleverTapSDK                   0x105414470 +[CleverTap onDidFinishLaunchingNotification:] + 296 (CleverTap.m:296)
> 8  CoreFoundation                 0x1977d69a0 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 28
> 9  CoreFoundation                 0x1977d6948 ___CFXRegistrationPost_block_invoke + 52
> 10 CoreFoundation                 0x1977d5eb0 _CFXRegistrationPost + 440
> 11 CoreFoundation                 0x1977d5870 _CFXNotificationPost + 716
> 12 Foundation                     0x198a9c4bc -[NSNotificationCenter postNotificationName:object:userInfo:] + 64
> 13 UIKitCore                      0x19a22cb94 -[UIApplication _callInitializationDelegatesWithActions:forCanvas:payload:fromOriginatingProcess:] + 3348
> 14 UIKitCore                      0x19a232cec -[UIApplication _runWithMainScene:transitionContext:completion:] + 1244
> 15 UIKitCore                      0x199888c74 -[_UISceneLifecycleMultiplexer completeApplicationLaunchWithFBSScene:transitionContext:] + 152
> 16 UIKitCore                      0x199df6f9c _UIScenePerformActionsWithLifecycleActionMask + 112
> 17 UIKitCore                      0x19988980c __101-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]_block_invoke + 224
> 18 UIKitCore                      0x1998892cc -[_UISceneLifecycleMultiplexer _performBlock:withApplicationOfDeactivationReasons:fromReasons:] + 484
> 19 UIKitCore                      0x19988961c -[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:] + 768
> 20 UIKitCore                      0x199888e58 -[_UISceneLifecycleMultiplexer uiScene:transitionedFromState:withTransitionContext:] + 340
> 21 UIKitCore                      0x1998913a4 __186-[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:]_block_invoke + 196
> 22 UIKitCore                      0x199d0360c +[BSAnimationSettings(UIKit) tryAnimatingWithSettings:actions:completion:] + 892
> 23 UIKitCore                      0x199e0f6c4 _UISceneSettingsDiffActionPerformChangesWithTransitionContext + 272
> 24 UIKitCore                      0x19989109c -[_UIWindowSceneFBSSceneTransitionContextDrivenLifecycleSettingsDiffAction _performActionsForUIScene:withUpdatedFBSScene:settingsDiff:fromSettings:transitionContext:lifecycleActionType:] + 384
> 25 UIKitCore                      0x1996b85a0 __64-[UIScene scene:didUpdateWithDiff:transitionContext:completion:]_block_invoke + 776
> 26 UIKitCore                      0x1996b6f14 -[UIScene _emitSceneSettingsUpdateResponseForCompletion:afterSceneUpdateWork:] + 256
> 27 UIKitCore                      0x1996b81c8 -[UIScene scene:didUpdateWithDiff:transitionContext:completion:] + 248
> 28 UIKitCore                      0x19a230e8c -[UIApplication workspace:didCreateScene:withTransitionContext:completion:] + 572
> 29 UIKitCore                      0x199d2ce38 -[UIApplicationSceneClientAgent scene:didInitializeWithEvent:completion:] + 388
> 30 FrontBoardServices             0x1a75e23bc -[FBSScene _callOutQueue_agent_didCreateWithTransitionContext:completion:] + 432
> 31 FrontBoardServices             0x1a760dd04 __94-[FBSWorkspaceScenesClient createWithSceneID:groupID:parameters:transitionContext:completion:]_block_invoke.200 + 128
> 32 FrontBoardServices             0x1a75f14a0 -[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:] + 240
> 33 FrontBoardServices             0x1a760d9c8 __94-[FBSWorkspaceScenesClient createWithSceneID:groupID:parameters:transitionContext:completion:]_block_invoke + 372
> 34 libdispatch.dylib              0x19746ddb0 _dispatch_client_callout + 20
> 35 libdispatch.dylib              0x197471738 _dispatch_block_invoke_direct + 268
> 36 FrontBoardServices             0x1a7636250 __FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 48
> 37 FrontBoardServices             0x1a7635ee0 -[FBSSerialQueue _targetQueue_performNextIfPossible] + 448
> 38 FrontBoardServices             0x1a7636434 -[FBSSerialQueue _performNextFromRunLoopSource] + 32
> 39 CoreFoundation                 0x1977f576c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
> 40 CoreFoundation                 0x1977f5668 __CFRunLoopDoSource0 + 208
> 41 CoreFoundation                 0x1977f4960 __CFRunLoopDoSources0 + 268
> 42 CoreFoundation                 0x1977eea8c __CFRunLoopRun + 824
> 43 CoreFoundation                 0x1977ee21c CFRunLoopRunSpecific + 600
> 44 GraphicsServices               0x1af3b8784 GSEventRunModal + 164
> 45 UIKitCore                      0x19a22eee8 -[UIApplication _run] + 1072
> 46 UIKitCore                      0x19a23475c UIApplicationMain + 168
> 47 Zomato                         0x10416b944 main + 15 (main.m:15)
> 48 libdyld.dylib                  0x1974ae6b0 start + 4

Looks like when the `struct utsname systemInfo` is referenced outside of its scope, it seems to get de-allocated in some rare conditions.

Hence, to overcome direct usage of struct.property outside of the scope. Created a key value map and the value is wrapped inside a string which is then passed around.