### PR TITLE
Mitigating [NSDictionary allValues] crashes and fixing memory warnings

### DIFF
--- a/CleverTapSDK/CTUIUtils.h
+++ b/CleverTapSDK/CTUIUtils.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSBundle *)bundle;
 + (NSBundle *)bundle:(Class)bundleClass;
-+ (UIApplication *)getSharedApplication;
++ (UIApplication * _Nullable)getSharedApplication;
 
 + (UIImage *)getImageForName:(NSString *)name;
 

--- a/CleverTapSDK/CTUIUtils.m
+++ b/CleverTapSDK/CTUIUtils.m
@@ -21,7 +21,7 @@
     return [UIImage imageNamed:name inBundle:[self bundle] compatibleWithTraitCollection:nil];
 }
 
-+ (UIApplication *)getSharedApplication {
++ (UIApplication * _Nullable)getSharedApplication {
     Class UIApplicationClass = NSClassFromString(@"UIApplication");
     if (UIApplicationClass && [UIApplicationClass respondsToSelector:@selector(sharedApplication)]) {
         return [UIApplication performSelector:@selector(sharedApplication)];

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -561,7 +561,7 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
         _defaultInstanceConfig.logLevel = [self getDebugLevel];
         CleverTapLogStaticInfo(@"Initializing default CleverTap SDK instance. %@: %@ %@: %@ %@: %@", CLTAP_ACCOUNT_ID_LABEL, _plistInfo.accountId, CLTAP_TOKEN_LABEL, _plistInfo.accountToken, CLTAP_REGION_LABEL, (!_plistInfo.accountRegion || _plistInfo.accountRegion.length < 1) ? @"default" : _plistInfo.accountRegion);
     }
-    return [self instanceWithConfig:_defaultInstanceConfig andCleverTapID:cleverTapID];
+    return [self _instanceWithConfig:_defaultInstanceConfig andCleverTapID:cleverTapID];
 }
 
 + (instancetype)instanceWithConfig:(CleverTapInstanceConfig*)config {


### PR DESCRIPTION
- Refactored code to use enumerateKeysAndObjectsUsingBlock instead of allValues for [NSDictionary allValues].
- Removed memory warnings.
