### PR TITLE
[MC-1739] PE File Variables

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -165,15 +165,13 @@
 		4808030E292EB4FB00C06E2F /* CleverTap+PushPermission.h in Headers */ = {isa = PBXBuildFile; fileRef = 4808030D292EB4FB00C06E2F /* CleverTap+PushPermission.h */; };
 		48080311292EB50D00C06E2F /* CTLocalInApp.h in Headers */ = {isa = PBXBuildFile; fileRef = 4808030F292EB50D00C06E2F /* CTLocalInApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48080312292EB50D00C06E2F /* CTLocalInApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 48080310292EB50D00C06E2F /* CTLocalInApp.m */; };
-		487854032BF4B79F00565685 /* CTFileDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 487854022BF4B79F00565685 /* CTFileDownloader.h */; };
-		487854052BF4B7D800565685 /* CTFileDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 487854042BF4B7D800565685 /* CTFileDownloader.m */; };
 		487854072BF4BC4E00565685 /* CTFileDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 487854062BF4BC4E00565685 /* CTFileDownloaderTests.m */; };
-		489A731A2BC51795008D4850 /* CTFileDownloadManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 489A73192BC51795008D4850 /* CTFileDownloadManager.h */; };
-		489A731C2BC517B4008D4850 /* CTFileDownloadManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 489A731B2BC517B4008D4850 /* CTFileDownloadManager.m */; };
 		48A2C4B92BD67DDC006C61BC /* sampleTXTStub.txt in Resources */ = {isa = PBXBuildFile; fileRef = 48A2C4B72BD67DDB006C61BC /* sampleTXTStub.txt */; };
 		48A2C4BA2BD67DDC006C61BC /* samplePDFStub.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 48A2C4B82BD67DDB006C61BC /* samplePDFStub.pdf */; };
 		48C0FD6F2BCD522100E01EA9 /* CTFileDownloadManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 48C0FD6E2BCD522100E01EA9 /* CTFileDownloadManagerTests.m */; };
 		48F9FD092C208F7100617770 /* CTInAppStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A4427D72ABCE5EB0098866F /* CTInAppStore.m */; };
+		48F9FD1D2C3D30BF00617770 /* CTFileDownloadManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 48F9FD182C3D30B600617770 /* CTFileDownloadManager.m */; };
+		48F9FD1E2C3D30BF00617770 /* CTFileDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 48F9FD192C3D30B600617770 /* CTFileDownloader.m */; };
 		4987C665251B5E79003E6BE8 /* CTImageInAppViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4987C663251B5E79003E6BE8 /* CTImageInAppViewController.h */; };
 		4987C666251B5E79003E6BE8 /* CTImageInAppViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4987C664251B5E79003E6BE8 /* CTImageInAppViewController.m */; };
 		4987C668251B5F9E003E6BE8 /* CTImageInAppViewControllerPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4987C667251B5F9E003E6BE8 /* CTImageInAppViewControllerPrivate.h */; };
