### PR TITLE
[MC-1466] Custom templates data in inapp notification (Custom Templates Part 3)

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -365,6 +365,12 @@
 		6BB727332B8F787D009CE7D0 /* CTCustomTemplatesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB727312B8F787D009CE7D0 /* CTCustomTemplatesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6BB727342B8F787D009CE7D0 /* CTCustomTemplatesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB727322B8F787D009CE7D0 /* CTCustomTemplatesManager.m */; };
 		6BB727362B8F8567009CE7D0 /* CTCustomTemplatesManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB727352B8F8567009CE7D0 /* CTCustomTemplatesManagerTest.m */; };
+		6BB778C72BECEC2700A41628 /* CTCustomTemplateInAppData.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB778C52BECEC2700A41628 /* CTCustomTemplateInAppData.h */; };
+		6BB778C82BECEC2700A41628 /* CTCustomTemplateInAppData.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778C62BECEC2700A41628 /* CTCustomTemplateInAppData.m */; };
+		6BB778CB2BED21CE00A41628 /* CTNotificationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB778C92BED21CE00A41628 /* CTNotificationAction.h */; };
+		6BB778CC2BED21CE00A41628 /* CTNotificationAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778CA2BED21CE00A41628 /* CTNotificationAction.m */; };
+		6BB778CE2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778CD2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m */; };
+		6BB778D02BEE4C3400A41628 /* CTNotificationActionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */; };
 		6BD334EA2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */; };
 		6BD334EB2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */; };
 		6BD334EC2AF2A41F0099E33E /* CTBatchSentDelegateHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */; };
@@ -894,6 +900,12 @@
 		6BB727312B8F787D009CE7D0 /* CTCustomTemplatesManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTCustomTemplatesManager.h; sourceTree = "<group>"; };
 		6BB727322B8F787D009CE7D0 /* CTCustomTemplatesManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTCustomTemplatesManager.m; sourceTree = "<group>"; };
 		6BB727352B8F8567009CE7D0 /* CTCustomTemplatesManagerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTCustomTemplatesManagerTest.m; sourceTree = "<group>"; };
+		6BB778C52BECEC2700A41628 /* CTCustomTemplateInAppData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTCustomTemplateInAppData.h; sourceTree = "<group>"; };
+		6BB778C62BECEC2700A41628 /* CTCustomTemplateInAppData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTCustomTemplateInAppData.m; sourceTree = "<group>"; };
+		6BB778C92BED21CE00A41628 /* CTNotificationAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTNotificationAction.h; sourceTree = "<group>"; };
+		6BB778CA2BED21CE00A41628 /* CTNotificationAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTNotificationAction.m; sourceTree = "<group>"; };
+		6BB778CD2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTCustomTemplateInAppDataTest.m; sourceTree = "<group>"; };
+		6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTNotificationActionTest.m; sourceTree = "<group>"; };
 		6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTBatchSentDelegateHelper.h; sourceTree = "<group>"; };
 		6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTBatchSentDelegateHelper.m; sourceTree = "<group>"; };
 		6BD334EF2AF545C70099E33E /* CTInAppStoreTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTInAppStoreTest.m; sourceTree = "<group>"; };
@@ -1401,6 +1413,7 @@
 				6BA3B2E72B07E207004E834B /* CTTriggersMatcher+Tests.m */,
 				6B9DEEA02B4DF1B70097EF40 /* CTInAppImagePrefetchManager+Tests.h */,
 				6B4A0F902B45EF6D00A42C6D /* CTInAppTriggerManagerTest.m */,
+				6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */,
 			);
 			path = InApps;
 			sourceTree = "<group>";
@@ -1433,6 +1446,7 @@
 				6B32A0B12B9F2A75009ADC57 /* CTCustomTemplatesManager+Tests.h */,
 				6B32A0B22B9F2E8F009ADC57 /* CTTestTemplateProducer.h */,
 				6B32A0B32B9F2E8F009ADC57 /* CTTestTemplateProducer.m */,
+				6BB778CD2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m */,
 			);
 			path = CustomTemplates;
 			sourceTree = "<group>";
@@ -1459,6 +1473,8 @@
 				6B32A09C2B9901AA009ADC57 /* CTCustomTemplateBuilder.h */,
 				6B32A09D2B9901AA009ADC57 /* CTCustomTemplateBuilder.m */,
 				6B32A0A02B99033F009ADC57 /* CTCustomTemplateBuilder-Internal.h */,
+				6BB778C52BECEC2700A41628 /* CTCustomTemplateInAppData.h */,
+				6BB778C62BECEC2700A41628 /* CTCustomTemplateInAppData.m */,
 			);
 			path = CustomTemplates;
 			sourceTree = "<group>";
@@ -1712,6 +1728,8 @@
 				6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */,
 				6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */,
 				6BA3B2DA2B03E926004E834B /* CTQueueType.h */,
+				6BB778C92BED21CE00A41628 /* CTNotificationAction.h */,
+				6BB778CA2BED21CE00A41628 /* CTNotificationAction.m */,
 			);
 			path = CleverTapSDK;
 			sourceTree = "<group>";
@@ -1852,6 +1870,7 @@
 				4987C665251B5E79003E6BE8 /* CTImageInAppViewController.h in Headers */,
 				D014B8E220E2F9F9001E0780 /* CleverTapInstanceConfigPrivate.h in Headers */,
 				071EB4CF217F6427008F0FAB /* CTBaseHeaderFooterViewControllerPrivate.h in Headers */,
+				6BB778C72BECEC2700A41628 /* CTCustomTemplateInAppData.h in Headers */,
 				6BB727192B8E469B009CE7D0 /* CTInAppTemplateBuilder.h in Headers */,
 				D0BD759D241760C60006EE55 /* CTProductConfigController.h in Headers */,
 				6BB7271D2B8E46AB009CE7D0 /* CTAppFunctionBuilder.h in Headers */,
@@ -1954,6 +1973,7 @@
 				6BD334EA2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */,
 				071EB4F9217F6427008F0FAB /* CTNotificationButton.h in Headers */,
 				48080311292EB50D00C06E2F /* CTLocalInApp.h in Headers */,
+				6BB778CB2BED21CE00A41628 /* CTNotificationAction.h in Headers */,
 				4803951C2A7ABAD200C4D254 /* CTAES.h in Headers */,
 				D0213D4D207D905800FE5740 /* CleverTapTrackedViewController.h in Headers */,
 				4E25E3C5278887A70008C888 /* CTFlexibleIdentityRepo.h in Headers */,
