### PR TITLE
Fix crash in deleteInboxMessagesForIDs method

### DIFF
--- a/CleverTapSDK/Inbox/controllers/CTInboxController.m
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.m
@@ -109,11 +109,11 @@ static NSManagedObjectContext *privateContext;
                 [toDeleteInboxMessages addObject:msg];
             }
             else {
-                NSLog(@"%@ is invalid App-inbox ID", ids);
+                CleverTapLogStaticDebug(@"Cannot delete App Inbox Message because Message ID %@ is invalid.", ids)
             }
         }
         else {
-            NSLog(@"App Inbox ID is null or not a string");
+            CleverTapLogStaticDebug(@"Cannot delete App Inbox Message because Message ID is null or not a string.");
         }
     }
     if ([toDeleteInboxMessages count] > 0) {

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.m
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.m
@@ -103,9 +103,19 @@ static NSManagedObjectContext *privateContext;
 - (void)deleteMessagesWithId:(NSArray *_Nonnull)messageIds {
     NSMutableArray *toDeleteInboxMessages = [NSMutableArray new];
     for (NSString *ids in messageIds) {
-        CTMessageMO *msg = [self _messageForId:ids];
-            [toDeleteInboxMessages addObject:msg];
+        if (ids != nil && ![ids isEqualToString:@""]){
+            CTMessageMO *msg = [self _messageForId:ids];
+            if (msg) {
+                [toDeleteInboxMessages addObject:msg];
+            }
+            else {
+                NSLog(@"%@ is invalid App-inbox ID", ids);
+            }
         }
+        else {
+            NSLog(@"App Inbox ID is null or not a string");
+        }
+    }
     if ([toDeleteInboxMessages count] > 0) {
         [self _deleteMessages:toDeleteInboxMessages];
     }


### PR DESCRIPTION
Add hotfix for deleteInboxMessageForID crash when message ID is null or invalid