@@ -719,14 +717,14 @@
 		4808030D292EB4FB00C06E2F /* CleverTap+PushPermission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CleverTap+PushPermission.h"; sourceTree = "<group>"; };
 		4808030F292EB50D00C06E2F /* CTLocalInApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTLocalInApp.h; sourceTree = "<group>"; };
 		48080310292EB50D00C06E2F /* CTLocalInApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTLocalInApp.m; sourceTree = "<group>"; };
-		487854022BF4B79F00565685 /* CTFileDownloader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTFileDownloader.h; sourceTree = "<group>"; };
-		487854042BF4B7D800565685 /* CTFileDownloader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloader.m; sourceTree = "<group>"; };
 		487854062BF4BC4E00565685 /* CTFileDownloaderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloaderTests.m; sourceTree = "<group>"; };
-		489A73192BC51795008D4850 /* CTFileDownloadManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTFileDownloadManager.h; sourceTree = "<group>"; };
-		489A731B2BC517B4008D4850 /* CTFileDownloadManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloadManager.m; sourceTree = "<group>"; };
 		48A2C4B72BD67DDB006C61BC /* sampleTXTStub.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sampleTXTStub.txt; sourceTree = "<group>"; };
 		48A2C4B82BD67DDB006C61BC /* samplePDFStub.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = samplePDFStub.pdf; sourceTree = "<group>"; };
 		48C0FD6E2BCD522100E01EA9 /* CTFileDownloadManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloadManagerTests.m; sourceTree = "<group>"; };
+		48F9FD172C3D30B600617770 /* CTFileDownloadManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTFileDownloadManager.h; sourceTree = "<group>"; };
+		48F9FD182C3D30B600617770 /* CTFileDownloadManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloadManager.m; sourceTree = "<group>"; };
+		48F9FD192C3D30B600617770 /* CTFileDownloader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloader.m; sourceTree = "<group>"; };
+		48F9FD1A2C3D30B600617770 /* CTFileDownloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTFileDownloader.h; sourceTree = "<group>"; };
 		4987C663251B5E79003E6BE8 /* CTImageInAppViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTImageInAppViewController.h; sourceTree = "<group>"; };
 		4987C664251B5E79003E6BE8 /* CTImageInAppViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTImageInAppViewController.m; sourceTree = "<group>"; };
 		4987C667251B5F9E003E6BE8 /* CTImageInAppViewControllerPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTImageInAppViewControllerPrivate.h; sourceTree = "<group>"; };
@@ -1404,10 +1402,10 @@
 		6B9E95B62C2AE6740002D557 /* FileDownload */ = {
 			isa = PBXGroup;
 			children = (
-				489A73192BC51795008D4850 /* CTFileDownloadManager.h */,
-				489A731B2BC517B4008D4850 /* CTFileDownloadManager.m */,
-				487854022BF4B79F00565685 /* CTFileDownloader.h */,
-				487854042BF4B7D800565685 /* CTFileDownloader.m */,
+				48F9FD1A2C3D30B600617770 /* CTFileDownloader.h */,
+				48F9FD192C3D30B600617770 /* CTFileDownloader.m */,
+				48F9FD172C3D30B600617770 /* CTFileDownloadManager.h */,
+				48F9FD182C3D30B600617770 /* CTFileDownloadManager.m */,
 			);
 			path = FileDownload;
 			sourceTree = "<group>";
@@ -1800,7 +1798,6 @@
 				07053B7221E653E70085B44A /* UIView+CTToast.h in Headers */,
 				6A3EBD362AA0705900CE97D4 /* CTLimitAdapter.h in Headers */,
 				4987C665251B5E79003E6BE8 /* CTImageInAppViewController.h in Headers */,
-				487854032BF4B79F00565685 /* CTFileDownloader.h in Headers */,
 				D014B8E220E2F9F9001E0780 /* CleverTapInstanceConfigPrivate.h in Headers */,
 				071EB4CF217F6427008F0FAB /* CTBaseHeaderFooterViewControllerPrivate.h in Headers */,
 				D0BD759D241760C60006EE55 /* CTProductConfigController.h in Headers */,
@@ -1830,7 +1827,6 @@
 				071EB4EE217F6427008F0FAB /* CTAlertViewController.h in Headers */,
 				4E838C4629A0C94B00ED0875 /* CleverTap+CTVar.h in Headers */,
 				D0CACF9620B8A4F800A02327 /* CTPinnedNSURLSessionDelegate.h in Headers */,
-				489A731A2BC51795008D4850 /* CTFileDownloadManager.h in Headers */,
 				4E41FD92294F46510001FBED /* CTVar-Internal.h in Headers */,
 				071EB4FE217F6427008F0FAB /* CTDismissButton.h in Headers */,
 				071EB511217F6427008F0FAB /* CTUIUtils.h in Headers */,
@@ -2394,7 +2390,7 @@
 				D01651AF2097B38400660178 /* CTEventBuilder.m in Sources */,
 				D020C929209006AD0073F61E /* CTUriHelper.m in Sources */,
 				07B9454C219EA34300D4C542 /* CTMessageMO.m in Sources */,
-				487854052BF4B7D800565685 /* CTFileDownloader.m in Sources */,
+				48F9FD1E2C3D30BF00617770 /* CTFileDownloader.m in Sources */,
 				D0D4C9F32414EE6C0029477E /* CleverTapFeatureFlags.m in Sources */,
 				4E5A02DE2A4C5FD800DE242A /* LeanplumCT.m in Sources */,
 				6AA1357B2A2E467800EFF2C1 /* NSDictionary+Extensions.m in Sources */,
@@ -2420,7 +2416,6 @@
 				071EB513217F6427008F0FAB /* CTInAppNotification.m in Sources */,
 				D0CACF9720B8A4F800A02327 /* CTPinnedNSURLSessionDelegate.m in Sources */,
 				D0047B0F2098E2F00019C6FD /* CTProfileBuilder.m in Sources */,
-				489A731C2BC517B4008D4850 /* CTFileDownloadManager.m in Sources */,
 				D0A6626E20801E7F00B403F3 /* CTDeviceInfo.m in Sources */,
 				6BD334EC2AF2A41F0099E33E /* CTBatchSentDelegateHelper.m in Sources */,
 				0797133A21A309720011C9A3 /* CTCarouselImageView.m in Sources */,
@@ -2494,6 +2489,7 @@
 				0797133021A2F09A0011C9A3 /* CTSwipeView.m in Sources */,
 				4E8B81662AD2ADAE00714BB4 /* CTSwizzleManager.m in Sources */,
 				071EB4EF217F6427008F0FAB /* CTInterstitialViewController.m in Sources */,
+				48F9FD1D2C3D30BF00617770 /* CTFileDownloadManager.m in Sources */,
 				D0CACF9920B8A78600A02327 /* CTConstants.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -254,7 +254,3 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_ENCRYPTION_LEVEL @"CleverTapEncryptionLevel"
 #define CLTAP_ENCRYPTION_IV @"__CL3>3Rt#P__1V_"
 #define CLTAP_ENCRYPTION_PII_DATA (@[@"Identity", @"userEmail", @"userPhone", @"userName"]);
-
-#define CLTAP_NO_PENDING_DOWNLOADS_NOTIFICATION @"CleverTapNoPendingDownloadsNotification"
-
-

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -101,6 +101,7 @@ extern NSString *CT_KIND_FLOAT;
 extern NSString *CT_KIND_STRING;
 extern NSString *CT_KIND_BOOLEAN;
 extern NSString *CT_KIND_DICTIONARY;
+extern NSString *CT_KIND_FILE;
 extern NSString *CLEVERTAP_DEFAULTS_VARIABLES_KEY;
 extern NSString *CLEVERTAP_DEFAULTS_VARS_JSON_KEY;
 
@@ -253,5 +254,7 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_ENCRYPTION_LEVEL @"CleverTapEncryptionLevel"
 #define CLTAP_ENCRYPTION_IV @"__CL3>3Rt#P__1V_"
 #define CLTAP_ENCRYPTION_PII_DATA (@[@"Identity", @"userEmail", @"userPhone", @"userName"]);
+
+#define CLTAP_NO_PENDING_DOWNLOADS_NOTIFICATION @"CleverTapNoPendingDownloadsNotification"
 
 

--- a/CleverTapSDK/CTConstants.m
+++ b/CleverTapSDK/CTConstants.m
@@ -12,6 +12,7 @@ NSString *CT_KIND_INT = @"integer";
 NSString *CT_KIND_FLOAT = @"float";
 NSString *CT_KIND_STRING = @"string";
 NSString *CT_KIND_BOOLEAN = @"bool";
+NSString *CT_KIND_FILE = @"file";
 NSString *CT_KIND_DICTIONARY = @"group";
 NSString *CLEVERTAP_DEFAULTS_VARIABLES_KEY = @"__clevertap_variables";
 NSString *CLEVERTAP_DEFAULTS_VARS_JSON_KEY = @"__clevertap_variables_json";

--- a/CleverTapSDK/CleverTap+CTVar.h
+++ b/CleverTapSDK/CleverTap+CTVar.h
@@ -52,6 +52,8 @@ NS_SWIFT_NAME(defineVar(name:unsignedLongLong:));
 NS_SWIFT_NAME(defineVar(name:UnsignedShort:));
 - (CTVar *)defineVar:(NSString *)name withDictionary:(nullable NSDictionary *)defaultValue
 NS_SWIFT_NAME(defineVar(name:dictionary:));
+- (CTVar *)defineFileVar:(NSString *)name
+NS_SWIFT_NAME(defineFileVar(name:));
 
 @end
 

--- a/CleverTapSDK/CleverTap.h
+++ b/CleverTapSDK/CleverTap.h
@@ -1417,6 +1417,26 @@ extern NSString * _Nonnull const CleverTapProfileDidInitializeNotification;
  */
 - (id _Nullable)getVariableValue:(NSString * _Nonnull)name;
 
+/*!
+ @method
+ 
+ @abstract
+ Adds a callback to be invoked when no more file downloads are pending (either when no files needed to be downloaded or all downloads have been completed).
+ 
+ @param block a callback to add.
+ */
+- (void)onVariablesChangedAndNoDownloadsPending:(CleverTapVariablesChangedBlock _Nonnull )block;
+
+/*!
+ @method
+ 
+ @abstract
+ Adds a callback to be invoked only once when no more file downloads are pending (either when no files needed to be downloaded or all downloads have been completed).
+ 
+ @param block a callback to add.
+ */
+- (void)onceVariablesChangedAndNoDownloadsPending:(CleverTapVariablesChangedBlock _Nonnull )block;
+
 @end
 
 #pragma clang diagnostic pop

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -498,7 +498,7 @@ static BOOL sharedInstanceErrorLogged;
         [self _initProductConfig];
         
         // Initialise Variables
-        self.variables = [[CTVariables alloc] initWithConfig:self.config deviceInfo:self.deviceInfo];
+        self.variables = [[CTVariables alloc] initWithConfig:self.config deviceInfo:self.deviceInfo fileDownloader:self.fileDownloader];
         
         [self notifyUserProfileInitialized];
     }
