### PR TITLE
SDK-2177 Get global instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+### [Version 4.1.5](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.1.5) (November 15, 2022)
+
+#### Added
+- Adds a class method `getGlobalInstance` to retrieve a CleverTap SDK instance for an account ID.
+
 ### [Version 4.1.4](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.1.4) (October 24, 2022)
 
 #### Changed

--- a/CleverTap-iOS-SDK.podspec
+++ b/CleverTap-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name                      = "CleverTap-iOS-SDK"
-s.version                   = "4.1.4"
+s.version                   = "4.1.5"
 s.summary                   = "The CleverTap iOS SDK for App Analytics and Engagement."
 s.homepage                  = "https://github.com/CleverTap/clevertap-ios-sdk"
 s.license                   = { :type => "MIT" }

--- a/CleverTap-iOS-SDK.podspec
+++ b/CleverTap-iOS-SDK.podspec
@@ -9,7 +9,7 @@ s.source                    = { :git => "https://github.com/CleverTap/clevertap-
 s.requires_arc              = true
 s.module_name               = 'CleverTapSDK'
 s.resources                 = 'CleverTapSDK/*.cer'
-s.ios.dependency             'SDWebImage', '~> 5.1'
+s.ios.dependency             'SDWebImage', '~> 5.11.1'
 s.ios.resource_bundle       = {'CleverTapSDK' => ['CleverTapSDK/**/*.{png,xib}', 'CleverTapSDK/**/*.xcdatamodeld']}
 s.ios.deployment_target     = '9.0'
 s.ios.source_files          = 'CleverTapSDK/**/*.{h,m}'

--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		57EDC7A12683845B001DD157 /* CleverTap+InAppNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 57EDC7A02683845B001DD157 /* CleverTap+InAppNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		583D9573DCDA5D219016B990 /* libPods-shared-CleverTapSDKTestsApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2108AFE9090417CC69A0E3EB /* libPods-shared-CleverTapSDKTestsApp.a */; };
 		63359A5791C468263B934E22 /* libPods-shared-CleverTapSDKTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 917B24847F7C2A8B0825AEC1 /* libPods-shared-CleverTapSDKTests.a */; };
+		6A2E4C18291E8A4A00385536 /* CleverTapInstanceConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A2E4C17291E8A4A00385536 /* CleverTapInstanceConfigTests.m */; };
 		D0047B0A2098D45B0019C6FD /* CTLocalDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = D0047B082098D45B0019C6FD /* CTLocalDataStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D0047B0B2098D45B0019C6FD /* CTLocalDataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = D0047B092098D45B0019C6FD /* CTLocalDataStore.m */; };
 		D0047B0E2098E2F00019C6FD /* CTProfileBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = D0047B0C2098E2F00019C6FD /* CTProfileBuilder.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -581,6 +582,7 @@
 		4EDCDE4D278AC4DF0065E699 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5709005227FD8E1E0011B89F /* CleverTap+DCDomain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CleverTap+DCDomain.h"; sourceTree = "<group>"; };
 		57EDC7A02683845B001DD157 /* CleverTap+InAppNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CleverTap+InAppNotifications.h"; sourceTree = "<group>"; };
+		6A2E4C17291E8A4A00385536 /* CleverTapInstanceConfigTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CleverTapInstanceConfigTests.m; sourceTree = "<group>"; };
 		840B38DDFBBEAE05FC6C5458 /* Pods-shared-CleverTapSDKTestsApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-CleverTapSDKTestsApp.release.xcconfig"; path = "Target Support Files/Pods-shared-CleverTapSDKTestsApp/Pods-shared-CleverTapSDKTestsApp.release.xcconfig"; sourceTree = "<group>"; };
 		917B24847F7C2A8B0825AEC1 /* libPods-shared-CleverTapSDKTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-shared-CleverTapSDKTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1765572FACEA4B081A89F82 /* Pods-shared-CleverTapSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-CleverTapSDKTests.debug.xcconfig"; path = "Target Support Files/Pods-shared-CleverTapSDKTests/Pods-shared-CleverTapSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -984,6 +986,7 @@
 				4E1F154E27691CA0009387AE /* CleverTapInstanceTests.m */,
 				4E1F155027692042009387AE /* EventTests.m */,
 				4EC2D084278AAD8000F4DE54 /* IdentityManagementTests.m */,
