### PR TITLE
[MC-1468] Custom templates present and dismiss (Custom Templates Part 4)

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -371,6 +371,7 @@
 		6BB778CC2BED21CE00A41628 /* CTNotificationAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778CA2BED21CE00A41628 /* CTNotificationAction.m */; };
 		6BB778CE2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778CD2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m */; };
 		6BB778D02BEE4C3400A41628 /* CTNotificationActionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */; };
+		6BB778D22BF267B600A41628 /* CTTemplateContextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778D12BF267B600A41628 /* CTTemplateContextTest.m */; };
 		6BD334EA2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */; };
 		6BD334EB2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */; };
 		6BD334EC2AF2A41F0099E33E /* CTBatchSentDelegateHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */; };
@@ -906,6 +907,7 @@
 		6BB778CA2BED21CE00A41628 /* CTNotificationAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTNotificationAction.m; sourceTree = "<group>"; };
 		6BB778CD2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTCustomTemplateInAppDataTest.m; sourceTree = "<group>"; };
 		6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTNotificationActionTest.m; sourceTree = "<group>"; };
+		6BB778D12BF267B600A41628 /* CTTemplateContextTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTTemplateContextTest.m; sourceTree = "<group>"; };
 		6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTBatchSentDelegateHelper.h; sourceTree = "<group>"; };
 		6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTBatchSentDelegateHelper.m; sourceTree = "<group>"; };
 		6BD334EF2AF545C70099E33E /* CTInAppStoreTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTInAppStoreTest.m; sourceTree = "<group>"; };
@@ -1447,6 +1449,7 @@
 				6B32A0B22B9F2E8F009ADC57 /* CTTestTemplateProducer.h */,
 				6B32A0B32B9F2E8F009ADC57 /* CTTestTemplateProducer.m */,
 				6BB778CD2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m */,
+				6BB778D12BF267B600A41628 /* CTTemplateContextTest.m */,
 			);
 			path = CustomTemplates;
 			sourceTree = "<group>";
@@ -2410,6 +2413,7 @@
 				6B32A0B42B9F2E8F009ADC57 /* CTTestTemplateProducer.m in Sources */,
 				6A2E0B9829D49D5100FCEA5F /* CTVarCacheMock.m in Sources */,
 				4EAF05022A495DD5009D9D61 /* CleverTapInstanceTests.m in Sources */,
+				6BB778D22BF267B600A41628 /* CTTemplateContextTest.m in Sources */,
 				6A2E0B9329D0A5CF00FCEA5F /* CTVariablesTest.m in Sources */,
 				D02AC2DB276044F70031C1BE /* CleverTapSDKTests.m in Sources */,
 				32394C2129FA264B00956058 /* CTPreferencesTest.m in Sources */,

--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -372,6 +372,9 @@
 		6BB778CE2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778CD2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m */; };
 		6BB778D02BEE4C3400A41628 /* CTNotificationActionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */; };
 		6BB778D22BF267B600A41628 /* CTTemplateContextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB778D12BF267B600A41628 /* CTTemplateContextTest.m */; };
+		6BB778D62BFD26E000A41628 /* CTInAppNotificationDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB778D52BFD26DF00A41628 /* CTInAppNotificationDisplayDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6BB778D72BFD26E000A41628 /* CTInAppNotificationDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB778D52BFD26DF00A41628 /* CTInAppNotificationDisplayDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6BB778D92BFD277400A41628 /* CTCustomTemplatesManager-Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB778D82BFD277400A41628 /* CTCustomTemplatesManager-Internal.h */; };
 		6BD334EA2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */; };
 		6BD334EB2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */; };
 		6BD334EC2AF2A41F0099E33E /* CTBatchSentDelegateHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */; };
@@ -908,6 +911,8 @@
 		6BB778CD2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTCustomTemplateInAppDataTest.m; sourceTree = "<group>"; };
 		6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTNotificationActionTest.m; sourceTree = "<group>"; };
 		6BB778D12BF267B600A41628 /* CTTemplateContextTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTTemplateContextTest.m; sourceTree = "<group>"; };
+		6BB778D52BFD26DF00A41628 /* CTInAppNotificationDisplayDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTInAppNotificationDisplayDelegate.h; sourceTree = "<group>"; };
+		6BB778D82BFD277400A41628 /* CTCustomTemplatesManager-Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CTCustomTemplatesManager-Internal.h"; sourceTree = "<group>"; };
 		6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTBatchSentDelegateHelper.h; sourceTree = "<group>"; };
 		6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTBatchSentDelegateHelper.m; sourceTree = "<group>"; };
 		6BD334EF2AF545C70099E33E /* CTInAppStoreTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTInAppStoreTest.m; sourceTree = "<group>"; };
@@ -1478,6 +1483,7 @@
 				6B32A0A02B99033F009ADC57 /* CTCustomTemplateBuilder-Internal.h */,
 				6BB778C52BECEC2700A41628 /* CTCustomTemplateInAppData.h */,
 				6BB778C62BECEC2700A41628 /* CTCustomTemplateInAppData.m */,
+				6BB778D82BFD277400A41628 /* CTCustomTemplatesManager-Internal.h */,
 			);
 			path = CustomTemplates;
 			sourceTree = "<group>";
@@ -1733,6 +1739,7 @@
 				6BA3B2DA2B03E926004E834B /* CTQueueType.h */,
 				6BB778C92BED21CE00A41628 /* CTNotificationAction.h */,
 				6BB778CA2BED21CE00A41628 /* CTNotificationAction.m */,
+				6BB778D52BFD26DF00A41628 /* CTInAppNotificationDisplayDelegate.h */,
 			);
 			path = CleverTapSDK;
 			sourceTree = "<group>";
@@ -1801,6 +1808,7 @@
 				4E8B816C2AD2B2FD00714BB4 /* CleverTapInternal.h in Headers */,
 				D014B90220E2FB4F001E0780 /* CTEventBuilder.h in Headers */,
 				6A6591692AC70FFE005FDE57 /* CTBatchSentDelegate.h in Headers */,