@@ -4370,6 +4370,14 @@ static BOOL sharedInstanceErrorLogged;
     return [[self.variables varCache] getMergedValue:name];
 }
 
+- (void)onVariablesChangedAndNoDownloadsPending:(CleverTapVariablesChangedBlock _Nonnull )block {
+    [[self variables] onVariablesChangedAndNoDownloadsPending:block];
+}
+
+- (void)onceVariablesChangedAndNoDownloadsPending:(CleverTapVariablesChangedBlock _Nonnull )block {
+    [[self variables] onceVariablesChangedAndNoDownloadsPending:block];
+}
+
 #pragma mark - PE Vars
 
 - (CTVar *)defineVar:(NSString *)name {
@@ -4479,6 +4487,10 @@ static BOOL sharedInstanceErrorLogged;
 
 - (CTVar *)defineVar:(NSString *)name withDictionary:(NSDictionary *)defaultValue {
     return [self.variables define:name with:defaultValue kind:CT_KIND_DICTIONARY];
+}
+
+- (CTVar *)defineFileVar:(NSString *)name {
+    return [self.variables define:name with:nil kind:CT_KIND_FILE];
 }
 
 @end

--- a/CleverTapSDK/ProductExperiences/CTVar-Internal.h
+++ b/CleverTapSDK/ProductExperiences/CTVar-Internal.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, strong) NSMutableArray *valueChangedBlocks;
 @property (nonatomic, unsafe_unretained, nullable) id <CTVarDelegate> delegate;
 @property (readonly) BOOL hasChanged;
