### PR TITLE
[MC-1472] In-app actions js interface (Custom Templates Part 7)

### DIFF
--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -142,6 +142,7 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_PROP_WZRK_ID @"wzrk_id"
 #define CLTAP_PROP_VARIANT @"Variant"
 #define CLTAP_PROP_WZRK_PIVOT @"wzrk_pivot"
+#define CLTAP_PROP_WZRK_CTA @"wzrk_c2a"
 
 #define CLTAP_INAPP_ID @"ti"
 #define CLTAP_INAPP_TTL @"wzrk_ttl"

--- a/CleverTapSDK/CTInAppDisplayViewController.h
+++ b/CleverTapSDK/CTInAppDisplayViewController.h
@@ -12,12 +12,11 @@
 
 - (instancetype)init __unavailable;
 - (instancetype)initWithNotification:(CTInAppNotification*)notification;
-#if !(TARGET_OS_TV)
-- (instancetype)initWithNotification:(CTInAppNotification*)notification jsInterface:(CleverTapJSInterface *)jsInterface;
-#endif
 
 - (void)show:(BOOL)animated;
 - (void)hide:(BOOL)animated;
 - (BOOL)deviceOrientationIsLandscape;
+
+- (void)triggerInAppAction:(CTNotificationAction *)action callToAction:(NSString *)callToAction buttonId:(NSString *)buttonId;
 
 @end

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -47,13 +47,6 @@
     return self;
 }
 
-#if !(TARGET_OS_TV)
-- (instancetype)initWithNotification:(CTInAppNotification *)notification jsInterface:(CleverTapJSInterface *)jsInterface {
-    self = [self initWithNotification:notification];
-    return self;
-}
-#endif
-
 // Notification will not be posted if the scene became active before registering the observer.
 // However, this means that there is already an active scene when the controller is initialized.
 // In this case, we do not need the notification, since showFromWindow will directly find the window from the already active scene and not wait for it.
@@ -260,8 +253,28 @@ API_AVAILABLE(ios(13.0)) {
     }
     
     if (self.delegate && [self.delegate respondsToSelector:@selector(handleNotificationAction:forNotification:withExtras:)]) {
-        [self.delegate handleNotificationAction:button.action forNotification:self.notification withExtras:@{CLTAP_NOTIFICATION_ID_TAG:campaignId, @"wzrk_c2a": buttonText}];
+        [self.delegate handleNotificationAction:button.action forNotification:self.notification withExtras:@{CLTAP_NOTIFICATION_ID_TAG:campaignId, CLTAP_PROP_WZRK_CTA: buttonText}];
     }
+}
+
+- (void)triggerInAppAction:(CTNotificationAction *)action callToAction:(NSString *)callToAction buttonId:(NSString *)buttonId {
+    NSMutableDictionary *extras = [NSMutableDictionary new];
+    if (callToAction) {
+        extras[CLTAP_PROP_WZRK_CTA] = callToAction;
+    }
+    if (buttonId) {
+        extras[@"button_id"] = buttonId;
+    }
+    NSString *campaignId = self.notification.campaignId;
+    if (campaignId == nil) {
+        campaignId = @"";
+    }
+    extras[CLTAP_NOTIFICATION_ID_TAG] = campaignId;
+    if (self.delegate &&
+        [self.delegate respondsToSelector:@selector(handleNotificationAction:forNotification:withExtras:)]) {
+        [self.delegate handleNotificationAction:action forNotification:self.notification withExtras:extras];
+    }
+    [self hide:YES];
 }
 
 - (void)handleImageTapGesture {
@@ -273,7 +286,7 @@ API_AVAILABLE(ios(13.0)) {
     }
     
     if (self.delegate && [self.delegate respondsToSelector:@selector(handleNotificationAction:forNotification:withExtras:)]) {
-        [self.delegate handleNotificationAction:button.action forNotification:self.notification withExtras:@{CLTAP_NOTIFICATION_ID_TAG:campaignId, @"wzrk_c2a": buttonText}];
+        [self.delegate handleNotificationAction:button.action forNotification:self.notification withExtras:@{CLTAP_NOTIFICATION_ID_TAG:campaignId, CLTAP_PROP_WZRK_CTA: buttonText}];
     }
 }
 

--- a/CleverTapSDK/CleverTapJSInterface.h
+++ b/CleverTapSDK/CleverTapJSInterface.h
@@ -1,17 +1,15 @@
 #import <Foundation/Foundation.h>
 #if !(TARGET_OS_TV)
 #import <WebKit/WebKit.h>
-@class CleverTapInstanceConfig;
 
