### PR TITLE
SDK-3226 Carrier & Country Code changes above iOS 16

### DIFF
--- a/CleverTapSDK/CTDeviceInfo.m
+++ b/CleverTapSDK/CTDeviceInfo.m
@@ -423,14 +423,25 @@ static void CleverTapReachabilityHandler(SCNetworkReachabilityRef target, SCNetw
 
 - (NSString *)carrier {
     if (!_carrier) {
-        _carrier = [self getCarrier].carrierName ?: @"";
+        if (@available(iOS 16.0, *)) {
+            // CTCarrier is deprecated above iOS version 16 with no replacements so carrierName will be empty.
+            _carrier = @"";
+        } else {
+            _carrier = [self getCarrier].carrierName ?: @"";
+        }
     }
     return _carrier;
 }
 
 - (NSString *)countryCode {
     if (!_countryCode) {
-        _countryCode =  [self getCarrier].isoCountryCode ?: @"";
+        if (@available(iOS 16.0, *)) {
+            // CTCarrier is deprecated above iOS version 16 with no replacements so used NSLocale to get isoCountryCode.
+            NSLocale *currentLocale = [NSLocale currentLocale];
+            _countryCode = [currentLocale objectForKey:NSLocaleCountryCode];
+        } else {
+            _countryCode =  [self getCarrier].isoCountryCode ?: @"";
+        }
     }
     return _countryCode;
 }

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1093,7 +1093,7 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
     evtData[@"Make"] = self.deviceInfo.manufacturer;
     evtData[@"OS Version"] = self.deviceInfo.osVersion;
     
-    if (self.deviceInfo.carrier) {
+    if (self.deviceInfo.carrier && ![self.deviceInfo.carrier isEqualToString:@""]) {
         evtData[@"Carrier"] = self.deviceInfo.carrier;
     }
     


### PR DESCRIPTION
- Updated logic to retrieve country code using NSLocale above iOS 16
- Updated logic to not send carrier name above iOS 16