+@property (readonly, strong, nullable) NSString *fileURL;
 
 - (void)update;
 - (void)cacheComputedValues;

--- a/CleverTapSDK/ProductExperiences/CTVar-Internal.h
+++ b/CleverTapSDK/ProductExperiences/CTVar-Internal.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) BOOL shouldDownloadFile;
 @property (readonly, strong, nullable) NSString *fileURL;
 
-- (void)update;
+- (BOOL)update;
 - (void)cacheComputedValues;
 - (void)triggerValueChanged;
 - (void)triggerFileIsReady;

--- a/CleverTapSDK/ProductExperiences/CTVar-Internal.h
+++ b/CleverTapSDK/ProductExperiences/CTVar-Internal.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)update;
 - (void)cacheComputedValues;
 - (void)triggerValueChanged;
+- (void)triggerFileIsReady;
 
 + (BOOL)printedCallbackWarning;
 + (void)setPrintedCallbackWarning:(BOOL)newPrintedCallbackWarning;

--- a/CleverTapSDK/ProductExperiences/CTVar-Internal.h
+++ b/CleverTapSDK/ProductExperiences/CTVar-Internal.h
@@ -16,8 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) BOOL hadStarted;
 @property (readonly, strong) NSString *kind;
 @property (readonly, strong) NSMutableArray *valueChangedBlocks;
+@property (readonly, strong) NSMutableArray *fileReadyBlocks;
 @property (nonatomic, unsafe_unretained, nullable) id <CTVarDelegate> delegate;
 @property (readonly) BOOL hasChanged;
+@property (readonly) BOOL shouldDownloadFile;
 @property (readonly, strong, nullable) NSString *fileURL;
 
 - (void)update;

--- a/CleverTapSDK/ProductExperiences/CTVar.h
+++ b/CleverTapSDK/ProductExperiences/CTVar.h
@@ -17,6 +17,10 @@ NS_SWIFT_NAME(VarDelegate)
  * Called when the value of the variable changes.
  */
 - (void)valueDidChange:(CTVar *)variable;
+/**
+ * Called when the file is downloaded and ready.
+ */
+- (void)fileIsReady:(CTVar *)var;
 @end
 
 /**
@@ -30,6 +34,7 @@ NS_SWIFT_NAME(Var)
 @property (readonly, strong, nullable) NSNumber *numberValue;
 @property (readonly, strong, nullable) id value;
 @property (readonly, strong, nullable) id defaultValue;
+@property (readonly, strong, nullable) NSString *fileValue;
 
 /**
  * @{
@@ -102,6 +107,7 @@ NS_SWIFT_NAME(Var)
 - (NSUInteger)unsignedIntegerValue;
 - (unsigned long)unsignedLongValue;
 - (unsigned long long)unsignedLongLongValue;
+- (nullable NSString *)fileValue;
 /**@}*/
 @end
 

--- a/CleverTapSDK/ProductExperiences/CTVar.h
+++ b/CleverTapSDK/ProductExperiences/CTVar.h
@@ -73,6 +73,11 @@ NS_SWIFT_NAME(Var)
 - (void)onValueChanged:(CleverTapVariablesChangedBlock)block;
 
 /**
+ * Called when the value of the file variable is downloaded and ready.
+ */
+- (void)onFileIsReady:(CleverTapVariablesChangedBlock)block;
+
+/**
  * Sets the delegate of the variable in order to use
  * {@link CTVarDelegate::valueDidChange:}
  */

--- a/CleverTapSDK/ProductExperiences/CTVar.m
+++ b/CleverTapSDK/ProductExperiences/CTVar.m
@@ -90,18 +90,19 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
     }
 }
 