+				6A2E4C17291E8A4A00385536 /* CleverTapInstanceConfigTests.m */,
 			);
 			path = CleverTapSDKTests;
 			sourceTree = "<group>";
@@ -1730,6 +1733,7 @@
 				D02AC2DB276044F70031C1BE /* CleverTapSDKTests.m in Sources */,
 				D02AC2EB2767F4590031C1BE /* BaseTestCase.m in Sources */,
 				4E1F15532769B83D009387AE /* EventTests.m in Sources */,
+				6A2E4C18291E8A4A00385536 /* CleverTapInstanceConfigTests.m in Sources */,
 				4EC2D085278AAD8000F4DE54 /* IdentityManagementTests.m in Sources */,
 				4E1F155227692A11009387AE /* CleverTap+Tests.m in Sources */,
 			);

--- a/CleverTapSDK/CTPreferences.m
+++ b/CleverTapSDK/CTPreferences.m
@@ -131,7 +131,9 @@
             if (newData == NULL) {
                 CleverTapLogStaticInternal(@"%@ file not found %@", self, filePath);
             } else {
-                data = [NSKeyedUnarchiver unarchivedObjectOfClass:cls fromData:newData error:&error];
+                // Allow NSString and NSSet unarchiving
+                NSSet *allowedClasses = [NSSet setWithObjects:cls, [NSArray class], [NSString class], nil];
+                data = [NSKeyedUnarchiver unarchivedObjectOfClasses:allowedClasses fromData:newData error:&error];
                 CleverTapLogStaticInternal(@"%@ unarchived data from %@: %@", self, filePath, data);
             }
         } else {

--- a/CleverTapSDK/CleverTap.h
+++ b/CleverTapSDK/CleverTap.h
@@ -173,6 +173,19 @@ typedef NS_ENUM(int, CTSignedCallEvent) {
  @method
  
  @abstract
+ Returns the CleverTap instance corresponding to the CleverTap accountId param.
+ 
+ @discussion
+ Returns the instance if such is already created, otherwise loads it from cache.
+ 
+ @param accountId  the CleverTap account id
+ */
++ (CleverTap *_Nullable)getGlobalInstance:(NSString *_Nonnull)accountId;
+
+/*!
+ @method
+ 
+ @abstract
  Set the CleverTap AccountID and Token
  
  @discussion
@@ -1295,19 +1308,6 @@ extern NSString * _Nonnull const CleverTapProfileDidInitializeNotification;
  Get region/ domain string value
  */
 - (NSString *_Nullable)getDomainString;
-
-/*!
- @method
- 
- @abstract
- Returns the CleverTap instance corresponding to the CleverTap accountId param.
- 
- @discussion
- Returns the instance if such is already created, otherwise loads it from cache.
- 
- @param accountId  the CleverTap account id
- */
-+ (CleverTap *_Nullable)getGlobalInstance:(NSString *_Nonnull)accountId;
 
 /*!
  @method

--- a/CleverTapSDK/CleverTap.h
+++ b/CleverTapSDK/CleverTap.h
@@ -1296,6 +1296,7 @@ extern NSString * _Nonnull const CleverTapProfileDidInitializeNotification;
  */
 - (NSString *_Nullable)getDomainString;
 
++ (CleverTap *_Nullable)getGlobalInstance:(NSString *_Nonnull)accountId;
 
 @end
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -651,6 +651,10 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
         self.validationResultStack = [[CTValidationResultStack alloc]initWithConfig: _config];
         self.userSetLocation = emptyLocation;
         self.minSessionSeconds =  CLTAP_SESSION_LENGTH_MINS * 60;
+        
+        // save config to defaults
+        [CTPreferences archiveObject:config forFileName: [CleverTapInstanceConfig dataArchiveFileNameWithAccountId:config.accountId]];
+        
         [self _setDeviceNetworkInfoReportingFromStorage];
         [self _setCurrentUserOptOutStateFromStorage];
         [self initNetworking];
@@ -676,6 +680,16 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
     }
     
     return self;
+}
+
++ (CleverTap *)getGlobalInstance:(NSString *)accountId {
+    
+    if (!_instances || [_instances count] <= 0) {
+        CleverTapInstanceConfig *config = [CTPreferences unarchiveFromFile: [CleverTapInstanceConfig dataArchiveFileNameWithAccountId:accountId] ofType:[CleverTapInstanceConfig class] removeFile:NO];
+        return [CleverTap instanceWithConfig:config];
+    }
+    
+    return _instances[accountId];
 }
 
 // notify application code once we have a device GUID