+				6BB778D72BFD26E000A41628 /* CTInAppNotificationDisplayDelegate.h in Headers */,
 				07BF465B217F7C41002E166D /* CTInAppDisplayViewController.h in Headers */,
 				4E25E3D22788889F0008C888 /* CTLoginInfoProvider.h in Headers */,
 				D0BD75AF241769E40006EE55 /* CleverTap+ProductConfig.h in Headers */,
@@ -1892,6 +1900,7 @@
 				6B535FB62AD56C60002A2663 /* CTMultiDelegateManager.h in Headers */,
 				4EF0D5452AD84BCA0044C48F /* CTSessionManager.h in Headers */,
 				D0213D4C207D905800FE5740 /* CleverTapSyncDelegate.h in Headers */,
+				6BB778D92BFD277400A41628 /* CTCustomTemplatesManager-Internal.h in Headers */,
 				07B94546219EA34300D4C542 /* CTMessageMO+CoreDataProperties.h in Headers */,
 				48BEA4F62AFB868B00690424 /* CTInAppImagePrefetchManager.h in Headers */,
 				6BB727332B8F787D009CE7D0 /* CTCustomTemplatesManager.h in Headers */,
@@ -1985,6 +1994,7 @@
 				6BB727212B8E55CD009CE7D0 /* CTTemplateContext.h in Headers */,
 				4E8B816F2AD2BB8A00714BB4 /* CTDispatchQueueManager.h in Headers */,
 				D01A0894207EC2D400423D6F /* CleverTapInstanceConfig.h in Headers */,
+				6BB778D62BFD26E000A41628 /* CTInAppNotificationDisplayDelegate.h in Headers */,
 				4808030E292EB4FB00C06E2F /* CleverTap+PushPermission.h in Headers */,
 				071EB50C217F6427008F0FAB /* CTCoverImageViewController.h in Headers */,
 				4E8B81782AD2CB4E00714BB4 /* CTPushPrimerManager.h in Headers */,

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -186,6 +186,7 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_INAPP_TEMPLATE_ID @"templateId"
 #define CLTAP_INAPP_TEMPLATE_DESCRIPTION @"templateDescription"
 #define CLTAP_INAPP_VARS @"vars"
+#define CLTAP_INAPP_ACTIONS @"actions"
 
 #define CLTAP_INAPP_PREVIEW_TYPE @"wzrk_inapp_type"
 #define CLTAP_INAPP_IMAGE_INTERSTITIAL_TYPE @"image-interstitial"

--- a/CleverTapSDK/CTInAppDisplayViewController.h
+++ b/CleverTapSDK/CTInAppDisplayViewController.h
@@ -1,28 +1,9 @@
 #import <UIKit/UIKit.h>
 #import "CTInAppNotification.h"
+#import "CTInAppNotificationDisplayDelegate.h"
 #if !(TARGET_OS_TV)
 #import "CleverTapJSInterface.h"
 #endif