-- (void)update {
+- (BOOL)update {
     NSObject *oldValue = _value;
     _value = [self.varCache getMergedValueFromComponentArray:_nameComponents];
     
     if ([_value isEqual:oldValue] && _hadStarted) {
-        return;
+        return NO;
     }
     [self cacheComputedValues];
     
+    BOOL changed = NO;
     if (![_value isEqual:oldValue]) {
         _hasChanged = YES;
-        
+        changed = YES;
         // Update _fileURL with new value if it has changed.
         if ([_kind isEqualToString:CT_KIND_FILE]) {
             _fileURL = _value;
@@ -117,6 +118,7 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
         _hadStarted = YES;
         _shouldDownloadFile = NO;
     }
+    return changed;
 }
 
 #pragma mark Callbacks

--- a/CleverTapSDK/ProductExperiences/CTVar.m
+++ b/CleverTapSDK/ProductExperiences/CTVar.m
@@ -109,9 +109,7 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
     }
     
     if (_shouldDownloadFile) {
-        if ([_kind isEqualToString:CT_KIND_FILE]) {
-            [self.varCache fileVarUpdated:self];
-        }
+        [self.varCache fileVarUpdated:self];
     }
     
     if ([[self varCache] hasVarsRequestCompleted]) {
@@ -173,7 +171,7 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
 
 - (void)onFileIsReady:(CleverTapVariablesChangedBlock)block {
     if (!block) {
-        CleverTapLogStaticDebug(@"Nil block parameter provided while calling [CTVar onValueChanged].");
+        CleverTapLogStaticDebug(@"Nil block parameter provided while calling [CTVar onFileIsReady].");
         return;
     }
     

--- a/CleverTapSDK/ProductExperiences/CTVar.m
+++ b/CleverTapSDK/ProductExperiences/CTVar.m
@@ -93,6 +93,11 @@ static BOOL LPVAR_PRINTED_CALLBACK_WARNING = NO;
     
     if (![_value isEqual:oldValue]) {
         _hasChanged = YES;
+        
+        // Update _fileURL with new value if it has changed.
+        if ([_kind isEqualToString:CT_KIND_FILE]) {
+            _fileURL = _value;
+        }
     }
     
     if ([[self varCache] hasVarsRequestCompleted]) {

--- a/CleverTapSDK/ProductExperiences/CTVarCache.h
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.h
@@ -23,7 +23,7 @@ NS_SWIFT_NAME(VarCache)
                 fileDownloader:(CTFileDownloader *)fileDownloader;
 
 @property (nonatomic, strong, readonly) CleverTapInstanceConfig *config;
-@property (strong, nonatomic) NSMutableDictionary<NSString *, id> *vars;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, CTVar *> *vars;
 @property (assign, nonatomic) BOOL hasVarsRequestCompleted;
 @property (assign, nonatomic) BOOL hasPendingDownloads;
 @property (nonatomic, weak) id<CTFileVarDelegate> delegate;

--- a/CleverTapSDK/ProductExperiences/CTVarCache.h
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.h
@@ -42,6 +42,8 @@ NS_SWIFT_NAME(VarCache)
 
 - (nullable NSString *)fileDownloadPath:(NSString *)fileURL;
 - (BOOL)isFileAlreadyPresent:(NSString *)fileURL;
+- (void)fileVarUpdated:(CTVar *)fileVar;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/ProductExperiences/CTVarCache.h
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.h
@@ -2,6 +2,7 @@
 #import "CTVar-Internal.h"
 #import "CleverTapInstanceConfig.h"
 #import "CTDeviceInfo.h"
+#import "CTFileDownloader.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -12,11 +13,14 @@ NS_SWIFT_NAME(VarCache)
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithConfig:(CleverTapInstanceConfig *)config deviceInfo: (CTDeviceInfo*)deviceInfo;
+- (instancetype)initWithConfig:(CleverTapInstanceConfig *)config 
+                    deviceInfo:(CTDeviceInfo*)deviceInfo
+                fileDownloader:(CTFileDownloader *)fileDownloader;
 
 @property (nonatomic, strong, readonly) CleverTapInstanceConfig *config;
 @property (strong, nonatomic) NSMutableDictionary<NSString *, id> *vars;
 @property (assign, nonatomic) BOOL hasVarsRequestCompleted;
+@property (assign, nonatomic) BOOL hasPendingDownloads;
 
 - (nullable NSDictionary<NSString *, id> *)diffs;
 - (void)loadDiffs;
@@ -30,6 +34,7 @@ NS_SWIFT_NAME(VarCache)
 - (nullable id)getMergedValueFromComponentArray:(NSArray<NSString *> *) components;
 - (void)clearUserContent;
 
+- (nullable NSString *)fileDownloadPath:(NSString *)fileURL;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/ProductExperiences/CTVarCache.h
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.h
@@ -35,6 +35,7 @@ NS_SWIFT_NAME(VarCache)
 - (void)clearUserContent;
 
 - (nullable NSString *)fileDownloadPath:(NSString *)fileURL;
+- (BOOL)isFileAlreadyPresent:(NSString *)fileURL;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/ProductExperiences/CTVarCache.h
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.h
@@ -4,6 +4,11 @@
 #import "CTDeviceInfo.h"
 #import "CTFileDownloader.h"
 
+@protocol CTFileVarDelegate <NSObject>
+@required
+- (void)triggerNoDownloadsPending;
+@end
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^CacheUpdateBlock)(void);
@@ -21,6 +26,7 @@ NS_SWIFT_NAME(VarCache)
 @property (strong, nonatomic) NSMutableDictionary<NSString *, id> *vars;
 @property (assign, nonatomic) BOOL hasVarsRequestCompleted;
 @property (assign, nonatomic) BOOL hasPendingDownloads;
+@property (nonatomic, weak) id<CTFileVarDelegate> delegate;
 
 - (nullable NSDictionary<NSString *, id> *)diffs;
 - (void)loadDiffs;

--- a/CleverTapSDK/ProductExperiences/CTVarCache.m
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.m
@@ -358,7 +358,9 @@
         [fileVar triggerFileIsReady];
     } else {
         [self.fileDownloader downloadFiles:@[url] withCompletionBlock:^(NSDictionary<NSString *,NSNumber *> * _Nonnull status) {
-            [fileVar triggerFileIsReady];
+            if ([status[url] boolValue]) {
+                [fileVar triggerFileIsReady];
+            }
         }];
     }
 }

--- a/CleverTapSDK/ProductExperiences/CTVarCache.m
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.m
@@ -137,11 +137,6 @@
                 values:self.valuesFromClient];
     
     [self mergeVariable:var];