--- a/CleverTapSDK/CleverTapBuildInfo.h
+++ b/CleverTapSDK/CleverTapBuildInfo.h
@@ -1,3 +1,3 @@
 
-#define WR_SDK_REVISION @"40104"
+#define WR_SDK_REVISION @"40105"
 

--- a/CleverTapSDK/CleverTapInstanceConfig.m
+++ b/CleverTapSDK/CleverTapInstanceConfig.m
@@ -5,6 +5,53 @@
 
 @implementation CleverTapInstanceConfig
 
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:_accountId forKey:@"accountId"];
+    [coder encodeObject:_accountToken forKey:@"accountToken"];
+    [coder encodeObject:_proxyDomain forKey:@"proxyDomain"];
+    [coder encodeObject:_spikyProxyDomain forKey:@"spikyProxyDomain"];
+    [coder encodeBool:_analyticsOnly forKey:@"analyticsOnly"];
+    [coder encodeBool:_disableAppLaunchedEvent forKey:@"disableAppLaunchedEvent"];
+    [coder encodeBool:_enablePersonalization forKey:@"enablePersonalization"];
+    [coder encodeBool:_useCustomCleverTapId forKey:@"useCustomCleverTapId"];
+    [coder encodeBool:_disableIDFV forKey:@"disableIDFV"];
+    [coder encodeInt:_logLevel forKey:@"logLevel"];
+    [coder encodeObject:_identityKeys forKey:@"identityKeys"];
+    
+    [coder encodeBool: _isDefaultInstance forKey:@"isDefaultInstance"];
+    [coder encodeObject: _queueLabel forKey:@"queueLabel"];
+    [coder encodeBool: _isCreatedPostAppLaunched forKey:@"isCreatedPostAppLaunched"];
+    [coder encodeBool: _beta forKey:@"beta"];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
+    if (self = [super init]) {
+        _accountId = [coder decodeObjectForKey:@"accountId"];
+        _accountToken = [coder decodeObjectForKey:@"accountToken"];
+        _proxyDomain = [coder decodeObjectForKey:@"proxyDomain"];
+        _spikyProxyDomain = [coder decodeObjectForKey:@"spikyProxyDomain"];
+        _analyticsOnly = [coder decodeObjectForKey:@"analyticsOnly"];
+        _disableAppLaunchedEvent = [coder decodeObjectForKey:@"disableAppLaunchedEvent"];
+        _enablePersonalization = [coder decodeObjectForKey:@"enablePersonalization"];
+        _useCustomCleverTapId = [coder decodeObjectForKey:@"useCustomCleverTapId"];
+        _disableIDFV = [coder decodeObjectForKey:@"disableIDFV"];
+        _logLevel = [coder decodeIntForKey:@"logLevel"];
+        _identityKeys = [coder decodeObjectForKey:@"identityKeys"];
+        
+        _isDefaultInstance = [coder decodeObjectForKey:@"isDefaultInstance"];
+        _queueLabel = [coder decodeObjectForKey:@"queueLabel"];
+        _isCreatedPostAppLaunched = [coder decodeObjectForKey:@"isCreatedPostAppLaunched"];
+        _beta = [coder decodeObjectForKey:@"beta"];
+    }
+    return self;
+}
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
+
 - (instancetype)initWithAccountId:(NSString *)accountId
                      accountToken:(NSString *)accountToken {
     return [self initWithAccountId:accountId
@@ -97,6 +144,10 @@
         [self setupPlistData:isDefault];
     }
     return self;
+}
+
++ (NSString*)dataArchiveFileNameWithAccountId:(NSString*)accountId {
+    return [NSString stringWithFormat:@"clevertap-%@-instance-config.plist", accountId];
 }
 
 - (instancetype)copyWithZone:(NSZone*)zone {

--- a/CleverTapSDK/CleverTapInstanceConfig.m
+++ b/CleverTapSDK/CleverTapInstanceConfig.m
@@ -9,6 +9,7 @@
 {
     [coder encodeObject:_accountId forKey:@"accountId"];
     [coder encodeObject:_accountToken forKey:@"accountToken"];
+    [coder encodeObject:_accountRegion forKey:@"accountRegion"];
     [coder encodeObject:_proxyDomain forKey:@"proxyDomain"];
     [coder encodeObject:_spikyProxyDomain forKey:@"spikyProxyDomain"];
     [coder encodeBool:_analyticsOnly forKey:@"analyticsOnly"];
@@ -29,20 +30,21 @@
     if (self = [super init]) {
         _accountId = [coder decodeObjectForKey:@"accountId"];
         _accountToken = [coder decodeObjectForKey:@"accountToken"];
+        _accountRegion = [coder decodeObjectForKey:@"accountRegion"];
         _proxyDomain = [coder decodeObjectForKey:@"proxyDomain"];
         _spikyProxyDomain = [coder decodeObjectForKey:@"spikyProxyDomain"];
-        _analyticsOnly = [coder decodeObjectForKey:@"analyticsOnly"];
-        _disableAppLaunchedEvent = [coder decodeObjectForKey:@"disableAppLaunchedEvent"];
-        _enablePersonalization = [coder decodeObjectForKey:@"enablePersonalization"];
-        _useCustomCleverTapId = [coder decodeObjectForKey:@"useCustomCleverTapId"];
-        _disableIDFV = [coder decodeObjectForKey:@"disableIDFV"];
+        _analyticsOnly = [coder decodeBoolForKey:@"analyticsOnly"];
+        _disableAppLaunchedEvent = [coder decodeBoolForKey:@"disableAppLaunchedEvent"];
+        _enablePersonalization = [coder decodeBoolForKey:@"enablePersonalization"];
+        _useCustomCleverTapId = [coder decodeBoolForKey:@"useCustomCleverTapId"];
+        _disableIDFV = [coder decodeBoolForKey:@"disableIDFV"];
         _logLevel = [coder decodeIntForKey:@"logLevel"];
         _identityKeys = [coder decodeObjectForKey:@"identityKeys"];
         
-        _isDefaultInstance = [coder decodeObjectForKey:@"isDefaultInstance"];
+        _isDefaultInstance = [coder decodeBoolForKey:@"isDefaultInstance"];
         _queueLabel = [coder decodeObjectForKey:@"queueLabel"];
-        _isCreatedPostAppLaunched = [coder decodeObjectForKey:@"isCreatedPostAppLaunched"];
-        _beta = [coder decodeObjectForKey:@"beta"];
+        _isCreatedPostAppLaunched = [coder decodeBoolForKey:@"isCreatedPostAppLaunched"];
+        _beta = [coder decodeBoolForKey:@"beta"];
     }
     return self;
 }

--- a/CleverTapSDK/CleverTapInstanceConfigPrivate.h
+++ b/CleverTapSDK/CleverTapInstanceConfigPrivate.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-@interface CleverTapInstanceConfig () <NSCopying> {}
+@interface CleverTapInstanceConfig () <NSCopying, NSCoding, NSSecureCoding> {}
 
 @property (nonatomic, assign, readonly) BOOL isDefaultInstance;
 @property (nonatomic, strong, readonly, nonnull) NSString *queueLabel;
@@ -22,4 +22,6 @@
                                proxyDomain:(NSString* _Nonnull)proxyDomain
                           spikyProxyDomain:(NSString* _Nonnull)spikyProxyDomain
                          isDefaultInstance:(BOOL)isDefault;
+
++ (NSString* _Nonnull)dataArchiveFileNameWithAccountId:(NSString* _Nonnull)accountId;
 @end

--- a/CleverTapSDKTests/CleverTapInstanceConfigTests.m
+++ b/CleverTapSDKTests/CleverTapInstanceConfigTests.m
@@ -22,7 +22,7 @@
 
 @implementation CleverTapGlobalInstanceTests
 
-- (void)test_clevertap_instance_g {
+- (void)test_clevertap_instance_nscoding {
     CleverTapInstanceConfig *config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"id" accountToken:@"token" accountRegion:@"eu"];
     [config setEnablePersonalization:YES];
     [config setDisableAppLaunchedEvent:YES];
@@ -50,7 +50,7 @@
     XCTAssertEqual([cachedConfig logLevel], [config logLevel]);
 }
 
-- (void)test_clevertap_instance_g2 {
+- (void)test_clevertap_instance_nscoding_proxy {
     CleverTapInstanceConfig *config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"id" accountToken:@"token"
                                                                              proxyDomain:@"proxy" spikyProxyDomain:@"spikyProxy"];
 

--- a/CleverTapSDKTests/CleverTapInstanceConfigTests.m
+++ b/CleverTapSDKTests/CleverTapInstanceConfigTests.m
@@ -1,0 +1,76 @@
+//
+//  CleverTapInstanceConfigTests.m
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 11.11.22.
+//  Copyright © 2022 CleverTap. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import "CleverTapInstanceConfig.h"
+#import "CTPreferences.h"
+
+@interface CleverTapInstanceConfig (Tests)
++ (NSString*)dataArchiveFileNameWithAccountId:(NSString*)accountId;
+@end
+
+@interface CleverTapGlobalInstanceTests : XCTestCase
+
+@end
+
+@implementation CleverTapGlobalInstanceTests
+
+- (void)test_clevertap_instance_g {
+    CleverTapInstanceConfig *config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"id" accountToken:@"token" accountRegion:@"eu"];
+    [config setEnablePersonalization:YES];
+    [config setDisableAppLaunchedEvent:YES];
+    [config setLogLevel:1];
+    [config setDisableIDFV:YES];
+    [config setAnalyticsOnly:YES];
+    [config setUseCustomCleverTapId:YES];
+    [config setIdentityKeys:@[@"Email"]];
+
+    [CTPreferences archiveObject:config forFileName: [CleverTapInstanceConfig dataArchiveFileNameWithAccountId:config.accountId]];
+
+    CleverTapInstanceConfig *cachedConfig = [CTPreferences unarchiveFromFile: [CleverTapInstanceConfig dataArchiveFileNameWithAccountId:config.accountId] ofType:[CleverTapInstanceConfig class] removeFile:YES];
+    
+    XCTAssertNotNil(cachedConfig);
+    XCTAssertEqualObjects([cachedConfig accountId], [config accountId]);
+    XCTAssertEqualObjects([cachedConfig accountToken], [config accountToken]);
+    XCTAssertEqualObjects([cachedConfig accountRegion], [config accountRegion]);
+    
+    XCTAssertEqual([cachedConfig enablePersonalization], [config enablePersonalization]);
+    XCTAssertEqual([cachedConfig disableAppLaunchedEvent], [config disableAppLaunchedEvent]);
+    XCTAssertEqual([cachedConfig disableIDFV], [config disableIDFV]);
+    XCTAssertEqual([cachedConfig analyticsOnly], [config analyticsOnly]);
+    XCTAssertEqual([cachedConfig useCustomCleverTapId], [config useCustomCleverTapId]);
+    XCTAssertEqualObjects([cachedConfig identityKeys], [config identityKeys]);
+    XCTAssertEqual([cachedConfig logLevel], [config logLevel]);
+}
+
+- (void)test_clevertap_instance_g2 {
+    CleverTapInstanceConfig *config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"id" accountToken:@"token"
+                                                                             proxyDomain:@"proxy" spikyProxyDomain:@"spikyProxy"];
+
+    [CTPreferences archiveObject:config forFileName: [CleverTapInstanceConfig dataArchiveFileNameWithAccountId:config.accountId]];
+
+    CleverTapInstanceConfig *cachedConfig = [CTPreferences unarchiveFromFile: [CleverTapInstanceConfig dataArchiveFileNameWithAccountId:config.accountId] ofType:[CleverTapInstanceConfig class] removeFile:YES];
+    
+    XCTAssertNotNil(cachedConfig);
+    XCTAssertEqualObjects([cachedConfig accountId], [config accountId]);
+    XCTAssertEqualObjects([cachedConfig accountToken], [config accountToken]);
+    XCTAssertEqualObjects([cachedConfig proxyDomain], [config proxyDomain]);
+    XCTAssertEqualObjects([cachedConfig spikyProxyDomain], [config spikyProxyDomain]);
+    
+    XCTAssertEqual([cachedConfig enablePersonalization], [config enablePersonalization]);
+    XCTAssertEqual([cachedConfig disableAppLaunchedEvent], [config disableAppLaunchedEvent]);
+    XCTAssertEqual([cachedConfig disableIDFV], [config disableIDFV]);
+    XCTAssertEqual([cachedConfig analyticsOnly], [config analyticsOnly]);
+    XCTAssertEqual([cachedConfig useCustomCleverTapId], [config useCustomCleverTapId]);
+    XCTAssertEqualObjects([cachedConfig identityKeys], [config identityKeys]);
+    XCTAssertEqual([cachedConfig logLevel], [config logLevel]);
+}
+
+@end

