### PR TITLE
Added a public api method to delete multiple app inbox messages in bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+### [Version 4.1.6](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.1.6) (November 28, 2022)
+
+#### Added
+Adds a public instance method `deleteInboxMessagesforID` for deleting multiple App Inbox messages by passing a collection of `messageID`s.
+
 ### [Version 4.1.5](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/4.1.5) (November 15, 2022)
 
 #### Added

--- a/CleverTapSDK/CleverTap+Inbox.h
+++ b/CleverTapSDK/CleverTap+Inbox.h
@@ -189,10 +189,10 @@ typedef void (^CleverTapInboxUpdatedBlock)(void);
  @method
  
  @abstract
- This method deletes `CleverTapInboxMessage` object for the given `Message Id` as String.
+ This method deletes `CleverTapInboxMessage` objects for the given `Message Id` as a collection.
  */
 
-- (void)deleteInboxMessagesForIDs:(NSArray *_Nonnull)messageIds;
+- (void)deleteInboxMessagesForIDs:(NSArray<NSString *> *_Nonnull)messageIds;
 
 /*!
  @method

--- a/CleverTapSDK/CleverTap+Inbox.h
+++ b/CleverTapSDK/CleverTap+Inbox.h
@@ -189,6 +189,15 @@ typedef void (^CleverTapInboxUpdatedBlock)(void);
  @method
  
  @abstract
+ This method deletes `CleverTapInboxMessage` object for the given `Message Id` as String.
+ */
+
+- (void)deleteInboxMessagesForIDs:(NSArray *_Nonnull)messageIds;
+
+/*!
+ @method
+ 
+ @abstract
  This method marks the `CleverTapInboxMessage` object as read for given 'Message Id` as String.
  */
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4310,6 +4310,13 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
     [self.inboxController deleteMessageWithId:messageId];
 }
 
+- (void)deleteInboxMessagesForIDs:(NSArray *_Nonnull)messageIds {
+    if (![self _isInboxInitialized]) {
+        return;
+    }
+    [self.inboxController deleteMessagesWithId:messageIds];
+}
+
 - (void)markReadInboxMessageForID:(NSString *)messageId{
     if (![self _isInboxInitialized]) {
         return;

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4310,7 +4310,7 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
     [self.inboxController deleteMessageWithId:messageId];
 }
 
-- (void)deleteInboxMessagesForIDs:(NSArray *_Nonnull)messageIds {
+- (void)deleteInboxMessagesForIDs:(NSArray<NSString *> *_Nonnull)messageIds {
     if (![self _isInboxInitialized]) {
         return;
     }

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.h
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateMessages:(NSArray<NSDictionary*> *)messages;
 - (NSDictionary * _Nullable )messageForId:(NSString *)messageId;
 - (void)deleteMessageWithId:(NSString *)messageId;
+- (void)deleteMessagesWithId:(NSArray *_Nonnull)messageIds;
 - (void)markReadMessageWithId:(NSString *)messageId;
 
 @end

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.m
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.m
@@ -100,6 +100,17 @@ static NSManagedObjectContext *privateContext;
     [self _deleteMessages:@[message]];
 }
 
+- (void)deleteMessagesWithId:(NSArray *_Nonnull)messageIds {
+    NSMutableArray *toDeleteInboxMessages = [NSMutableArray new];
+    for (NSString *ids in messageIds) {
+        CTMessageMO *msg = [self _messageForId:ids];
+            [toDeleteInboxMessages addObject:msg];
+        }
+    if ([toDeleteInboxMessages count] > 0) {
+        [self _deleteMessages:toDeleteInboxMessages];
+    }
+}
+
 - (void)markReadMessageWithId:(NSString *)messageId {
     [privateContext performBlock:^{
         CTMessageMO *message = [self _messageForId:messageId];


### PR DESCRIPTION
- Added a public Api `deleteInboxMessagesforID` to delete multiple App Inbox messages by passing an array of App Inbox IDs.