-    
-    // setHasPendingDownloads to YES if type is FILE.
-    if ([var.kind isEqualToString:CT_KIND_FILE]) {
-        [self setHasPendingDownloads:YES];
-    }
 }
 
 - (CTVar *)getVariable:(NSString *)name {
@@ -312,19 +307,23 @@
     return [self.fileDownloader fileDownloadPath:fileURL];
 }
 
+- (BOOL)isFileAlreadyPresent:(NSString *)fileURL {
+    return [self.fileDownloader isFileAlreadyPresent:fileURL];
+}
+
 - (NSMutableArray<NSString *> *)fileURLs {
     NSMutableArray<NSString *> *downloadURLs = [NSMutableArray new];
     for (id key in self.vars) {
         CTVar *var = self.vars[key];
-        if (var.kind == CT_KIND_FILE) {
+        if (var.kind == CT_KIND_FILE && var.fileURL) {
             // If file is already present, call fileIsReady
             // Else download the file and call fileIsReady when downloaded
-            if ([self.fileDownloader isFileAlreadyPresent:var.value]) {
+            if ([self.fileDownloader isFileAlreadyPresent:var.fileURL]) {
                 [var triggerFileIsReady];
             } else {
-                [downloadURLs addObject:var.value];
+                [downloadURLs addObject:var.fileURL];
                 @synchronized (self) {
-                    [self.fileVarsInDownload setObject:var forKey:var.value];
+                    [self.fileVarsInDownload setObject:var forKey:var.fileURL];
                 }
             }
         }

--- a/CleverTapSDK/ProductExperiences/CTVarCache.m
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.m
@@ -253,7 +253,7 @@
                 [self setHasPendingDownloads:YES];
                 [self startFileDownload:fileURLs];
             } else {
-                [[NSNotificationCenter defaultCenter] postNotificationName:CLTAP_NO_PENDING_DOWNLOADS_NOTIFICATION object:nil];
+                [self.delegate triggerNoDownloadsPending];
             }
         } else {
             CleverTapLogDebug(self.config.logLevel, @"%@: No variables received from the server", self);
@@ -296,7 +296,7 @@
         // Retry once if any url is not downloaded.
         if ([retryURLs count] == 0) {
             [self setHasPendingDownloads:NO];
-            [[NSNotificationCenter defaultCenter] postNotificationName:CLTAP_NO_PENDING_DOWNLOADS_NOTIFICATION object:nil];
+            [self.delegate triggerNoDownloadsPending];
         } else {
             [self retryFileDownload:retryURLs];
         }
@@ -336,15 +336,15 @@
     [self.fileDownloader downloadFiles:urls withCompletionBlock:^(NSDictionary<NSString *,id> * _Nullable status) {
         [self setHasPendingDownloads:NO];
         for (NSString *key in status.allKeys) {
-            if (status[key]) {
-                @synchronized (self) {
+            @synchronized (self) {
+                if (status[key]) {
                     [self.fileVarsInDownload[key] triggerFileIsReady];
-                    [self.fileVarsInDownload removeObjectForKey:key];
                 }
+                [self.fileVarsInDownload removeObjectForKey:key];
             }
         }
         
-        [[NSNotificationCenter defaultCenter] postNotificationName:CLTAP_NO_PENDING_DOWNLOADS_NOTIFICATION object:nil];
+        [self.delegate triggerNoDownloadsPending];
     }];
 }
 

--- a/CleverTapSDK/ProductExperiences/CTVariables.h
+++ b/CleverTapSDK/ProductExperiences/CTVariables.h
@@ -10,6 +10,7 @@
 #import "CTVarCache.h"
 #import "CleverTapInstanceConfig.h"
 #import "CTDeviceInfo.h"
+#import "CTFileDownloader.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property(strong, nonatomic) CTVarCache *varCache;
 @property(strong, nonatomic, nullable) CleverTapFetchVariablesBlock fetchVariablesBlock;
 
-- (instancetype)initWithConfig:(CleverTapInstanceConfig *)config deviceInfo: (CTDeviceInfo *)deviceInfo;
+- (instancetype)initWithConfig:(CleverTapInstanceConfig *)config 
+                    deviceInfo:(CTDeviceInfo *)deviceInfo
+                fileDownloader:(CTFileDownloader *)fileDownloader;
 
 - (CTVar * _Nullable)define:(NSString *)name
              with:(nullable NSObject *)defaultValue
@@ -30,6 +33,8 @@ NS_SWIFT_NAME(define(name:value:kind:));
 - (void)triggerFetchVariables:(BOOL)success;
 - (void)onVariablesChanged:(CleverTapVariablesChangedBlock _Nonnull)block;
 - (void)onceVariablesChanged:(CleverTapVariablesChangedBlock _Nonnull)block;
+- (void)onVariablesChangedAndNoDownloadsPending:(CleverTapVariablesChangedBlock _Nonnull)block;
+- (void)onceVariablesChangedAndNoDownloadsPending:(CleverTapVariablesChangedBlock _Nonnull)block;
 - (NSDictionary*)flatten:(NSDictionary*)map varName:(NSString*)varName;
 - (NSDictionary*)varsPayload;
 - (NSDictionary*)unflatten:(NSDictionary*)result;

--- a/CleverTapSDK/ProductExperiences/CTVariables.h
+++ b/CleverTapSDK/ProductExperiences/CTVariables.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CTVariables : NSObject
+@interface CTVariables : NSObject <CTFileVarDelegate>
 
 @property(strong, nonatomic) CTVarCache *varCache;
 @property(strong, nonatomic, nullable) CleverTapFetchVariablesBlock fetchVariablesBlock;

--- a/CleverTapSDK/ProductExperiences/CTVariables.m
+++ b/CleverTapSDK/ProductExperiences/CTVariables.m
@@ -29,16 +29,9 @@
                 fileDownloader:(CTFileDownloader *)fileDownloader {
     if ((self = [super init])) {
         self.varCache = [[CTVarCache alloc] initWithConfig:config deviceInfo:deviceInfo fileDownloader:fileDownloader];
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(triggerVariablesChangedAndNoDownloadsPending)
-                                                     name:CLTAP_NO_PENDING_DOWNLOADS_NOTIFICATION
-                                                   object:nil];
+        [self.varCache setDelegate:self];
     }
     return self;
-}
-
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 #pragma mark Define Var
@@ -324,6 +317,12 @@
     }];
     
     return unflattenVars;
+}
+
+#pragma mark CTFileVarDelegate
+
+- (void)triggerNoDownloadsPending { 
+    [self triggerVariablesChangedAndNoDownloadsPending];
 }
 
 @end