-
-@class CTInAppDisplayViewController;
-
-@protocol CTInAppNotificationDisplayDelegate <NSObject>
-- (void)handleNotificationCTA:(NSURL*)ctaURL buttonCustomExtras:(NSDictionary *)buttonCustomExtras forNotification:(CTInAppNotification*)notification fromViewController:(CTInAppDisplayViewController*)controller withExtras:(NSDictionary*)extras;
-- (void)notificationDidDismiss:(CTInAppNotification*)notification fromViewController:(CTInAppDisplayViewController*)controller;
-/**
- Called when in-app button is tapped for requesting push permission.
- */
-- (void)handleInAppPushPrimer:(CTInAppNotification*)notification
-           fromViewController:(CTInAppDisplayViewController*)controller
-       withFallbackToSettings:(BOOL)isFallbackToSettings;
-
-/**
- Called to notify that local in-app push primer is dismissed.
- */
-- (void)inAppPushPrimerDidDismissed;
-@optional
-- (void)notificationDidShow:(CTInAppNotification*)notification fromViewController:(CTInAppDisplayViewController*)controller;
-@end
 
 @interface CTInAppDisplayViewController : UIViewController
 

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -136,8 +136,8 @@ API_AVAILABLE(ios(13.0)) {
     [self.window setHidden:NO];
     
     void (^completionBlock)(void) = ^ {
-        if (self.delegate && [self.delegate respondsToSelector:@selector(notificationDidShow:fromViewController:)]) {
-            [self.delegate notificationDidShow:self.notification fromViewController:self];
+        if (self.delegate) {
+            [self.delegate notificationDidShow:self.notification];
         }
     };
     

--- a/CleverTapSDK/CTInAppNotificationDisplayDelegate.h
+++ b/CleverTapSDK/CTInAppNotificationDisplayDelegate.h
@@ -1,0 +1,36 @@
+//
+//  CTInAppNotificationDisplayDelegate.h
+//  CleverTapSDK
+//
+//  Created by Nikola Zagorchev on 21.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#ifndef CTInAppNotificationDisplayDelegate_h
+#define CTInAppNotificationDisplayDelegate_h
+
+@class CTInAppDisplayViewController;
+
+@protocol CTInAppNotificationDisplayDelegate <NSObject>
+
+- (void)notificationDidShow:(CTInAppNotification *)notification;
+
+- (void)handleNotificationCTA:(NSURL *)ctaURL buttonCustomExtras:(NSDictionary *)buttonCustomExtras forNotification:(CTInAppNotification *)notification fromViewController:(CTInAppDisplayViewController *)controller withExtras:(NSDictionary *)extras;
+
+- (void)notificationDidDismiss:(CTInAppNotification *)notification fromViewController:(CTInAppDisplayViewController *)controller;
+
+/**
+ Called when in-app button is tapped for requesting push permission.
+ */
+- (void)handleInAppPushPrimer:(CTInAppNotification *)notification
+           fromViewController:(CTInAppDisplayViewController *)controller
+       withFallbackToSettings:(BOOL)isFallbackToSettings;
+
+/**
+ Called to notify that local in-app push primer is dismissed.
+ */
+- (void)inAppPushPrimerDidDismissed;
+
+@end
+
+#endif /* Header_h */

--- a/CleverTapSDK/CTInAppUtils.h
+++ b/CleverTapSDK/CTInAppUtils.h
@@ -27,8 +27,9 @@ typedef NS_ENUM(NSUInteger, CTInAppActionType){
 
 @interface CTInAppUtils : NSObject
 
-+ (CTInAppType)inAppTypeFromString:(NSString* _Nonnull)type;
-+ (CTInAppActionType)inAppActionTypeFromString:(NSString* _Nonnull)type;
++ (CTInAppType)inAppTypeFromString:(NSString *_Nonnull)type;
++ (CTInAppActionType)inAppActionTypeFromString:(NSString *_Nonnull)type;
++ (NSString * _Nonnull)inAppActionTypeString:(CTInAppActionType)type;
 + (NSBundle *_Nullable)bundle;
 + (NSString *_Nullable)getXibNameForControllerName:(NSString *_Nonnull)controllerName;
 

--- a/CleverTapSDK/CTInAppUtils.m
+++ b/CleverTapSDK/CTInAppUtils.m
@@ -6,8 +6,9 @@
 #import "CTUIUtils.h"
 #endif
 
-static NSDictionary *_inAppTypeMap;
-static NSDictionary *_inAppActionTypeMap;
+static NSDictionary<NSString *, NSNumber *> *_inAppTypeMap;
+static NSDictionary<NSString *, NSNumber *> *_inAppActionTypeStringToTypeMap;
+static NSDictionary<NSNumber *, NSString *> *_inAppActionTypeTypeToStringMap;
 
 @implementation CTInAppUtils
 
@@ -35,9 +36,21 @@ static NSDictionary *_inAppActionTypeMap;
     return [_type integerValue];
 }
 
-+ (CTInAppActionType)inAppActionTypeFromString:(NSString* _Nonnull)type {
-    if (_inAppActionTypeMap == nil) {
-        _inAppActionTypeMap = @{
++ (NSDictionary<NSNumber *, NSString *> *)inAppActionTypeTypeToStringMap {
+    if (_inAppActionTypeTypeToStringMap == nil) {
+        NSDictionary *dict = [self inAppActionTypeStringToTypeMap];
+        NSMutableDictionary *swapped = [NSMutableDictionary new];
+        [dict enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+            swapped[value] = key;
+        }];
+        _inAppActionTypeTypeToStringMap = [swapped copy];
+    }
+    return _inAppActionTypeTypeToStringMap;
+}
+
++ (NSDictionary<NSString *, NSNumber *> *)inAppActionTypeStringToTypeMap {
+    if (_inAppActionTypeStringToTypeMap == nil) {
+        _inAppActionTypeStringToTypeMap = @{
             @"close": @(CTInAppActionTypeClose),
             @"url": @(CTInAppActionTypeOpenURL),
             @"kv": @(CTInAppActionTypeKeyValues),
@@ -45,14 +58,20 @@ static NSDictionary *_inAppActionTypeMap;
             @"rfp": @(CTInAppActionTypeRequestForPermission)
         };
     }
-    
-    NSNumber *_type = type != nil ? _inAppActionTypeMap[type] : @(CTInAppActionTypeUnknown);
+    return _inAppActionTypeStringToTypeMap;
+}
+
++ (CTInAppActionType)inAppActionTypeFromString:(NSString* _Nonnull)type {
+    NSNumber *_type = type != nil ? [self inAppActionTypeStringToTypeMap][type] : @(CTInAppActionTypeUnknown);
     if (_type == nil) {
         _type = @(CTInAppActionTypeUnknown);
     }
     return [_type integerValue];
 }
 
++ (NSString * _Nonnull)inAppActionTypeString:(CTInAppActionType)type {
+    return self.inAppActionTypeTypeToStringMap[@(type)];
+}
 
 + (NSBundle *)bundle {
 #if CLEVERTAP_NO_INAPP_SUPPORT

--- a/CleverTapSDK/CTNotificationButton.m
+++ b/CleverTapSDK/CTNotificationButton.m
@@ -1,4 +1,5 @@
 #import "CTNotificationButton.h"
+#import "CTConstants.h"
 
 @interface CTNotificationButton () {
     
@@ -30,7 +31,7 @@
             self.borderColor = jsonObject[@"border"];
             self.backgroundColor = jsonObject[@"bg"];
             
-            NSDictionary *actions = jsonObject[@"actions"];
+            NSDictionary *actions = jsonObject[CLTAP_INAPP_ACTIONS];
             if (actions) {
                 self.action = [[CTNotificationAction alloc] initWithJSON:actions];
                 if (self.action.error) {

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -57,7 +57,7 @@
 #import "CTInAppEvaluationManager.h"
 #import "CTInAppTriggerManager.h"
 #import "CTInAppImagePrefetchManager.h"
-#import "CTCustomTemplatesManager.h"
+#import "CTCustomTemplatesManager-Internal.h"
 #endif
 
 #if !CLEVERTAP_NO_INBOX_SUPPORT
@@ -523,16 +523,17 @@ static BOOL sharedInstanceErrorLogged;
     
     CTInAppFCManager *inAppFCManager = [[CTInAppFCManager alloc] initWithConfig:self.config delegateManager:self.delegateManager deviceId:[_deviceInfo.deviceId copy] impressionManager:impressionManager inAppTriggerManager:triggerManager];
     
+    CTCustomTemplatesManager *templatesManager = [[CTCustomTemplatesManager alloc] initWithConfig:self.config];
+    
     CTInAppDisplayManager *displayManager = [[CTInAppDisplayManager alloc] initWithCleverTap:self
                                                                         dispatchQueueManager:self.dispatchQueueManager
                                                                               inAppFCManager:inAppFCManager
                                                                            impressionManager:impressionManager
                                                                                   inAppStore:inAppStore
-                                                                        imagePrefetchManager:self.imagePrefetchManager];
+                                                                        imagePrefetchManager:self.imagePrefetchManager
+                                                                            templatesManager:templatesManager];
     
     CTInAppEvaluationManager *evaluationManager = [[CTInAppEvaluationManager alloc] initWithAccountId:self.config.accountId deviceId:self.deviceInfo.deviceId delegateManager:self.delegateManager impressionManager:impressionManager inAppDisplayManager:displayManager inAppStore:inAppStore inAppTriggerManager:triggerManager];
-    
-    CTCustomTemplatesManager *templatesManager = [[CTCustomTemplatesManager alloc] initWithConfig:self.config];
     
     self.customTemplatesManager = templatesManager;
     self.inAppFCManager = inAppFCManager;

--- a/CleverTapSDK/InApps/CTAlertViewController.m
+++ b/CleverTapSDK/InApps/CTAlertViewController.m
@@ -118,8 +118,8 @@
     [self.window setHidden:NO];
     
     void (^completionBlock)(void) = ^ {
-        if (self.delegate && [self.delegate respondsToSelector:@selector(notificationDidShow:fromViewController:)]) {
-            [self.delegate notificationDidShow:self.notification fromViewController:self];
+        if (self.delegate) {
+            [self.delegate notificationDidShow:self.notification];
         }
     };
     

--- a/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
+++ b/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
@@ -381,8 +381,8 @@ typedef enum {
     [self.window setHidden:NO];
     
     void (^completionBlock)(void) = ^ {
-        if (self.delegate && [self.delegate respondsToSelector:@selector(notificationDidShow:fromViewController:)]) {
-            [self.delegate notificationDidShow:self.notification fromViewController:self];
+        if (self.delegate) {
+            [self.delegate notificationDidShow:self.notification];
         }
     };
     if (animated) {

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.h
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.h
@@ -14,6 +14,7 @@
 #import "CTPushPrimerManager.h"
 #import "CTInAppStore.h"
 #import "CTInAppImagePrefetchManager.h"
+#import "CTCustomTemplatesManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,11 +37,13 @@ typedef NS_ENUM(NSInteger, CleverTapInAppRenderingStatus) {
                             inAppFCManager:(CTInAppFCManager *)inAppFCManager
                          impressionManager:(CTImpressionManager *)impressionManager
                                 inAppStore:(CTInAppStore *)inAppStore
-                      imagePrefetchManager:(CTInAppImagePrefetchManager *)imagePrefetchManager;
+                      imagePrefetchManager:(CTInAppImagePrefetchManager *)imagePrefetchManager
+                          templatesManager:(CTCustomTemplatesManager *)templatesManager;
 
 - (void)setPushPrimerManager:(CTPushPrimerManager* _Nonnull)pushPrimerManagerObj;
 - (void)prepareNotificationForDisplay:(NSDictionary* _Nonnull)jsonObj;
 - (BOOL)didHandleInAppTestFromPushNotificaton:(NSDictionary* _Nullable)notification;
+- (BOOL)isTemplateRegistered:(NSDictionary *)inAppJSON;
 
 - (void)_addInAppNotificationsToQueue:(NSArray *)inappNotifs;
 - (void)_showNotificationIfAvailable;

--- a/CleverTapSDK/InApps/CTInAppEvaluationManager.m
+++ b/CleverTapSDK/InApps/CTInAppEvaluationManager.m
@@ -157,6 +157,10 @@
         if (!campaignId) {
             continue;
         }
+        if (![self.inAppDisplayManager isTemplateRegistered:inApp]) {
+            continue;
+        }
+        
         // Match trigger
         NSArray *whenTriggers = inApp[CLTAP_INAPP_TRIGGERS];
         BOOL matchesTrigger = [self.triggersMatcher matchEventWhenTriggers:whenTriggers event:event];

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -504,8 +504,8 @@ typedef enum {
     [self.window setHidden:NO];
     
     void (^completionBlock)(void) = ^ {
-        if (self.delegate && [self.delegate respondsToSelector:@selector(notificationDidShow:fromViewController:)]) {
-            [self.delegate notificationDidShow:self.notification fromViewController:self];
+        if (self.delegate) {
+            [self.delegate notificationDidShow:self.notification];
         }
     };
     if (animated) {

--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplate-Internal.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplate-Internal.h
@@ -17,6 +17,7 @@
 
 @property (nonatomic, strong, readonly) NSString *templateType;
 @property (nonatomic, strong, readonly) NSArray<CTTemplateArgument *> *arguments;
+@property (nonatomic, strong, readonly) id<CTTemplatePresenter> presenter;
 
 - (instancetype)initWithTemplateName:(NSString *)templateName
                         templateType:(NSString *)templateType

--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager-Internal.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager-Internal.h
@@ -1,0 +1,25 @@
+//
+//  CTCustomTemplatesManager-Internal.h
+//  CleverTapSDK
+//
+//  Created by Nikola Zagorchev on 21.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#ifndef CTCustomTemplatesManager_Internal_h
+#define CTCustomTemplatesManager_Internal_h
+
+#import "CTCustomTemplatesManager.h"
+#import "CleverTapInstanceConfig.h"
+#import "CTInAppNotification.h"
+#import "CTInAppNotificationDisplayDelegate.h"
+
+@interface CTCustomTemplatesManager (Internal)
+
+- (instancetype)initWithConfig:(CleverTapInstanceConfig *)instanceConfig;
+
+- (void)presentNotification:(CTInAppNotification *)notification withDelegate:(id<CTInAppNotificationDisplayDelegate>)delegate;
+
+@end
+
+#endif /* CTCustomTemplatesManager_Internal_h */

--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager.h
@@ -8,7 +8,6 @@
 
 #import <Foundation/Foundation.h>
 #import "CTTemplateProducer.h"
-#import "CleverTapInstanceConfig.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,8 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)registerTemplateProducer:(id<CTTemplateProducer>)producer;
 
 - (instancetype)init NS_UNAVAILABLE;
-
-- (instancetype)initWithConfig:(CleverTapInstanceConfig *)instanceConfig;
 
 - (BOOL)isRegisteredTemplateWithName:(NSString *)name;
 

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext-Internal.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext-Internal.h
@@ -9,9 +9,13 @@
 #ifndef CTTemplateContext_Internal_h
 #define CTTemplateContext_Internal_h
 
-@interface CTTemplateContext ()
+#import "CTInAppNotification.h"
+#import "CTCustomTemplate.h"
+#import "CTTemplateContext.h"
 
-- (instancetype)initWithTemplateName:(NSString *)templateName;
+@interface CTTemplateContext (Internal)
+
+- (instancetype)initWithTemplate:(CTCustomTemplate *)template andNotification:(CTInAppNotification *)notification;
 
 @end
 

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext-Internal.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext-Internal.h
@@ -12,10 +12,13 @@
 #import "CTInAppNotification.h"
 #import "CTCustomTemplate.h"
 #import "CTTemplateContext.h"
+#import "CTInAppNotificationDisplayDelegate.h"
 
 @interface CTTemplateContext (Internal)
 
-- (instancetype)initWithTemplate:(CTCustomTemplate *)template andNotification:(CTInAppNotification *)notification;
+- (instancetype)initWithTemplate:(CTCustomTemplate *)customTemplate andNotification:(CTInAppNotification *)notification;
+
+- (void)setDelegate:(id<CTInAppNotificationDisplayDelegate>)delegate;
 
 @end
 

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.h
@@ -51,11 +51,16 @@ NS_SWIFT_NAME(dictionary(name:));
 NS_SWIFT_NAME(file(name:));
 
 /**
+ * Call this method to notify the SDK the template is presented.
+ */
+- (void)presented;
+
+/**
  * Executes the action given by the "name" key.
  * Records Notification Clicked event.
  */
-- (void)executeActionNamed:(NSString *)name
-NS_SWIFT_NAME(executeAction(name:));
+- (void)triggerActionNamed:(NSString *)name
+NS_SWIFT_NAME(triggerAction(name:));
 
 /**
  * Call this method to notify the SDK the template is dismissed.

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.h
@@ -20,17 +20,35 @@ NS_SWIFT_NAME(name());
 - (nullable NSString *)stringNamed:(NSString *)name
 NS_SWIFT_NAME(string(name:));
 
-- (nullable NSString *)fileNamed:(NSString *)name
-NS_SWIFT_NAME(file(name:));
-
 - (nullable NSNumber *)numberNamed:(NSString *)name
 NS_SWIFT_NAME(number(name:));
+
+- (int)charNamed:(NSString *)name
+NS_SWIFT_NAME(char(name:));
+
+- (int)intNamed:(NSString *)name
+NS_SWIFT_NAME(int(name:));
+
+- (double)doubleNamed:(NSString *)name
+NS_SWIFT_NAME(double(name:));
+
+- (float)floatNamed:(NSString *)name
+NS_SWIFT_NAME(float(name:));
+
+- (long)longNamed:(NSString *)name
+NS_SWIFT_NAME(long(name:));
+
+- (long long)longLongNamed:(NSString *)name
+NS_SWIFT_NAME(longLong(name:));
 
 - (BOOL)boolNamed:(NSString *)name
 NS_SWIFT_NAME(boolean(name:));
 
 - (nullable NSDictionary *)dictionaryNamed:(NSString *)name
 NS_SWIFT_NAME(dictionary(name:));
+
+- (nullable NSString *)fileNamed:(NSString *)name
+NS_SWIFT_NAME(file(name:));
 
 /**
  * Executes the action given by the "name" key.

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
@@ -160,6 +160,7 @@
 - (void)dismissed {
     if (self.delegate) {
         [self.delegate notificationDidDismiss:self.notification fromViewController:nil];
+        self.delegate = nil;
     } else {
         CleverTapLogStaticDebug(@"%@: Cannot set template as dismissed.", [self class])
     }

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
@@ -18,6 +18,7 @@
 @property (nonatomic) CTCustomTemplate *template;
 @property (nonatomic) CTInAppNotification *notification;
 @property (nonatomic, strong) NSDictionary *argumentValues;
+@property (nonatomic) id<CTInAppNotificationDisplayDelegate> delegate;
 
 @end
 
@@ -25,10 +26,10 @@
 
 @synthesize argumentValues = _argumentValues;
 
-- (instancetype)initWithTemplate:(CTCustomTemplate *)template andNotification:(CTInAppNotification *)notification {
+- (instancetype)initWithTemplate:(CTCustomTemplate *)customTemplate andNotification:(CTInAppNotification *)notification {
     if (self = [super init]) {
         self.notification = notification;
-        self.template = template;
+        self.template = customTemplate;
     }
     return self;
 }
@@ -140,12 +141,28 @@
     return self.argumentValues[name];
 }
 
-- (void)executeActionNamed:(NSString *)name {
+- (void)presented {
+    if (self.delegate) {
+        [self.delegate notificationDidShow:self.notification];
+    } else {
+        CleverTapLogStaticDebug(@"%@: Cannot set template as presented.", [self class])
+    }
+}
+
+- (void)triggerActionNamed:(NSString *)name {
     // TODO: add when implementing action handling
+    id action = self.argumentValues[name];
+    if ([action isKindOfClass:[CTNotificationAction class]]) {
+        
+    }
 }
 
 - (void)dismissed {
-    // TODO: implement
+    if (self.delegate) {
+        [self.delegate notificationDidDismiss:self.notification fromViewController:nil];
+    } else {
+        CleverTapLogStaticDebug(@"%@: Cannot set template as dismissed.", [self class])
+    }
 }
 
 - (NSDictionary *)argumentValues {
@@ -193,7 +210,7 @@
                 if (action && !action.error) {
                     return action;
                 } else if (action.error) {
-                    CleverTapLogStaticDebug(@"%@: Error creating action for argument: %@. Error: %@", self, arg.name, action.error);
+                    CleverTapLogStaticDebug(@"%@: Error creating action for argument: %@. Error: %@", [self class], arg.name, action.error);
                 }
                 break;
             }

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplatePresenter.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplatePresenter.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)onPresent:(CTTemplateContext *)context
 NS_SWIFT_NAME(onPresent(context:));
+
 - (void)onCloseClicked:(CTTemplateContext *)context
 NS_SWIFT_NAME(onCloseClicked(context:));
 

--- a/CleverTapSDKTests/InApps/CTInAppEvaluationManagerTest.m
+++ b/CleverTapSDKTests/InApps/CTInAppEvaluationManagerTest.m
@@ -36,7 +36,8 @@
                          inAppFCManager:nil
                       impressionManager:nil
                              inAppStore:nil
-                   imagePrefetchManager:nil]) {
+                   imagePrefetchManager:nil
+                       templatesManager:nil]) {
         self.inappNotifs = [NSMutableArray new];
     }
     return self;

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplatesManagerTest.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplatesManagerTest.m
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
-#import "CTCustomTemplatesManager.h"
+#import "CTCustomTemplatesManager-Internal.h"
 #import "CTCustomTemplatesManager+Tests.h"
 #import "CTInAppTemplateBuilder.h"
 #import "CTAppFunctionBuilder.h"

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTTemplateContextTest.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTTemplateContextTest.m
@@ -1,0 +1,266 @@
+//
+//  CTTemplateContextTest.m
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 13.05.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "CTTemplateContext-Internal.h"
+#import "CTInAppTemplateBuilder.h"
+#import "CTAppFunctionBuilder.h"
+#import "CTTemplatePresenterMock.h"
+#import "CTTemplateContext-Internal.h"
+
+@interface CTTemplateContextTest : XCTestCase
+
+@end
+
+@implementation CTTemplateContextTest
+
+- (void)testSimpleValueOverrides {
+    CTInAppNotification *notification = [[CTInAppNotification alloc] initWithJSON:self.simpleTemplateNotificationJson];
+    CTTemplateContext *context = [[CTTemplateContext alloc] initWithTemplate:self.simpleTemplate andNotification:notification];
+    XCTAssertEqual(VARS_OVERRIDE_BOOLEAN, [context boolNamed:@"a.b.c"]);
+    XCTAssertEqualObjects(VARS_OVERRIDE_STRING, [context stringNamed:@"a.b.d"]);
+    XCTAssertEqualObjects(@(VARS_OVERRIDE_LONG), [context numberNamed:@"a.b.e.f"]);
+    XCTAssertEqual(VARS_OVERRIDE_DOUBLE, [context doubleNamed:@"g"]);
+    XCTAssertEqual(VARS_OVERRIDE_BOOLEAN, [context boolNamed:@"h"]);
+    XCTAssertEqualObjects(VARS_DEFAULT_STRING, [context stringNamed:@"i"]);
+    
+    NSDictionary *a = [context dictionaryNamed:@"a"];
+    XCTAssertTrue([a isEqualToDictionary:(@{
+        @"b": @{
+            @"c": @(VARS_OVERRIDE_BOOLEAN),
+            @"d": VARS_OVERRIDE_STRING,
+            @"e": @{
+                @"f": @(VARS_OVERRIDE_LONG)
+            }
+        }
+    })]);
+    
+    NSDictionary *ab = [context dictionaryNamed:@"a.b"];
+    XCTAssertTrue([ab isEqualToDictionary:(@{
+        @"c": @(VARS_OVERRIDE_BOOLEAN),
+        @"d": VARS_OVERRIDE_STRING,
+        @"e": @{
+            @"f": @(VARS_OVERRIDE_LONG)
+        }
+    })]);
+    
+    NSDictionary *abe = [context dictionaryNamed:@"a.b.e"];
+    XCTAssertTrue([abe isEqualToDictionary:(@{
+        @"f": @(VARS_OVERRIDE_LONG)
+    })]);
+    
+    NSDictionary *abg = [context dictionaryNamed:@"a.b.g"];
+    XCTAssertNil(abg);
+}
+
+- (void)testValueOverrides {
+    XCTAssertEqual(VARS_OVERRIDE_BOOLEAN, [self.templateContext boolNamed:@"boolean"]);
+    XCTAssertEqual(VARS_OVERRIDE_STRING, [self.templateContext stringNamed:@"string"]);
+    XCTAssertEqual(VARS_OVERRIDE_CHAR, [self.templateContext charNamed:@"char"]);
+    XCTAssertEqual(VARS_OVERRIDE_LONG, [self.templateContext longNamed:@"long"]);
+    XCTAssertEqual(VARS_OVERRIDE_DOUBLE, [self.templateContext doubleNamed:@"double"]);
+    XCTAssertEqualObjects(@(VARS_DEFAULT_INT), [self.templateContext numberNamed:@"noOverrideInt"]);
+    XCTAssertFalse([self.templateContext boolNamed:@"overrideWithoutDefinitionBoolean"]);
+    XCTAssertNil([self.templateContext numberNamed:@"nonDefinedNumber"]);
+}
+
+- (void)testNotDefinedValues {
+    XCTAssertFalse([self.templateContext boolNamed:@"overrideWithoutDefinitionBoolean"]);
+    XCTAssertNil([self.templateContext stringNamed:@"notDefinedString"]);
+    XCTAssertNil([self.templateContext numberNamed:@"notDefinedNumber"]);
+    XCTAssertNil([self.templateContext dictionaryNamed:@"notDefinedMap"]);
+    XCTAssertEqual(0, [self.templateContext longNamed:@"notDefinedLong"]);
+    XCTAssertEqual(0, [self.templateContext charNamed:@"notDefinedChar"]);
+    XCTAssertEqual(0, [self.templateContext intNamed:@"notDefinedInt"]);
+    XCTAssertEqual(0, [self.templateContext doubleNamed:@"notDefinedDouble"]);
+    XCTAssertEqual(0, [self.templateContext floatNamed:@"notDefinedFloat"]);
+}
+
+- (void)testDictionaryArguments {
+    NSDictionary *notificationVars = self.templateNotificationJson[@"vars"];
+    
+    NSDictionary *map = [self.templateContext dictionaryNamed:@"map"];
+    XCTAssertEqualObjects(notificationVars[@"map.int"], map[@"int"]);
+    XCTAssertEqualObjects(notificationVars[@"map.float"], map[@"float"]);
+    XCTAssertEqualObjects(@25, map[@"noOverrideInt"]);
+    
+    NSDictionary *innerMap = map[@"innerMap"];
+    [self verifyInnerMap:notificationVars map:innerMap];
+    XCTAssertTrue([innerMap isEqualToDictionary:[self.templateContext dictionaryNamed:@"map.innerMap"]]);
+    
+    NSDictionary *innermostMap = innerMap[@"innermostMap"];
+    [self verifyInnermostMap:notificationVars map:innermostMap];
+    XCTAssertTrue([innermostMap isEqualToDictionary:[self.templateContext dictionaryNamed:@"map.innerMap.innermostMap"]]);
+}
+
+- (void)testActionsValueInDictionary {
+    NSDictionary *actionsMap = [self.templateContext dictionaryNamed:@"map.actions"];
+    XCTAssertEqualObjects(VARS_ACTION_FUNCTION_NAME, actionsMap[@"function"]);
+    XCTAssertEqualObjects(@"close", actionsMap[@"close"]);
+}
+
+- (void)verifyInnerMap:(NSDictionary *)vars map:(NSDictionary *)map {
+    XCTAssertEqualObjects(vars[@"map.innerMap.boolean"], map[@"boolean"]);
+    XCTAssertEqualObjects(vars[@"map.innerMap.string"], map[@"string"]);
+    XCTAssertEqualObjects(vars[@"map.innerMap.char"], map[@"char"]);
+    XCTAssertEqualObjects(vars[@"map.innerMap.int"], map[@"int"]);
+    XCTAssertEqualObjects(vars[@"map.innerMap.long"], map[@"long"]);
+    XCTAssertEqualObjects(vars[@"map.innerMap.double"], map[@"double"]);
+    XCTAssertEqualObjects(@15, map[@"noOverrideInt"]);
+}
+
+- (void)verifyInnermostMap:(NSDictionary *)vars map:(NSDictionary *)map {
+    XCTAssertEqualObjects(vars[@"map.innerMap.innermostMap.int"], map[@"int"]);
+    XCTAssertEqualObjects(vars[@"map.innerMap.innermostMap.string"], map[@"string"]);
+    XCTAssertEqualObjects(vars[@"map.innerMap.innermostMap.boolean"], map[@"boolean"]);
+    XCTAssertEqualObjects(@YES, map[@"noOverrideBoolean"]);
+}
+
+- (CTCustomTemplate *)simpleTemplate {
+    CTInAppTemplateBuilder *builder = [[CTInAppTemplateBuilder alloc] init];
+    [builder setName:TEMPLATE_NAME];
+    [builder addArgument:@"a.b.c" withBool:VARS_DEFAULT_BOOLEAN];
+    [builder addArgument:@"a.b.d" withString:VARS_DEFAULT_STRING];
+    [builder addArgument:@"a.b.e.f" withNumber:@(VARS_DEFAULT_LONG)];
+    [builder addArgument:@"g" withNumber:@(VARS_DEFAULT_DOUBLE)];
+    [builder addArgument:@"h" withBool:VARS_DEFAULT_BOOLEAN];
+    [builder addArgument:@"i" withString:VARS_DEFAULT_STRING];
+    [builder setPresenter:[CTTemplatePresenterMock new]];
+    return [builder build];
+}
+
+- (NSDictionary *)simpleTemplateNotificationJson {
+    return @{
+        @"templateName": TEMPLATE_NAME,
+        @"type": @"custom-code",
+        @"vars": @{
+            @"a.b.c": @(VARS_OVERRIDE_BOOLEAN),
+            @"a.b.d": VARS_OVERRIDE_STRING,
+            @"a.b.e.f": @(VARS_OVERRIDE_LONG),
+            @"g": @(VARS_OVERRIDE_DOUBLE),
+            @"h": @YES
+        }
+    };
+}
+
+- (CTTemplateContext *)templateContext {
+    CTInAppNotification *notification = [[CTInAppNotification alloc] initWithJSON:self.templateNotificationJson];
+    return [[CTTemplateContext alloc] initWithTemplate:self.template andNotification:notification];
+}
+
+- (CTCustomTemplate *)template {
+    CTInAppTemplateBuilder *templateBuilder = [[CTInAppTemplateBuilder alloc] init];
+    [templateBuilder setName:TEMPLATE_NAME_NESTED];
+    [templateBuilder addArgument:@"boolean" withBool:NO];
+    [templateBuilder addArgument:@"char" withNumber:[NSNumber numberWithChar:VARS_DEFAULT_CHAR]];
+    [templateBuilder addArgument:@"string" withString:VARS_DEFAULT_STRING];
+    [templateBuilder addArgument:@"long" withNumber:[NSNumber numberWithLong:VARS_DEFAULT_LONG]];
+    [templateBuilder addArgument:@"double" withNumber:@(VARS_DEFAULT_DOUBLE)];
+    [templateBuilder addArgument:@"map.int" withNumber:@(VARS_DEFAULT_INT)];
+    [templateBuilder addArgument:@"noOverrideInt" withNumber:@(VARS_DEFAULT_INT)];
+    [templateBuilder addArgument:@"map.noOverrideInt" withNumber:@25];
+    [templateBuilder addArgument:@"map" withDictionary:@{
+        @"float": @15.6f,
+        @"innerMap": @{
+            @"boolean": @NO,
+            @"string": @"Default",
+            @"noOverrideInt": @15
+        }
+    }];
+    [templateBuilder addArgument:@"map.innerMap" withDictionary:@{
+        @"char": @10,
+        @"int": @1100,
+        @"long": @21474836472,
+        @"innermostMap": @{
+            @"int": @1200,
+            @"string": @"Default",
+            @"boolean": @NO,
+            @"noOverrideBoolean": @YES
+        }
+    }];
+    [templateBuilder addArgument:@"map.innerMap.double" withNumber:@12.12];
+    [templateBuilder addActionArgument:@"map.actions.function"];
+    [templateBuilder addActionArgument:@"map.actions.close"];
+    [templateBuilder addActionArgument:@"map.actions.openUrl"];
+    [templateBuilder setPresenter:[CTTemplatePresenterMock new]];
+    return [templateBuilder build];
+}
+
+- (NSDictionary *)templateNotificationJson {
+    return @{
+        @"templateName": TEMPLATE_NAME_NESTED,
+        @"type": @"custom-code",
+        @"vars": @{
+            @"boolean": @(VARS_OVERRIDE_BOOLEAN),
+            @"string": VARS_OVERRIDE_STRING,
+            @"char": @(VARS_OVERRIDE_CHAR),
+            @"long": @(VARS_OVERRIDE_LONG),
+            @"double": @(VARS_OVERRIDE_DOUBLE),
+            @"overrideWithoutDefinitionBoolean": @YES,
+            @"map.actions.close": @{
+                @"actions": @{
+                    @"type": @"close"
+                }
+            },
+            @"map.actions.function": @{
+                @"actions": @{
+                    @"templateName": VARS_ACTION_FUNCTION_NAME,
+                    @"type": @"custom-code",
+                    @"vars": @{
+                        @"boolean": @(VARS_ACTION_OVERRIDE_BOOLEAN),
+                        @"string": VARS_ACTION_OVERRIDE_STRING,
+                        @"int": @(VARS_ACTION_OVERRIDE_INT)
+                    }
+                }
+            },
+            @"map.actions.openUrl": @{
+                @"actions": @{
+                    @"type": @"url",
+                    @"ios": VARS_ACTION_OPEN_URL_ADDRESS
+                }
+            },
+            @"map.int": @123,
+            @"map.float": @15.6f,
+            @"map.innerMap.boolean": @YES,
+            @"map.innerMap.string": @"String",
+            @"map.innerMap.char": @1,
+            @"map.innerMap.int": @1345,
+            @"map.innerMap.long": @21474836470,
+            @"map.innerMap.double": @3402823466385288.0,
+            @"map.innerMap.innermostMap.int": @1024,
+            @"map.innerMap.innermostMap.string": @"innerText",
+            @"map.innerMap.innermostMap.boolean": @YES
+        }
+    };
+}
+
+static NSString * const TEMPLATE_NAME = @"Template";
+static NSString * const TEMPLATE_NAME_NESTED = @"TemplateNestedArgs";
+static NSString * const FUNCTION_NAME_TOP_LEVEL = @"FunctionTopLevel";
+
+static BOOL const VARS_OVERRIDE_BOOLEAN = YES;
+static NSString * const VARS_OVERRIDE_STRING = @"Text";
+static char const VARS_OVERRIDE_CHAR = 10;
+static long long const VARS_OVERRIDE_LONG = 21474836475;
+static double const VARS_OVERRIDE_DOUBLE = 3402823466385285.0;
+
+static BOOL const VARS_DEFAULT_BOOLEAN = NO;
+static NSString * const VARS_DEFAULT_STRING = @"Default";
+static char const VARS_DEFAULT_CHAR = 1;
+static long long const VARS_DEFAULT_LONG = 5435050l;
+static double const VARS_DEFAULT_DOUBLE = 12.345678;
+static int const VARS_DEFAULT_INT = 35;
+
+static NSString * const VARS_ACTION_FUNCTION_NAME = @"function";
+static BOOL const VARS_ACTION_OVERRIDE_BOOLEAN = YES;
+static NSString * const VARS_ACTION_OVERRIDE_STRING = @"Function text";
+static int const VARS_ACTION_OVERRIDE_INT = 5421;
+
+static NSString * const VARS_ACTION_OPEN_URL_ADDRESS = @"https://clevertap.com";
+
+@end

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTTemplatePresenterMock.h
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTTemplatePresenterMock.h
@@ -13,6 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CTTemplatePresenterMock : NSObject<CTTemplatePresenter>
 
+@property (nonatomic) int onPresentInvocationsCount;
+@property (nonatomic) CTTemplateContext *onPresentContext;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTTemplatePresenterMock.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTTemplatePresenterMock.m
@@ -14,6 +14,8 @@
 }
 
 - (void)onPresent:(CTTemplateContext *)context {
+    self.onPresentInvocationsCount++;
+    self.onPresentContext = context;
 }
 
 @end


### PR DESCRIPTION
### Overview
Present custom in-app templates. 
Call the presenter onPresent with the TemplateContext. 
Dismiss the notification from the in-app queue when context dismissed is called.

### Implementation
- `CTTemplateContext` merging and getting of argument values.
- Move `CTInAppNotificationDisplayDelegate` to a separate file.
- Modify the `CTInAppDisplayManager` to use a static `CTInAppNotification currentlyDisplayingNotification` instead of the display controller to check if a notification is currently being displayed. 
- `checkPendingNotifications` uses `NSNotificationCenter` to post a notification when a pending notification `CTInAppNotification` needs to be displayed. This way the in-app notification can be displayed by the correct `CTInAppDisplayManager` instance in case of multi instances.