### PR TITLE
fix getLocationWithSuccess method parameter andError = nil is crash

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4104,7 +4104,9 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
     else {
         NSString *errorMsg = @"To Enable CleverTap Location services/apis please build the SDK with the CLEVERTAP_LOCATION macro or use enableLocation method";
         CleverTapLogStaticDebug(@"%@",errorMsg);
-        error(errorMsg);
+        if (error) {
+            error(errorMsg);
+        }
     }
 #endif
 }


### PR DESCRIPTION
fix Non-null judgment handling, it crashes all over the place when you pass nil