--- a/CleverTapSDKTests/FileDownload/CTFileDownloadTestHelper.h
+++ b/CleverTapSDKTests/FileDownload/CTFileDownloadTestHelper.h
@@ -7,6 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import "CTFileDownloader.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,7 +23,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)fileURL;
 - (NSURL *)generateFileURL;
 - (NSArray<NSURL *> *)generateFileURLs:(int)count;
+- (NSString *)generateFileURLString;
 - (NSArray<NSString *> *)generateFileURLStrings:(int)count;
+
+- (void)cleanUpFiles:(CTFileDownloader *)fileDownloader forTest:(XCTestCase *)testCase;
 
 @end
 

--- a/CleverTapSDKTests/FileDownload/CTFileDownloaderMock.h
+++ b/CleverTapSDKTests/FileDownload/CTFileDownloaderMock.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable) CTFilesDeleteCompletedBlock removeAllAssetsCompletion;
 
+@property (nonatomic) CTFilesDownloadCompletedBlock downloadCompletion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDKTests/FileDownload/CTFileDownloaderMock.m
+++ b/CleverTapSDKTests/FileDownload/CTFileDownloaderMock.m
@@ -52,4 +52,16 @@
     [super removeAllAssetsWithCompletion:completionBlock];
 }
 
+- (void)downloadFiles:(NSArray<NSString *> *)fileURLs withCompletionBlock:(void (^)(NSDictionary<NSString *,NSNumber *> * _Nonnull))completion {
+    CTFilesDownloadCompletedBlock completionBlock = ^(NSDictionary<NSString *,id> *status) {
+        if (completion) {
+            completion(status);
+        }
+        if (self.downloadCompletion) {
+            self.downloadCompletion(status);
+        }
+    };
+    [super downloadFiles:fileURLs withCompletionBlock:completionBlock];
+}
+
 @end

--- a/CleverTapSDKTests/ProductExperiences/CTVarCache+Tests.h
+++ b/CleverTapSDKTests/ProductExperiences/CTVarCache+Tests.h
@@ -11,10 +11,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CTVarCache (Tests)
+
 @property (strong, nonatomic) NSMutableDictionary<NSString *, id> *valuesFromClient;
+@property (strong, nonatomic) id merged;
+
 - (NSString*)dataArchiveFileName;
 - (id)traverse:(id)collection withKey:(id)key autoInsert:(BOOL)autoInsert;
 - (void)saveDiffs;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDKTests/ProductExperiences/CTVarCacheTest.m
+++ b/CleverTapSDKTests/ProductExperiences/CTVarCacheTest.m
@@ -601,13 +601,12 @@ CTVariables *variables;
     }];
     CTVar *var1 = [variables define:@"var1" with:nil kind:CT_KIND_FILE];
     [var1 onFileIsReady:^{
-        [expectation fulfill];
-        
         NSString *expValue1 = [self.fileDownloader fileDownloadPath:url];
         XCTAssertEqualObjects(url, var1.fileURL);
         XCTAssertEqualObjects(expValue1, var1.value);
         XCTAssertEqualObjects(expValue1, var1.stringValue);
         XCTAssertEqualObjects(expValue1, var1.fileValue);
+        [expectation fulfill];
     }];
     [variables.varCache fileVarUpdated:var1];
     [self waitForExpectations:@[expectation] timeout:2.0];

--- a/CleverTapSDKTests/ProductExperiences/CTVarCacheTest.m
+++ b/CleverTapSDKTests/ProductExperiences/CTVarCacheTest.m
@@ -15,6 +15,7 @@
 #import "CTVarCacheMock.h"
 #import "CTVariables+Tests.h"
 #import "CTConstants.h"
+#import "InAppHelper.h"
 
 @interface CTVarCacheTest : XCTestCase
 
@@ -25,10 +26,11 @@ CTVariables *variables;
 @implementation CTVarCacheTest
 
 - (void)setUp {
+    InAppHelper *helper = [InAppHelper new];
     CleverTapInstanceConfig *config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"id" accountToken:@"token" accountRegion:@"eu"];
     config.useCustomCleverTapId = YES;
     CTDeviceInfo *deviceInfo = [[CTDeviceInfo alloc] initWithConfig:config andCleverTapID:@"test"];