@@ -2374,6 +2394,7 @@
 			files = (
 				6BA3B2E12B05411C004E834B /* InAppHelper.m in Sources */,
 				32394C2529FA272600956058 /* CTValidatorTest.m in Sources */,
+				6BB778CE2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m in Sources */,
 				6BA3B2E82B07E207004E834B /* CTTriggersMatcher+Tests.m in Sources */,
 				6B32A0A52B9A0F17009ADC57 /* CTCustomTemplateTest.m in Sources */,
 				4E1F155B276B662C009387AE /* EventDetail.m in Sources */,
@@ -2394,6 +2415,7 @@
 				32394C2129FA264B00956058 /* CTPreferencesTest.m in Sources */,
 				6BD334F02AF545C80099E33E /* CTInAppStoreTest.m in Sources */,
 				32394C1F29FA251E00956058 /* CTEventBuilderTest.m in Sources */,
+				6BB778D02BEE4C3400A41628 /* CTNotificationActionTest.m in Sources */,
 				D02AC2EB2767F4590031C1BE /* BaseTestCase.m in Sources */,
 				6BEEC2CE2AEC49F100BD4EC5 /* CTImpressionManagerTest.m in Sources */,
 				6A2E4C18291E8A4A00385536 /* CleverTapInstanceConfigTests.m in Sources */,
@@ -2462,6 +2484,7 @@
 				D079742A21FE2F2300773602 /* CTVideoThumbnailGenerator.m in Sources */,
 				071EB4C9217F6427008F0FAB /* CTHeaderViewController.m in Sources */,
 				6A3EBD3B2AA0713100CE97D4 /* CTTriggerValue.m in Sources */,
+				6BB778CC2BED21CE00A41628 /* CTNotificationAction.m in Sources */,
 				4E25E3C7278887A70008C888 /* CTIdentityRepoFactory.m in Sources */,
 				6BB7271E2B8E46AB009CE7D0 /* CTAppFunctionBuilder.m in Sources */,
 				4E41FD94294F46510001FBED /* CTVar.m in Sources */,
@@ -2552,6 +2575,7 @@
 				4E49AE55275D24570074A774 /* CTValidationResultStack.m in Sources */,
 				D01A0895207EC2D400423D6F /* CleverTapInstanceConfig.m in Sources */,
 				071EB4C8217F6427008F0FAB /* CTDismissButton.m in Sources */,
+				6BB778C82BECEC2700A41628 /* CTCustomTemplateInAppData.m in Sources */,
 				4EF0D5472AD84BCA0044C48F /* CTSessionManager.m in Sources */,
 				4EB4C8BF2AAD91AC00B7F045 /* CTTriggerEvaluator.m in Sources */,
 				0701E9652372DE9C0034AAC2 /* CleverTapDisplayUnit.m in Sources */,

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -183,6 +183,12 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 
 #define CLTAP_INAPP_HTML_TYPE @"custom-html"
 
+#define CLTAP_INAPP_TYPE @"type"
+#define CLTAP_INAPP_TEMPLATE_NAME @"templateName"
+#define CLTAP_INAPP_TEMPLATE_ID @"templateId"
+#define CLTAP_INAPP_TEMPLATE_DESCRIPTION @"templateDescription"
+#define CLTAP_INAPP_VARS @"vars"
+
 #define CLTAP_INAPP_PREVIEW_TYPE @"wzrk_inapp_type"
 #define CLTAP_INAPP_IMAGE_INTERSTITIAL_TYPE @"image-interstitial"
 #define CLTAP_INAPP_IMAGE_INTERSTITIAL_CONFIG @"imageInterstitialConfig"

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -253,7 +253,7 @@ API_AVAILABLE(ios(13.0)) {
     }
     
     // For showing Push Permission through InApp Campaign, positive button type is "rfp".
-    if ([button.type isEqual:@"rfp"]) {
+    if (button.type == CTInAppActionTypeRequestForPermission) {
         if (self.delegate && [self.delegate respondsToSelector:@selector(handleInAppPushPrimer:fromViewController:withFallbackToSettings:)]) {
             [self.delegate handleInAppPushPrimer:self.notification
                               fromViewController:self

--- a/CleverTapSDK/CTInAppNotification.h
+++ b/CleverTapSDK/CTInAppNotification.h
@@ -4,6 +4,7 @@
 #import "CTNotificationButton.h"
 #if !CLEVERTAP_NO_INAPP_SUPPORT
 #import "CTInAppImagePrefetchManager.h"
+#import "CTCustomTemplateInAppData.h"
 #endif
 
 @interface CTInAppNotification : NSObject
@@ -65,6 +66,8 @@
 @property (nonatomic, readonly) BOOL isPushSettingsSoftAlert;
 @property (nonatomic, readonly) BOOL fallBackToNotificationSettings;
 @property (nonatomic, readonly) BOOL skipSettingsAlert;
+
+@property (nonatomic, readonly) CTCustomTemplateInAppData *customTemplateInAppData;
 
 - (instancetype)init __unavailable;
 #if !CLEVERTAP_NO_INAPP_SUPPORT

--- a/CleverTapSDK/CTInAppNotification.h
+++ b/CleverTapSDK/CTInAppNotification.h
@@ -28,10 +28,13 @@
 @property (nonatomic, assign, readonly) float width;
 @property (nonatomic, assign, readonly) float widthPercent;
 
+@property (nonatomic, copy, readonly) NSString *landscapeContentType;
 @property (nonatomic, readonly) UIImage *inAppImage;
 @property (nonatomic, readonly) UIImage *inAppImageLandscape;
-@property (nonatomic, readonly) NSData *image;
-@property (nonatomic, readonly) NSData *imageLandscape;
+@property (nonatomic, readonly) NSData *imageData;
+@property (nonatomic, strong, readonly) NSURL *imageURL;
+@property (nonatomic, readonly) NSData *imageLandscapeData;
+@property (nonatomic, strong, readonly) NSURL *imageUrlLandscape;
 @property (nonatomic, copy, readonly) NSString *contentType;
 @property (nonatomic, copy, readonly) NSString *mediaUrl;
 @property (nonatomic, readonly, assign) BOOL mediaIsVideo;
@@ -53,7 +56,7 @@
 @property (nonatomic, readonly) NSArray<CTNotificationButton *> *buttons;
 
 @property (nonatomic, copy, readonly) NSDictionary *jsonDescription;
-@property (nonatomic, readonly) NSString *error;
+@property (nonatomic) NSString *error;
 
 @property (nonatomic, copy, readonly) NSDictionary *customExtras;
 @property (nonatomic, copy, readwrite) NSDictionary *actionExtras;
@@ -65,12 +68,15 @@
 
 - (instancetype)init __unavailable;
 #if !CLEVERTAP_NO_INAPP_SUPPORT
-- (instancetype)initWithJSON:(NSDictionary*)json
-        imagePrefetchManager:(CTInAppImagePrefetchManager *)imagePrefetchManager;
+- (instancetype)initWithJSON:(NSDictionary*)json;
 #endif
 
-- (void)prepareWithCompletionHandler: (void (^)(void))completionHandler;
-
 + (NSString * _Nullable)inAppId:(NSDictionary * _Nullable)inApp;
+
+- (void)setPreparedInAppImage:(UIImage * _Nullable)inAppImage
+               inAppImageData:(NSData * _Nullable)inAppImageData error:(NSString * _Nullable)error;
+
+- (void)setPreparedInAppImageLandscape:(UIImage * _Nullable)inAppImageLandscape
+               inAppImageLandscapeData:(NSData * _Nullable)inAppImageLandscapeData error:(NSString * _Nullable)error;
 
 @end

--- a/CleverTapSDK/CTInAppNotification.m
+++ b/CleverTapSDK/CTInAppNotification.m
@@ -15,13 +15,13 @@
 @property (nonatomic, readwrite) NSString *type;
 @property (nonatomic, readwrite) CTInAppType inAppType;
 
-@property (nonatomic, strong) NSURL *imageURL;
-@property (nonatomic, strong) NSURL *imageUrlLandscape;
+@property (nonatomic, strong, readwrite) NSURL *imageURL;
+@property (nonatomic, strong, readwrite) NSURL *imageUrlLandscape;
 
 @property (nonatomic, readwrite, strong) UIImage *inAppImage;
 @property (nonatomic, readwrite, strong) UIImage *inAppImageLandscape;
-@property (nonatomic, readwrite, strong) NSData *image;
-@property (nonatomic, readwrite, strong) NSData *imageLandscape;
+@property (nonatomic, readwrite, strong) NSData *imageData;
+@property (nonatomic, readwrite, strong) NSData *imageLandscapeData;
 @property (nonatomic, copy, readwrite) NSString *contentType;
 @property (nonatomic, copy, readwrite) NSString *landscapeContentType;
 @property (nonatomic, copy, readwrite) NSString *mediaUrl;
@@ -64,10 +64,6 @@
 @property (nonatomic, readwrite) BOOL fallBackToNotificationSettings;
 @property (nonatomic, readwrite) BOOL skipSettingsAlert;
 
-@property (nonatomic, readwrite) NSString *error;
-
-@property (nonatomic, strong) CTInAppImagePrefetchManager *imagePrefetchManager;
-
 @end
 
 @implementation CTInAppNotification: NSObject
@@ -77,11 +73,9 @@
 @synthesize mediaIsAudio=_mediaIsAudio;
 @synthesize mediaIsVideo=_mediaIsVideo;
 
-- (instancetype)initWithJSON:(NSDictionary *)jsonObject
-        imagePrefetchManager:(CTInAppImagePrefetchManager *)imagePrefetchManager {
+- (instancetype)initWithJSON:(NSDictionary *)jsonObject {
     if (self = [super init]) {
         @try {
-            self.imagePrefetchManager = imagePrefetchManager;
             self.inAppType = CTInAppTypeUnknown;
             self.jsonDescription = jsonObject;
             self.campaignId = (NSString*) jsonObject[CLTAP_NOTIFICATION_ID_TAG];
@@ -307,58 +301,18 @@
 #endif
 }
 
-- (void)prepareWithCompletionHandler: (void (^)(void))completionHandler {
-#if !(TARGET_OS_TV)
-    if ([NSThread isMainThread]) {
-        self.error = [NSString stringWithFormat:@"[%@ prepareWithCompletionHandler] should not be called on the main thread", [self class]];
-        completionHandler();
-        return;
-    }
-    
-    if (self.imageURL) {
-        UIImage *image = [self loadImageIfPresentInDiskCache:self.imageURL];
-        if (image) {
-            self.inAppImage = image;
-            self.error = nil;
-        } else {
-            NSError *error = nil;
-            NSData *imageData = [NSData dataWithContentsOfURL:self.imageURL options:NSDataReadingMappedIfSafe error:&error];
-            if (error || !imageData) {
-                self.error = [NSString stringWithFormat:@"unable to load image from URL: %@", self.imageURL];
-            } else {
-                if ([self.contentType isEqualToString:@"image/gif"] ) {
-                    SDAnimatedImage *gif = [SDAnimatedImage imageWithData:imageData];
-                    if (gif == nil) {
-                        self.error = [NSString stringWithFormat:@"unable to decode gif for URL: %@", self.imageURL];
-                    }
-                }
-                self.image = self.error ? nil : imageData;
-            }
-        }
-    }
-    if (self.imageUrlLandscape && self.hasLandscape) {
-        UIImage *image = [self loadImageIfPresentInDiskCache:self.imageUrlLandscape];
-        if (image) {
-            self.inAppImageLandscape = image;
-            self.error = nil;
-        } else {
-            NSError *error = nil;
-            NSData *imageData = [NSData dataWithContentsOfURL:self.imageUrlLandscape options:NSDataReadingMappedIfSafe error:&error];
-            if (error || !imageData) {
-                self.error = [NSString stringWithFormat:@"unable to load landscape image from URL: %@", self.imageUrlLandscape];
-            } else {
-                if ([self.landscapeContentType isEqualToString:@"image/gif"] ) {
-                    SDAnimatedImage *gif = [SDAnimatedImage imageWithData:imageData];
-                    if (gif == nil) {
-                        self.error = [NSString stringWithFormat:@"unable to decode landscape gif for URL: %@", self.imageUrlLandscape];
-                    }
-                }
-                self.imageLandscape = self.error ? nil : imageData;
-            }
-        }
-    }
-#endif
-    completionHandler();
+- (void)setPreparedInAppImage:(UIImage *)inAppImage
+               inAppImageData:(NSData *)inAppImageData error:(NSString *)error {
+    self.error = error;
+    self.inAppImage = inAppImage;
+    self.imageData = inAppImageData;
+}
+
+- (void)setPreparedInAppImageLandscape:(UIImage *)inAppImageLandscape
+               inAppImageLandscapeData:(NSData *)inAppImageLandscapeData error:(NSString *)error {
+    self.error = error;
+    self.inAppImageLandscape = inAppImageLandscape;
+    self.imageLandscapeData = inAppImageLandscapeData;
 }
 
 - (BOOL)validateLegacyJSON:(NSDictionary *)jsonObject {
@@ -430,13 +384,6 @@
         }
     }
     return FALSE;
-}
-
-- (UIImage *)loadImageIfPresentInDiskCache:(NSURL *)imageURL {
-    NSString *imageURLString = [imageURL absoluteString];
-    UIImage *image = [self.imagePrefetchManager loadImageFromDisk:imageURLString];
-    if (image) return image;
-    return nil;
 }
 
 + (NSString * _Nullable)inAppId:(NSDictionary * _Nullable)inApp {

--- a/CleverTapSDK/CTInAppNotification.m
+++ b/CleverTapSDK/CTInAppNotification.m
@@ -64,6 +64,8 @@
 @property (nonatomic, readwrite) BOOL fallBackToNotificationSettings;
 @property (nonatomic, readwrite) BOOL skipSettingsAlert;
 
+@property (nonatomic, readwrite) CTCustomTemplateInAppData *customTemplateInAppData;
+
 @end
 
 @implementation CTInAppNotification: NSObject
@@ -100,6 +102,7 @@
                 [self legacyConfigureFromJSON:jsonObject];
             } else {
                 [self configureFromJSON:jsonObject];
+                self.customTemplateInAppData = [CTCustomTemplateInAppData createWithJSON:jsonObject];
             }
             if (self.inAppType == CTInAppTypeUnknown) {
                 self.error = @"Unknown InApp Type";

--- a/CleverTapSDK/CTInAppUtils.h
+++ b/CleverTapSDK/CTInAppUtils.h
@@ -13,11 +13,22 @@ typedef NS_ENUM(NSUInteger, CTInAppType){
     CTInAppTypeInterstitialImage,
     CTInAppTypeHalfInterstitialImage,
     CTInAppTypeCoverImage,
+    CTInAppTypeCustom
+};
+
+typedef NS_ENUM(NSUInteger, CTInAppActionType){
+    CTInAppActionTypeUnknown,
+    CTInAppActionTypeClose,
+    CTInAppActionTypeOpenURL,
+    CTInAppActionTypeKeyValues,
+    CTInAppActionTypeCustom,
+    CTInAppActionTypeRequestForPermission
 };
 
 @interface CTInAppUtils : NSObject
 
-+ (CTInAppType)inAppTypeFromString:(NSString*_Nonnull)type;
++ (CTInAppType)inAppTypeFromString:(NSString* _Nonnull)type;
++ (CTInAppActionType)inAppActionTypeFromString:(NSString* _Nonnull)type;
 + (NSBundle *_Nullable)bundle;
 + (NSString *_Nullable)getXibNameForControllerName:(NSString *_Nonnull)controllerName;
 

--- a/CleverTapSDK/CTInAppUtils.m
+++ b/CleverTapSDK/CTInAppUtils.m
@@ -7,6 +7,7 @@
 #endif
 
 static NSDictionary *_inAppTypeMap;
+static NSDictionary *_inAppActionTypeMap;
 
 @implementation CTInAppUtils
 
@@ -22,7 +23,8 @@ static NSDictionary *_inAppTypeMap;
             @"alert-template": @(CTInAppTypeAlert),
             @"interstitial-image": @(CTInAppTypeInterstitialImage),
             @"half-interstitial-image": @(CTInAppTypeHalfInterstitialImage),
-            @"cover-image": @(CTInAppTypeCoverImage)
+            @"cover-image": @(CTInAppTypeCoverImage),
+            @"custom-code": @(CTInAppTypeCustom)
         };
     }
     
@@ -32,6 +34,25 @@ static NSDictionary *_inAppTypeMap;
     }
     return [_type integerValue];
 }
+
++ (CTInAppActionType)inAppActionTypeFromString:(NSString* _Nonnull)type {
+    if (_inAppActionTypeMap == nil) {
+        _inAppActionTypeMap = @{
+            @"close": @(CTInAppActionTypeClose),
+            @"url": @(CTInAppActionTypeOpenURL),
+            @"kv": @(CTInAppActionTypeKeyValues),
+            @"custom-code": @(CTInAppActionTypeCustom),
+            @"rfp": @(CTInAppActionTypeRequestForPermission)
+        };
+    }
+    
+    NSNumber *_type = type != nil ? _inAppActionTypeMap[type] : @(CTInAppActionTypeUnknown);
+    if (_type == nil) {
+        _type = @(CTInAppActionTypeUnknown);
+    }
+    return [_type integerValue];
+}
+
 
 + (NSBundle *)bundle {
 #if CLEVERTAP_NO_INAPP_SUPPORT

--- a/CleverTapSDK/CTNotificationAction.h
+++ b/CleverTapSDK/CTNotificationAction.h
@@ -1,0 +1,32 @@
+//
+//  CTNotificationAction.h
+//  CleverTapSDK
+//
+//  Created by Nikola Zagorchev on 9.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CTCustomTemplateInAppData.h"
+#import "CTInAppUtils.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CTNotificationAction : NSObject
+
+@property (nonatomic, readonly) CTInAppActionType type;
+@property (nonatomic, copy, readonly) NSURL *actionURL;
+@property (nonatomic, strong, readonly) NSDictionary *keyValues;
+@property (nonatomic, readonly) BOOL fallbackToSettings;
+@property (nonatomic, strong, readonly) CTCustomTemplateInAppData *customTemplateInAppData;
+
+@property (nonatomic, readonly) NSString *error;
+
+- (instancetype)init NS_UNAVAILABLE;
+#if !CLEVERTAP_NO_INAPP_SUPPORT
+- (instancetype)initWithJSON:(NSDictionary*)json;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/CTNotificationAction.m
+++ b/CleverTapSDK/CTNotificationAction.m
@@ -1,0 +1,50 @@
+//
+//  CTNotificationAction.m
+//  CleverTapSDK
+//
+//  Created by Nikola Zagorchev on 9.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import "CTNotificationAction.h"
+
+@interface CTNotificationAction()
+
+@property (nonatomic, readwrite) CTInAppActionType type;
+@property (nonatomic, copy, readwrite) NSURL *actionURL;
+@property (nonatomic, strong, readwrite) NSDictionary *keyValues;
+@property (nonatomic, readwrite) BOOL fallbackToSettings;
+@property (nonatomic, strong, readwrite) CTCustomTemplateInAppData *customTemplateInAppData;
+@property (nonatomic, readwrite) NSString *error;
+
+@end
+
+@implementation CTNotificationAction
+
+- (nonnull instancetype)initWithJSON:(nonnull NSDictionary *)json {
+    if (self = [super init]) {
+        @try {
+            id kv = json[@"kv"];
+            if ([kv isKindOfClass:[NSDictionary class]]) {
+                self.keyValues = kv;
+            }
+            NSString *action = json[@"ios"];
+            if (action && action.length > 0) {
+                @try {
+                    self.actionURL = [NSURL URLWithString:action];
+                } @catch (NSException *e) {
+                    self.error = [e debugDescription];
+                }
+            }
+            NSString *type = json[@"type"];
+            self.type = [CTInAppUtils inAppActionTypeFromString:type];
+            self.fallbackToSettings = json[@"fbSettings"] ? [json[@"fbSettings"] boolValue] : NO;
+            self.customTemplateInAppData = [CTCustomTemplateInAppData createWithJSON:json];
+        } @catch (NSException *e) {
+            self.error = [e debugDescription];
+        }
+    }
+    return self;
+}
+
+@end

--- a/CleverTapSDK/CTNotificationButton.h
+++ b/CleverTapSDK/CTNotificationButton.h
@@ -1,4 +1,6 @@
 #import <Foundation/Foundation.h>
+#import "CTInAppUtils.h"
+#import "CTNotificationAction.h"
 
 @interface CTNotificationButton : NSObject
 
@@ -7,8 +9,10 @@
 @property (nonatomic, copy, readonly) NSString *borderRadius;
 @property (nonatomic, copy, readonly) NSString *borderColor;
 @property (nonatomic, copy, readonly) NSDictionary *customExtras;
-@property (nonatomic, copy, readonly) NSString *type;
+@property (nonatomic, readonly) CTInAppActionType type;
 @property (nonatomic, readonly) BOOL fallbackToSettings;
+
+@property (nonatomic, strong, readonly) CTNotificationAction *action;
 
 @property (nonatomic, copy, readonly) NSString *backgroundColor;
 @property (nonatomic, readonly) NSURL *actionURL;

--- a/CleverTapSDK/CTNotificationButton.m
+++ b/CleverTapSDK/CTNotificationButton.m
@@ -9,10 +9,8 @@
 @property (nonatomic, copy, readwrite) NSString *borderRadius;
 @property (nonatomic, copy, readwrite) NSString *borderColor;
 @property (nonatomic, copy, readwrite) NSString *backgroundColor;
-@property (nonatomic, copy, readwrite) NSDictionary *customExtras;
-@property (nonatomic, copy, readwrite) NSString *type;
-@property (nonatomic, readwrite) BOOL fallbackToSettings;
-@property (nonatomic, readwrite) NSURL *actionURL;
+
+@property (nonatomic, strong, readwrite) CTNotificationAction *action;
 
 @property (nonatomic, copy, readwrite) NSDictionary *jsonDescription;
 
@@ -34,24 +32,32 @@
             
             NSDictionary *actions = jsonObject[@"actions"];
             if (actions) {
-                self.customExtras = (NSDictionary *) actions[@"kv"];
-                NSString *action = actions[@"ios"];
-                if (action && action.length > 0) {
-                    @try {
-                        self.actionURL = [NSURL URLWithString:action];
-                    } @catch (NSException *e) {
-                        self.error = [e debugDescription];
-                    }
+                self.action = [[CTNotificationAction alloc] initWithJSON:actions];
+                if (self.action.error) {
+                    self.error = self.action.error;
                 }
-                self.type = actions[@"type"];
-                self.fallbackToSettings = actions[@"fbSettings"] ? [actions[@"fbSettings"] boolValue] : NO;
             }
-            
         } @catch (NSException *e) {
             self.error = [e debugDescription];
         }
     }
     return self;
+}
+
+- (NSDictionary *)customExtras {
+    return [self.action keyValues];
+}
+
+- (CTInAppActionType)type {
+    return [self.action type];
+}
+
+- (BOOL)fallbackToSettings {
+    return [self.action fallbackToSettings];
+}
+
+- (NSURL *)actionURL {
+    return [self.action actionURL];
 }
 
 @end

--- a/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
+++ b/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
@@ -86,8 +86,8 @@ typedef enum {
     // set image
     if (self.notification.inAppImage) {
         self.inAppImage = self.notification.inAppImage;
-    } else if (self.notification.image) {
-        self.inAppImage = [UIImage imageWithData:self.notification.image];
+    } else if (self.notification.imageData) {
+        self.inAppImage = [UIImage imageWithData:self.notification.imageData];
     }
     if (self.inAppImage) {
         self.imageView.clipsToBounds = YES;

--- a/CleverTapSDK/InApps/CTCoverViewController.m
+++ b/CleverTapSDK/InApps/CTCoverViewController.m
@@ -74,14 +74,14 @@
     if (![self deviceOrientationIsLandscape]) {
         if (self.notification.inAppImage) {
             self.imageView.image = self.notification.inAppImage;
-        } else if (self.notification.image) {
-            self.imageView.image  = [UIImage imageWithData:self.notification.image];
+        } else if (self.notification.imageData) {
+            self.imageView.image  = [UIImage imageWithData:self.notification.imageData];
         }
     } else {
         if (self.notification.inAppImageLandscape) {
             self.imageView.image = self.notification.inAppImageLandscape;
-        } else if (self.notification.imageLandscape) {
-            self.imageView.image = [UIImage imageWithData:self.notification.imageLandscape];
+        } else if (self.notification.imageLandscapeData) {
+            self.imageView.image = [UIImage imageWithData:self.notification.imageLandscapeData];
         }
     }
     

--- a/CleverTapSDK/InApps/CTHalfInterstitialViewController.m
+++ b/CleverTapSDK/InApps/CTHalfInterstitialViewController.m
@@ -118,14 +118,14 @@
     if (![self deviceOrientationIsLandscape]) {
         if (self.notification.inAppImage) {
             self.imageView.image = self.notification.inAppImage;
-        } else if (self.notification.image) {
-            self.imageView.image  = [UIImage imageWithData:self.notification.image];
+        } else if (self.notification.imageData) {
+            self.imageView.image  = [UIImage imageWithData:self.notification.imageData];
         }
     } else {
         if (self.notification.inAppImageLandscape) {
             self.imageView.image = self.notification.inAppImageLandscape;
-        } else if (self.notification.imageLandscape) {
-            self.imageView.image = [UIImage imageWithData:self.notification.imageLandscape];
+        } else if (self.notification.imageLandscapeData) {
+            self.imageView.image = [UIImage imageWithData:self.notification.imageLandscapeData];
         }
     }
     

--- a/CleverTapSDK/InApps/CTImageInAppViewController.m
+++ b/CleverTapSDK/InApps/CTImageInAppViewController.m
@@ -120,14 +120,14 @@ static const CGFloat kSpacingConstant = 160.f;
     if (![self deviceOrientationIsLandscape]) {
         if (self.notification.inAppImage) {
             self.imageView.image = self.notification.inAppImage;
-        } else if (self.notification.image) {
-            self.imageView.image  = [UIImage imageWithData:self.notification.image];
+        } else if (self.notification.imageData) {
+            self.imageView.image  = [UIImage imageWithData:self.notification.imageData];
         }
     } else {
         if (self.notification.inAppImageLandscape) {
             self.imageView.image = self.notification.inAppImageLandscape;
-        } else if (self.notification.imageLandscape) {
-            self.imageView.image = [UIImage imageWithData:self.notification.imageLandscape];
+        } else if (self.notification.imageLandscapeData) {
+            self.imageView.image = [UIImage imageWithData:self.notification.imageLandscapeData];
         }
     }
 }

--- a/CleverTapSDK/InApps/CTInterstitialViewController.m
+++ b/CleverTapSDK/InApps/CTInterstitialViewController.m
@@ -145,13 +145,13 @@
     if (self.notification.inAppImage) {
         self.imageView.contentMode = UIViewContentModeScaleAspectFit;
         self.imageView.image = self.notification.inAppImage;
-    } else if (self.notification.image) {
+    } else if (self.notification.imageData) {
         self.imageView.contentMode = UIViewContentModeScaleAspectFit;
         if ([self.notification.contentType isEqualToString:@"image/gif"] ) {
-            SDAnimatedImage *gif = [SDAnimatedImage imageWithData:self.notification.image];
+            SDAnimatedImage *gif = [SDAnimatedImage imageWithData:self.notification.imageData];
             self.imageView.image = gif;
         } else {
-            self.imageView.image = [UIImage imageWithData:self.notification.image];
+            self.imageView.image = [UIImage imageWithData:self.notification.imageData];
         }
     }
     

--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplateInAppData.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplateInAppData.h
@@ -1,0 +1,27 @@
+//
+//  CTCustomTemplateInAppData.h
+//  CleverTapSDK
+//
+//  Created by Nikola Zagorchev on 9.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CTCustomTemplateInAppData : NSObject
+
+@property (nonatomic, copy, readonly) NSString *templateName;
+@property (nonatomic, copy, readonly) NSString *templateId;
+@property (nonatomic, copy, readonly) NSString *templateDescription;
+@property (nonatomic, strong, readonly) NSDictionary *args;
+
+- (instancetype)init NS_UNAVAILABLE;
+#if !CLEVERTAP_NO_INAPP_SUPPORT
++ (instancetype _Nullable)createWithJSON:(NSDictionary * _Nonnull)json;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplateInAppData.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplateInAppData.m
@@ -1,0 +1,49 @@
+//
+//  CTCustomTemplateInAppData.m
+//  CleverTapSDK
+//
+//  Created by Nikola Zagorchev on 9.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import "CTCustomTemplateInAppData.h"
+#import "CTConstants.h"
+#import "CTInAppUtils.h"
+
+@interface CTCustomTemplateInAppData()
+
+@property (nonatomic, copy, readwrite) NSString *templateName;
+@property (nonatomic, copy, readwrite) NSString *templateId;
+@property (nonatomic, copy, readwrite) NSString *templateDescription;
+@property (nonatomic, strong, readwrite) NSDictionary *args;
+
+@end
+
+@implementation CTCustomTemplateInAppData
+
+- (nonnull instancetype)initWithJSON:(nonnull NSDictionary *)json {
+    if (self = [super init]) {
+        @try {
+            self.templateName = json[CLTAP_INAPP_TEMPLATE_NAME];
+            self.templateId = json[CLTAP_INAPP_TEMPLATE_ID];
+            self.templateDescription = json[CLTAP_INAPP_TEMPLATE_DESCRIPTION];
+            id vars = json[CLTAP_INAPP_VARS];
+            if ([vars isKindOfClass:[NSDictionary class]]) {
+                self.args = vars;
+            }
+        } @catch (NSException *e) {
+            CleverTapLogStaticInfo(@"Cannot initialize %@ with json:%@. Error: %@.", self.class, json, [e debugDescription]);
+        }
+    }
+    return self;
+}
+
++ (instancetype)createWithJSON:(nonnull NSDictionary *)json {
+    NSString *inAppType = json[CLTAP_INAPP_TYPE];
+    if ([CTInAppUtils inAppTypeFromString:inAppType] == CTInAppTypeCustom) {
+        return [[CTCustomTemplateInAppData alloc] initWithJSON:json];
+    }
+    return nil;
+}
+
+@end

--- a/CleverTapSDKTests/CTEventBuilderTest.m
+++ b/CleverTapSDKTests/CTEventBuilderTest.m
@@ -283,7 +283,7 @@
 
 - (void)test_buildInAppNotificationStateEvent_withClickedTrueAndInvalidKey {
     NSDictionary *notification = @{@"notiKey": @"notiValue"};
-    CTInAppNotification *inAppNotification = [[CTInAppNotification alloc] initWithJSON:notification imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *inAppNotification = [[CTInAppNotification alloc] initWithJSON:notification];
     NSDictionary *queryParam = @{@"key1": @"value1"};
     
     [CTEventBuilder buildInAppNotificationStateEvent:true forNotification:inAppNotification andQueryParameters:queryParam completionHandler:^(NSDictionary * _Nullable event, NSArray<CTValidationResult *> * _Nullable errors) {
@@ -296,7 +296,7 @@
 
 - (void)test_buildInAppNotificationStateEvent_withClickedFalseAndInvalidKey {
     NSDictionary *notification = @{@"notiKey": @"notiValue"};
-    CTInAppNotification *inAppNotification = [[CTInAppNotification alloc] initWithJSON:notification imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *inAppNotification = [[CTInAppNotification alloc] initWithJSON:notification];
     NSDictionary *queryParam = @{@"key1": @"value1"};
     
     [CTEventBuilder buildInAppNotificationStateEvent:false forNotification:inAppNotification andQueryParameters:queryParam completionHandler:^(NSDictionary * _Nullable event, NSArray<CTValidationResult *> * _Nullable errors) {
@@ -309,7 +309,7 @@
 
 - (void)test_buildInAppNotificationStateEvent_withValidKey {
     NSDictionary *notification = @{@"wzrk_notiKey": @"notiValue"};
-    CTInAppNotification *inAppNotification = [[CTInAppNotification alloc] initWithJSON:notification imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *inAppNotification = [[CTInAppNotification alloc] initWithJSON:notification];
     NSDictionary *queryParam = @{@"key1": @"value1"};
     
     [CTEventBuilder buildInAppNotificationStateEvent:false forNotification:inAppNotification andQueryParameters:queryParam completionHandler:^(NSDictionary * _Nullable event, NSArray<CTValidationResult *> * _Nullable errors) {

--- a/CleverTapSDKTests/InApps/CTInAppFCManagerTest.m
+++ b/CleverTapSDKTests/InApps/CTInAppFCManagerTest.m
@@ -75,7 +75,7 @@
     NSDictionary *inApp = @{
         @"ti": @1
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     [self.inAppFCManager didShow:notif];
     XCTAssertEqual(1, [[self.inAppFCManager.impressionManager getImpressions:@"1"] count]);
     XCTAssertEqual(1, [self.inAppFCManager shownTodayCount]);
@@ -109,7 +109,7 @@
     NSDictionary *inApp = @{
         @"ti": @1
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     [self.inAppFCManager didShow:notif];
     XCTAssertNotNil(self.inAppFCManager.inAppCounts[@"1"]);
 
@@ -121,7 +121,7 @@
     NSDictionary *inApp = @{
         @"ti": @1
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.helper.imagePrefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     [self.helper.inAppTriggerManager incrementTrigger:@"1"];
     [self.inAppFCManager didShow:notif];
     XCTAssertNotNil(self.inAppFCManager.inAppCounts[@"1"]);
@@ -193,7 +193,7 @@
     };
     self.inAppFCManager.globalSessionMax = 5;
     
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     XCTAssertEqual(-1, notif.maxPerSession);
     // Record 4 impressions
     [self recordImpressions:4];
@@ -221,7 +221,7 @@
     };
     self.inAppFCManager.globalSessionMax = 5;
     
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     XCTAssertEqual(1000, notif.maxPerSession);
     // Record 4 impressions
     [self recordImpressions:4];
@@ -241,7 +241,7 @@
     NSDictionary *inApp = @{
         @"ti": @1
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     self.inAppFCManager.impressionManager.sessionImpressions = [@{} mutableCopy];
     // InApp session max will default to -1 on notification level
     XCTAssertEqual(-1, notif.maxPerSession);
@@ -262,7 +262,7 @@
         @"ti": @1,
         @"mdc": @1
     };
-    notif = [[CTInAppNotification alloc] initWithJSON:inAppMdc1000 imagePrefetchManager:self.prefetchManager];
+    notif = [[CTInAppNotification alloc] initWithJSON:inAppMdc1000];
     XCTAssertEqual(1, notif.maxPerSession);
     
     self.inAppFCManager.impressionManager.sessionImpressions = [@{} mutableCopy];
@@ -277,7 +277,7 @@
         @"ti": @1,
         @"mdc": @3
     };
-    notif = [[CTInAppNotification alloc] initWithJSON:inAppMdc3 imagePrefetchManager:self.prefetchManager];
+    notif = [[CTInAppNotification alloc] initWithJSON:inAppMdc3];
     XCTAssertEqual(3, notif.maxPerSession);
     self.inAppFCManager.impressionManager.sessionImpressions = [@{
         @"1": @2
@@ -310,7 +310,7 @@
             @"html": @""
         }
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inAppMdc3 imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inAppMdc3];
     XCTAssertEqual(3, notif.maxPerSession);
     self.inAppFCManager.impressionManager.sessionImpressions = [@{
         @"1": @2
@@ -329,7 +329,7 @@
         @"ti": @1,
         @"tlc": @5
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     XCTAssertEqual(5, notif.totalLifetimeCount);
     XCTAssertFalse([self.inAppFCManager hasLifetimeCapacityMaxedOut:notif]);
     
@@ -347,7 +347,7 @@
     NSDictionary *inApp = @{
         @"ti": @1
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     XCTAssertEqual(-1, notif.totalDailyCount);
     XCTAssertFalse([self.inAppFCManager hasDailyCapacityMaxedOut:notif]);
     // Max Default is 1
@@ -361,7 +361,7 @@
         @"ti": @1,
         @"tdc": @10
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     XCTAssertEqual(10, notif.totalDailyCount);
     XCTAssertFalse([self.inAppFCManager hasDailyCapacityMaxedOut:notif]);
     
@@ -380,7 +380,7 @@
         @"ti": @1,
         @"tdc": @5
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     XCTAssertEqual(5, notif.totalDailyCount);
     
     // Record 4 impressions
@@ -403,7 +403,7 @@
             }
         ]
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     
     // 1 impression is in limit
     [self.inAppFCManager.impressionManager recordImpression:notif.Id];
@@ -421,7 +421,7 @@
         @"efc": @1,
         @"tdc": @1
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     
     [self.inAppFCManager recordImpression:notif.Id];
     XCTAssertTrue([self.inAppFCManager canShow:notif]);
@@ -433,7 +433,7 @@
         @"excludeGlobalFCaps": @1,
         @"tdc": @1
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     
     [self.inAppFCManager recordImpression:notif.Id];
     XCTAssertTrue([self.inAppFCManager canShow:notif]);
@@ -444,7 +444,7 @@
         @"ti": @1,
         @"tdc": @1
     };
-    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp imagePrefetchManager:self.prefetchManager];
+    CTInAppNotification *notif = [[CTInAppNotification alloc] initWithJSON:inApp];
     
     [self.inAppFCManager recordImpression:notif.Id];
     XCTAssertFalse([self.inAppFCManager canShow:notif]);

--- a/CleverTapSDKTests/InApps/CTNotificationActionTest.m
+++ b/CleverTapSDKTests/InApps/CTNotificationActionTest.m
@@ -1,0 +1,129 @@
+//
+//  CTNotificationActionTest.m
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 10.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "CTNotificationAction.h"
+#import "CTNotificationButton.h"
+#import "CTConstants.h"
+
+@interface CTNotificationActionTest : XCTestCase
+
+@end
+
+@implementation CTNotificationActionTest
+
+- (void)testInitWithJSONCustom {
+    NSDictionary *json = @{
+        @"android": @"",
+        @"close": @1,
+        @"ios": @"",
+        @"kv": @{},
+        @"templateId": @"6633c45ae2a2f07007c031a6",
+        @"templateName": @"Function1",
+        @"type": @"custom-code",
+        @"vars": @{
+            @"string": @"hello"
+        }
+    };
+    CTNotificationAction *notificationAction = [[CTNotificationAction alloc] initWithJSON:json];
+    
+    XCTAssertEqual(notificationAction.type, CTInAppActionTypeCustom);
+    XCTAssertEqualObjects(notificationAction.customTemplateInAppData.templateId, @"6633c45ae2a2f07007c031a6");
+    XCTAssertEqualObjects(notificationAction.customTemplateInAppData.templateName, @"Function1");
+    XCTAssertEqualObjects(notificationAction.customTemplateInAppData.args, (@{
+        @"string" : @"hello"
+    }));
+}
+
+- (void)testInitWithJSONOpenURL {
+    NSDictionary *json = @{
+        @"android": @"https://example.com/",
+        @"close": @1,
+        @"ios": @"https://example.com/",
+        @"kv": @{},
+        @"type": @"url"
+    };
+    CTNotificationAction *notificationAction = [[CTNotificationAction alloc] initWithJSON:json];
+    
+    XCTAssertEqual(notificationAction.type, CTInAppActionTypeOpenURL);
+    XCTAssertTrue([notificationAction.actionURL.absoluteString isEqualToString:@"https://example.com/"]);
+    XCTAssertNil(notificationAction.customTemplateInAppData);
+}
+
+- (void)testInitWithJSONKV {
+    NSDictionary *json = @{
+        @"android": @"",
+        @"close": @1,
+        @"ios": @"",
+        @"kv": @{
+            @"key": @"value"
+        },
+        @"type": @"kv"
+    };
+    CTNotificationAction *notificationAction = [[CTNotificationAction alloc] initWithJSON:json];
+    
+    XCTAssertEqual(notificationAction.type, CTInAppActionTypeKeyValues);
+    XCTAssertNil(notificationAction.customTemplateInAppData);
+    XCTAssertEqualObjects(notificationAction.keyValues, (@{
+        @"key" : @"value"
+    }));
+}
+
+- (void)testInitWithJSONClose {
+    NSDictionary *json = @{
+        @"android": @"",
+        @"close": @1,
+        @"ios": @"",
+        @"kv": @{},
+        @"type": @"close"
+    };
+    CTNotificationAction *notificationAction = [[CTNotificationAction alloc] initWithJSON:json];
+    
+    XCTAssertEqual(notificationAction.type, CTInAppActionTypeClose);
+}
+
+- (void)testInitWithJSONRFP {
+    NSDictionary *json = @{
+        @"android": @"",
+        @"close": @1,
+        @"ios": @"",
+        @"kv": @{},
+        @"fbSettings": @1,
+        @"type": @"rfp"
+    };
+    CTNotificationAction *notificationAction = [[CTNotificationAction alloc] initWithJSON:json];
+    
+    XCTAssertEqual(notificationAction.type, CTInAppActionTypeRequestForPermission);
+    XCTAssertEqual(notificationAction.fallbackToSettings, YES);
+}
+
+- (void)testInitWithNotificationButton {
+    NSDictionary *json = @{
+        @"actions": @{
+            @"android": @"",
+            @"close": @1,
+            @"ios": @"https://example.com/",
+            @"kv": @{
+                @"key": @"value"
+            },
+            @"type": @"url",
+            @"fbSettings": @1
+        }
+    };
+    CTNotificationButton *notificationButton = [[CTNotificationButton alloc] initWithJSON:json];
+
+    XCTAssertNotNil(notificationButton.action);
+    XCTAssertEqual(notificationButton.type, CTInAppActionTypeOpenURL);
+    XCTAssertTrue([notificationButton.actionURL.absoluteString isEqualToString:@"https://example.com/"]);
+    XCTAssertEqual(notificationButton.fallbackToSettings, YES);
+    XCTAssertEqualObjects(notificationButton.customExtras, (@{
+        @"key" : @"value"
+    }));
+}
+
+@end

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplateInAppDataTest.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplateInAppDataTest.m
@@ -1,0 +1,96 @@
+//
+//  CTCustomTemplateInAppDataTest.m
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 10.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "CTCustomTemplateInAppData.h"
+#import "CTInAppNotification.h"
+#import "CTConstants.h"
+
+@interface CTCustomTemplateInAppDataTest : XCTestCase
+
+@end
+
+@implementation CTCustomTemplateInAppDataTest
+
+- (void)testCreateWithJSON {
+    NSDictionary *json = @{
+        CLTAP_INAPP_TEMPLATE_ID: @"templateId",
+        CLTAP_INAPP_TEMPLATE_NAME: @"templateName",
+        CLTAP_INAPP_TYPE: @"custom-code",
+        CLTAP_INAPP_TEMPLATE_DESCRIPTION: @"templateDescription",
+        CLTAP_INAPP_VARS: @{
+            @"key1": @"value1",
+            @"key2": @"value2"
+        }
+    };
+    CTCustomTemplateInAppData *customTemplate = [CTCustomTemplateInAppData createWithJSON:json];
+    
+    XCTAssertEqualObjects(customTemplate.templateName, @"templateName");
+    XCTAssertEqualObjects(customTemplate.templateId, @"templateId");
+    XCTAssertEqualObjects(customTemplate.templateDescription, @"templateDescription");
+    XCTAssertEqualObjects(customTemplate.args, (@{
+        @"key1": @"value1",
+        @"key2": @"value2"
+    }));
+}
+
+- (void)testCreateWithJSONNotCustomCode {
+    NSDictionary *json = @{
+        CLTAP_INAPP_TEMPLATE_ID: @"templateId",
+        CLTAP_INAPP_TEMPLATE_NAME: @"templateName",
+        CLTAP_INAPP_TYPE: @"interstitial",
+        CLTAP_INAPP_TEMPLATE_DESCRIPTION: @"templateDescription",
+        CLTAP_INAPP_VARS: @{
+            @"key1": @"value1",
+            @"key2": @"value2"
+        }
+    };
+    CTCustomTemplateInAppData *customTemplate = [CTCustomTemplateInAppData createWithJSON:json];
+    XCTAssertNil(customTemplate);
+}
+
+- (void)testCreateWithJSONNoType {
+    NSDictionary *json = @{
+        CLTAP_INAPP_TEMPLATE_ID: @"templateId",
+        CLTAP_INAPP_TEMPLATE_NAME: @"templateName",
+        CLTAP_INAPP_TEMPLATE_DESCRIPTION: @"templateDescription",
+        CLTAP_INAPP_VARS: @{
+            @"key1": @"value1",
+            @"key2": @"value2"
+        }
+    };
+    CTCustomTemplateInAppData *customTemplate = [CTCustomTemplateInAppData createWithJSON:json];
+    XCTAssertNil(customTemplate);
+}
+
+- (void)testCreateFromInAppNotification {
+    NSDictionary *json = @{
+        @"templateDescription": @"",
+        @"templateId": @"6633c400e2a2f07007c031a5",
+        @"templateName": @"templateName",
+        @"ti": @1715349815,
+        @"type": @"custom-code",
+        @"vars": @{
+            @"number": @123,
+            @"string": @"hello",
+        },
+        @"wzrk_id": @"1715349815_20240510"
+    };
+    
+    CTInAppNotification *inApp = [[CTInAppNotification alloc] initWithJSON:json];
+    CTCustomTemplateInAppData *customTemplateData = inApp.customTemplateInAppData;
+    XCTAssertEqualObjects(customTemplateData.templateName, @"templateName");
+    XCTAssertEqualObjects(customTemplateData.templateId, @"6633c400e2a2f07007c031a5");
+    XCTAssertEqualObjects(customTemplateData.templateDescription, @"");
+    XCTAssertEqualObjects(customTemplateData.args, (@{
+        @"number": @123,
+        @"string": @"hello",
+    }));
+}
+
+@end


### PR DESCRIPTION
### Overview
Refactor `CTInAppNotification`. Move the prepare notification logic for downloading the image and landscape image to the `CTInAppDisplayManager`.
Extend `CTInAppNotification` and `CTNotificationButton` to support custom functions.

### Implementation
- Add `CTCustomTemplateInAppData` to the `CTInAppNotification`
- Move the action from `CTNotificationButton` to the `CTNotificationAction`
- Add `CTCustomTemplateInAppData` to the `CTNotificationAction`

Commits: [efbc064](https://github.com/CleverTap/clevertap-ios-sdk/pull/330/commits/efbc0643008313674b39a29fd630aa14f08952b4), [60db706](https://github.com/CleverTap/clevertap-ios-sdk/pull/330/commits/60db706a65ea86196f0476a264b8ef7dc77a961f)