+@class CleverTapInstanceConfig;
+@class CTInAppDisplayViewController;
 /*!
- 
  @abstract
  The `CleverTapJSInterface` class is a bridge to communicate between Webviews and CleverTap SDK. Calls to forward record events or set user properties fired within a Webview to CleverTap SDK.
  */
 
 @interface CleverTapJSInterface : NSObject <WKScriptMessageHandler>
-
-@property (nonatomic, strong) WKUserContentController *userContentController;
 
 - (instancetype)initWithConfig:(CleverTapInstanceConfig *)config;
 

--- a/CleverTapSDK/CleverTapJSInterfacePrivate.h
+++ b/CleverTapSDK/CleverTapJSInterfacePrivate.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 
 @interface CleverTapJSInterface () {}
-- (instancetype)initWithConfigForInApps:(CleverTapInstanceConfig *)config;
+- (instancetype)initWithConfigForInApps:(CleverTapInstanceConfig *)config fromController:(CTInAppDisplayViewController *)controller;
 
 // SET ONLY WHEN THE USER INITIALISES A WEBVIEW WITH CT JS INTERFACE
 @property (nonatomic, assign) BOOL wv_init;

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -53,8 +53,6 @@ static CTInAppDisplayViewController *currentDisplayController;
 static CTInAppNotification *currentlyDisplayingNotification;
 static NSMutableArray<NSArray *> *pendingNotifications;
 
-static BOOL once = YES;
-
 // private class
 @interface ImageLoadingResult : NSObject
 
@@ -427,12 +425,9 @@ static BOOL once = YES;
 
     CTInAppDisplayViewController *controller;
     NSString *errorString = nil;