-    CTVarCacheMock *varCache = [[CTVarCacheMock alloc] initWithConfig:config deviceInfo:deviceInfo];
+    CTVarCacheMock *varCache = [[CTVarCacheMock alloc] initWithConfig:config deviceInfo:deviceInfo fileDownloader:helper.fileDownloader];
     variables = [[CTVariables alloc] initWithConfig:config deviceInfo:deviceInfo varCache:varCache];
 }
 

--- a/CleverTapSDKTests/ProductExperiences/CTVarTest.m
+++ b/CleverTapSDKTests/ProductExperiences/CTVarTest.m
@@ -13,6 +13,7 @@
 #import "CTVarCacheMock.h"
 #import "CTConstants.h"
 #import "CTVariables+Tests.h"
+#import "InAppHelper.h"
 
 @interface CTVarDelegateImpl : NSObject <CTVarDelegate>
 
@@ -40,10 +41,11 @@ typedef void(^Callback)(CTVar *);
 @implementation CTVarTest
 
 - (void)setUp {
+    InAppHelper *helper = [InAppHelper new];
     CleverTapInstanceConfig *config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"id" accountToken:@"token" accountRegion:@"eu"];
     config.useCustomCleverTapId = YES;
     CTDeviceInfo *deviceInfo = [[CTDeviceInfo alloc] initWithConfig:config andCleverTapID:@"test"];
-    CTVarCacheMock *varCache = [[CTVarCacheMock alloc] initWithConfig:config deviceInfo:deviceInfo];
+    CTVarCacheMock *varCache = [[CTVarCacheMock alloc] initWithConfig:config deviceInfo:deviceInfo fileDownloader:helper.fileDownloader];
     self.variables = [[CTVariables alloc] initWithConfig:config deviceInfo:deviceInfo varCache:varCache];
 }
 

--- a/CleverTapSDKTests/ProductExperiences/CTVarTest.m
+++ b/CleverTapSDKTests/ProductExperiences/CTVarTest.m
@@ -309,23 +309,23 @@ typedef void(^Callback)(CTVar *);
     
     XCTestExpectation *expect1 = [self expectationWithDescription:@"var1 onValueChanged"];
     [var1 onValueChanged:^{
-        [expect1 fulfill];
         XCTAssertEqualObjects(url, var1.fileURL);
+        [expect1 fulfill];
     }];
     
     XCTestExpectation *expect2 = [self expectationWithDescription:@"var2 onValueChanged"];
     [var2 onValueChanged:^{
-        [expect2 fulfill];
         XCTAssertNil(var2.value);
+        [expect2 fulfill];
     }];
     
     XCTestExpectation *expect3 = [self expectationWithDescription:@"var1 onFileIsReady"];
     [var1 onFileIsReady:^{
-        [expect3 fulfill];
         NSString *expValue1 = [self.fileDownloader fileDownloadPath:url];
         XCTAssertEqualObjects(expValue1, var1.value);
         XCTAssertEqualObjects(expValue1, var1.stringValue);
         XCTAssertEqualObjects(expValue1, var1.fileValue);
+        [expect3 fulfill];
     }];
     
     [var2 onFileIsReady:^{

--- a/CleverTapSDKTests/ProductExperiences/CTVariables+Tests.m
+++ b/CleverTapSDKTests/ProductExperiences/CTVariables+Tests.m
@@ -15,6 +15,7 @@
     self = [super init];
     if (self) {
         self.varCache = varCache;
+        [self.varCache setDelegate:self];
     }
     return self;
 }

--- a/CleverTapSDKTests/ProductExperiences/CTVariablesTest.m
+++ b/CleverTapSDKTests/ProductExperiences/CTVariablesTest.m
@@ -12,6 +12,7 @@
 #import "CTVarCacheMock.h"
 #import "CTVariables.h"
 #import "CTConstants.h"
+#import "InAppHelper.h"
 
 @interface CTVariablesTest : XCTestCase
 
@@ -22,9 +23,10 @@
 @implementation CTVariablesTest
 
 - (void)setUp {
+    InAppHelper *helper = [InAppHelper new];
     CleverTapInstanceConfig *config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"id" accountToken:@"token" accountRegion:@"eu"];
     CTDeviceInfo *deviceInfo = [[CTDeviceInfo alloc] initWithConfig:config andCleverTapID:@"test"];
-    CTVarCacheMock *varCache = [[CTVarCacheMock alloc] initWithConfig:config deviceInfo:deviceInfo];
+    CTVarCacheMock *varCache = [[CTVarCacheMock alloc] initWithConfig:config deviceInfo:deviceInfo fileDownloader:helper.fileDownloader];
     self.variables = [[CTVariables alloc] initWithConfig:config deviceInfo:deviceInfo varCache:varCache];
 }
 


### PR DESCRIPTION
- Added support for File in PE Variables
- Adds new CleverTap APIs `onVariablesChangedAndNoDownloadsPending` and `onceVariablesChangedAndNoDownloadsPending`.
- Adds new `fileIsReady` callback in CTVarDelegate when file is downloaded.
- Added unit tests for File type variables