### PR TITLE
Resolve build errors with no inbox support CT build

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1590,8 +1590,10 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
         }
         if ([self didHandleInAppTestFromPushNotificaton:testPayload]) {
             return YES;
+        #if !defined(CLEVERTAP_NO_INBOX_SUPPORT)
         } else if ([self didHandleInboxMessageTestFromPushNotificaton:testPayload]) {
             return YES;
+        #endif
         } else if ([self didHandleDisplayUnitTestFromPushNotificaton:testPayload]) {
             return YES;
         } else {

--- a/CleverTapSDK/Inbox/models/CleverTapInboxMessage.m
+++ b/CleverTapSDK/Inbox/models/CleverTapInboxMessage.m
@@ -49,14 +49,16 @@
         }
         
         NSMutableArray *_contents = [NSMutableArray new];
-        NSMutableArray *contents = json[@"msg"][@"content"];
         
+        #if !defined(CLEVERTAP_NO_INBOX_SUPPORT)
+        NSMutableArray *contents = json[@"msg"][@"content"];
         for (NSDictionary *content in contents) {
             CleverTapInboxMessageContent *ct_content = [[CleverTapInboxMessageContent alloc] initWithJSON:content];
             if (ct_content) {
                 [_contents addObject:ct_content];
             }
         }
+        #endif
         _content = _contents;
         
         _date = (long)[json[@"date"] longValue];


### PR DESCRIPTION
## Description

We've been using the preprocessor macro support for not compiling Inbox related features in our app in a custom forked repo.

In this MR we are trying to upstream the changes required for such support.

Building the SDK with the `CLEVERTAP_NO_INBOX_SUPPORT` macro allows us to reduce the app size impact of CleverTapSDK on our app.

Before this change, we used to get 2 build errors on master when compiling with the `CLEVERTAP_NO_INBOX_SUPPORT` macro enabled in `GCC_PREPROCESSOR_DEFINITIONS`. This MR fixes these build issues.

## What does this PR do?

- Wrap function calls in `#if` blocks so that the builds compile with or without the `CLEVERTAP_NO_INBOX_SUPPORT` macro. 