### PR TITLE
[SDK-2943]: Updated recordEventWithProps argument key

### DIFF
--- a/CleverTapSDK/CleverTapJSInterface.m
+++ b/CleverTapSDK/CleverTapJSInterface.m
@@ -41,7 +41,7 @@
 - (void)handleMessageFromWebview:(NSDictionary<NSString *,id> *)message forInstance:(CleverTap *)cleverTap {
     NSString *action = [message objectForKey:@"action"];
     if ([action isEqual:@"recordEventWithProps"]) {
-        [cleverTap recordEvent: message[@"event"] withProps: message[@"props"]];
+        [cleverTap recordEvent: message[@"event"] withProps: message[@"properties"]];
     } else if ([action isEqual: @"profilePush"]) {
         [cleverTap profilePush: message[@"properties"]];
     } else if ([action isEqual: @"profileSetMultiValues"]) {


### PR DESCRIPTION
- Updated to "properties" to make key consistent with profilePush and onUserLogin.
- Tested on Starter app in which we were already passing key as "properties" instead of "props".