### PR TITLE
MC-1578 Fix in-apps not discarded

### DIFF
--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -196,6 +196,11 @@ static NSMutableArray<CTInAppDisplayViewController*> *pendingNotificationControl
 }
 
 - (void)prepareNotificationForDisplay:(NSDictionary*)jsonObj {
+    if (self.inAppRenderingStatus == CleverTapInAppDiscard) {
+        CleverTapLogDebug(self.config.logLevel, @"%@: InApp Notifications are set to be discarded, not saving and showing the InApp Notification", self);
+        return;
+    }
+    
     if (!self.instance.isAppForeground) {
         CleverTapLogInternal(self.config.logLevel, @"%@: Application is not in the foreground, won't prepare in-app: %@", self, jsonObj);
         return;

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -50,6 +50,19 @@
     NSString *mode = jsonResp[CLTAP_INAPP_MODE_JSON_RESPONSE_KEY];
     [self.inAppStore setMode:mode];
     
+    // Handle stale in-apps
+    @try {
+        NSArray *stale = jsonResp[CLTAP_INAPP_STALE_JSON_RESPONSE_KEY];
+        [self.inAppFCManager removeStaleInAppCounts:stale];
+    } @catch (NSException *ex) {
+        CleverTapLogInternal(self.config.logLevel, @"%@: Failed to handle inapp_stale update: %@", self, ex.debugDescription)
+    }
+    
+    if (self.inAppDisplayManager.inAppRenderingStatus == CleverTapInAppDiscard) {
+        CleverTapLogDebug(self.config.logLevel, @"%@: InApp Notifications are set to be discarded, not saving and showing the InApp Notification", self);
+        return;
+    }
+    
     // Parse SS App Launched notifications
     NSArray *inAppNotifsAppLaunched = jsonResp[CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY];
     if (inAppNotifsAppLaunched) {
@@ -60,21 +73,8 @@
         }
     }
     
-    // Handle stale in-apps
-    @try {
-        NSArray *stale = jsonResp[CLTAP_INAPP_STALE_JSON_RESPONSE_KEY];
-        [self.inAppFCManager removeStaleInAppCounts:stale];
-    } @catch (NSException *ex) {
-        CleverTapLogInternal(self.config.logLevel, @"%@: Failed to handle inapp_stale update: %@", self, ex.debugDescription)
-    }
-    
     // Parse in-app notifications to be displayed
     NSArray *inappsJSON = jsonResp[CLTAP_INAPP_JSON_RESPONSE_KEY];
-    
-    if (self.inAppDisplayManager.inAppRenderingStatus == CleverTapInAppDiscard) {
-        CleverTapLogDebug(self.config.logLevel, @"%@: InApp Notifications are set to be discarded, not saving and showing the InApp Notification", self);
-        return;
-    }
     if (inappsJSON) {
         NSMutableArray *inappNotifs;
         @try {


### PR DESCRIPTION
## Background
1. In-apps are not discarded in CS mode.
2. In-apps are not discarded on App Launched SS mode.

## Implementation
1. Check the in-app rendering status in `prepareNotificationForDisplay`. If it is `CleverTapInAppDiscard` return and remove the in-app.
2. Move the check for the `CleverTapInAppDiscard` in-app rendering status before calling `evaluateOnAppLaunchedServerSide`