--- a/CleverTapSDKTests/CleverTapInstanceTests.m
+++ b/CleverTapSDKTests/CleverTapInstanceTests.m
@@ -57,4 +57,17 @@
     XCTAssertFalse(result);
 }
 
+- (void)test_clevertap_shared_get_global_instance {
+    CleverTap *shared = [CleverTap sharedInstance];
+    CleverTap *instance = [CleverTap getGlobalInstance:[shared getAccountID]];
+    XCTAssertEqualObjects(instance, shared);
+}
+
+- (void)test_clevertap_get_global_instance {
+    CleverTap *instance = [CleverTap getGlobalInstance:@"test"];
+    XCTAssertNotNil(instance);
+    XCTAssertEqualObjects([[instance config] accountId], @"test");
+    XCTAssertEqualObjects([[instance config] accountToken], @"test");
+}
+
 @end


### PR DESCRIPTION
People involved | @nzagorchev @akashvercetti
------------------|----------------------------------------
JIRA | [SDK-2177](https://wizrocket.atlassian.net/browse/SDK-2177), [SDK-2382](https://wizrocket.atlassian.net/browse/SDK-2382)

- Cache instance config
- Get global instance

- Allow NSString and NSSet unarchiving: this prevents errors such as:
  - Attempted to decode a collection type 'Type' (subclass of 'Type') for key 'key'. 'Type' requires its subclasses to be explicitly added to the allowed classes list but it is not present.
  - Example: `Attempted to decode a collection type 'NSString' (subclass of 'NSObject') for key 'accountId'. 'NSString' requires its subclasses to be explicitly added to the allowed classes list but it is not present. Allowing this has been a source of security issues. Please ensure you meant this type to be in archives: 'NSString'`