-    CleverTapJSInterface *jsInterface = nil;
-
     switch (notification.inAppType) {
         case CTInAppTypeHTML:
-            jsInterface = [[CleverTapJSInterface alloc] initWithConfigForInApps:self.config];
-            controller = [[CTInAppHTMLViewController alloc] initWithNotification:notification jsInterface:jsInterface];
+            controller = [[CTInAppHTMLViewController alloc] initWithNotification:notification config:self.config];
             break;
         case CTInAppTypeInterstitial:
             controller = [[CTInterstitialViewController alloc] initWithNotification:notification];

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.h
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.h
@@ -2,4 +2,6 @@
 
 @interface CTInAppHTMLViewController : CTInAppDisplayViewController
 
+- (instancetype)initWithNotification:(CTInAppNotification *)notification config:(CleverTapInstanceConfig *)config;
+
 @end

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -1,7 +1,7 @@
 #import <WebKit/WebKit.h>
 #import "CTInAppHTMLViewController.h"
 #import "CTInAppDisplayViewControllerPrivate.h"
-#import "CleverTapJSInterface.h"
+#import "CleverTapJSInterfacePrivate.h"
 #import "CTUIUtils.h"
 #import "CTDismissButton.h"
 #import "CTUriHelper.h"
@@ -44,10 +44,10 @@ typedef enum {
 
 @implementation CTInAppHTMLViewController
 
-- (instancetype)initWithNotification:(CTInAppNotification *)notification jsInterface:(CleverTapJSInterface *)jsInterface {
+- (instancetype)initWithNotification:(CTInAppNotification *)notification config:(CleverTapInstanceConfig *)config {
     self = [super initWithNotification:notification];
-    _jsInterface = jsInterface;
     if (self) {
+        _jsInterface = [[CleverTapJSInterface alloc] initWithConfigForInApps:config fromController:self];
         self.shouldPassThroughTouches = (self.notification.position == CLTAP_INAPP_POSITION_TOP || self.notification.position == CLTAP_INAPP_POSITION_BOTTOM);
     }
     return self;
@@ -244,13 +244,13 @@ typedef enum {
             params[elts[0]] = [elts[1] stringByRemovingPercentEncoding];
         };
         mutableParams = [params mutableCopy];
-        NSString *c2a = params[@"wzrk_c2a"];
+        NSString *c2a = params[CLTAP_PROP_WZRK_CTA];
         if (c2a) {
             c2a = [c2a stringByRemovingPercentEncoding];
             NSArray *parts = [c2a componentsSeparatedByString:@"__dl__"];
             if (parts && [parts count] == 2) {
                 dl = [NSURL URLWithString:parts[1]];
-                mutableParams[@"wzrk_c2a"] = parts[0];
+                mutableParams[CLTAP_PROP_WZRK_CTA] = parts[0];
             }
         }
     }
@@ -260,7 +260,6 @@ typedef enum {
     }
     [self hide:YES];
     decisionHandler(WKNavigationActionPolicyCancel);
-    
 }
 
 - (BOOL)isInlineMedia:(NSURL *)url {

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -521,6 +521,7 @@ typedef enum {
 
 - (void)hideFromWindow:(BOOL)animated {
     void (^completionBlock)(void) = ^ {
+        [self->webView.configuration.userContentController removeScriptMessageHandlerForName:@"clevertap"];
         [self.window removeFromSuperview];
         self.window = nil;
         if (self.delegate && [self.delegate respondsToSelector:@selector(notificationDidDismiss:fromViewController:)]) {

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
@@ -173,7 +173,7 @@
         CTNotificationAction *notificationAction = action;
         NSString *campaignId = self.notification.campaignId ? self.notification.campaignId : @"";
         NSString *cta = notificationAction.customTemplateInAppData.templateName ? notificationAction.customTemplateInAppData.templateName : name;
-        NSDictionary *extras = @{CLTAP_NOTIFICATION_ID_TAG:campaignId, @"wzrk_c2a": cta};
+        NSDictionary *extras = @{CLTAP_NOTIFICATION_ID_TAG:campaignId, CLTAP_PROP_WZRK_CTA: cta};
         [self.notificationDelegate handleNotificationAction:notificationAction forNotification:self.notification withExtras:extras];
     }
 }

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTTemplateContextTest.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTTemplateContextTest.m
@@ -15,6 +15,7 @@
 #import "CTTemplateContext-Internal.h"
 #import "CTCustomTemplateInAppData-Internal.h"
 #import "CTInAppNotificationDisplayDelegateMock.h"
+#import "CTConstants.h"
 
 @interface CTTemplateContext (Tests)
 
@@ -77,7 +78,7 @@
     CTInAppNotificationDisplayDelegateMock *delegate = [[CTInAppNotificationDisplayDelegateMock alloc] init];
     [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
         XCTAssertEqual(action.type, CTInAppActionTypeClose);
-        XCTAssertEqualObjects(extras[@"wzrk_c2a"], @"map.actions.close");
+        XCTAssertEqualObjects(extras[CLTAP_PROP_WZRK_CTA], @"map.actions.close");
     }];
     [context setNotificationDelegate:delegate];
     [context triggerActionNamed:@"map.actions.close"];
@@ -88,7 +89,7 @@
     [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
         XCTAssertEqual(action.type, CTInAppActionTypeCustom);
         XCTAssertEqualObjects(action.customTemplateInAppData.templateName, VARS_ACTION_FUNCTION_NAME);
-        XCTAssertEqualObjects(extras[@"wzrk_c2a"], VARS_ACTION_FUNCTION_NAME);
+        XCTAssertEqualObjects(extras[CLTAP_PROP_WZRK_CTA], VARS_ACTION_FUNCTION_NAME);
     }];
     [context setNotificationDelegate:delegate];
     [context triggerActionNamed:@"map.actions.function"];
@@ -99,7 +100,7 @@
     [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
         XCTAssertEqual(action.type, CTInAppActionTypeOpenURL);
         XCTAssertEqualObjects(action.actionURL, [[NSURL alloc] initWithString:VARS_ACTION_OPEN_URL_ADDRESS]);
-        XCTAssertEqualObjects(extras[@"wzrk_c2a"], @"map.actions.openUrl");
+        XCTAssertEqualObjects(extras[CLTAP_PROP_WZRK_CTA], @"map.actions.openUrl");
     }];
     [context setNotificationDelegate:delegate];
     [context triggerActionNamed:@"map.actions.openUrl"];
@@ -112,7 +113,7 @@
         XCTAssertEqualObjects(action.keyValues, @{
             @"key1": @"value1"
         });
-        XCTAssertEqualObjects(extras[@"wzrk_c2a"], @"map.actions.kv");
+        XCTAssertEqualObjects(extras[CLTAP_PROP_WZRK_CTA], @"map.actions.kv");
     }];
     [context setNotificationDelegate:delegate];
     [context triggerActionNamed:@"map.actions.kv"];


### PR DESCRIPTION
### Overview
Support triggering actions from HTML in-app notifications.

### Implementation
Modify the `CleverTapJSInterface` to support `triggerInAppAction` message. The interface needs to be initialized with config and `CTInAppDisplayViewController` controller.
The interface is now initialized from inside the controller (in this case `CTInAppHTMLViewController` which extends `CTInAppDisplayViewController`) and holds a weak reference to that controller. The action can be triggered using the controller, call the delegate, and hide the notification. This is similar to how the button clicks are handled in `buttonTapped:` and `handleButtonClickFromIndex:`.

Commits 
cb41a661b37579056e0878d8803133355cb71102 
970c9bb5b19710e39bd39b58424c76433ffb6eb9