### PR TITLE
File download changes

### DIFF
--- a/CleverTapSDK/FileDownload/CTFileDownloadManager.m
+++ b/CleverTapSDK/FileDownload/CTFileDownloadManager.m
@@ -62,8 +62,10 @@
                     _downloadInProgressHandlers[url] = [NSMutableArray array];
                 }
                 [_downloadInProgressHandlers[url] addObject:^(NSURL *completedURL, BOOL success) {
-                    [filesDownloadStatus setObject:[NSNumber numberWithBool:success] forKey:[completedURL absoluteString]];
-                    dispatch_group_leave(group);
+                    @synchronized (self) {
+                        [filesDownloadStatus setObject:[NSNumber numberWithBool:success] forKey:[completedURL absoluteString]];
+                        dispatch_group_leave(group);
+                    }
                 }];
                 continue;
             }

--- a/CleverTapSDK/FileDownload/CTFileDownloadManager.m
+++ b/CleverTapSDK/FileDownload/CTFileDownloadManager.m
@@ -158,6 +158,7 @@
     if (error) {
         CleverTapLogInternal(self.config.logLevel, @"%@ Failed to get contents of directory %@ - %@", self, path, error);
         completion(filesDeleteStatus);
+        return;
     }
     for (NSURL *file in files) {
         dispatch_group_enter(deleteGroup);

--- a/CleverTapSDK/FileDownload/CTFileDownloadManager.m
+++ b/CleverTapSDK/FileDownload/CTFileDownloadManager.m
@@ -106,7 +106,7 @@
 }
 
 - (BOOL)isFileAlreadyPresent:(NSURL *)url {
-    NSString* filePath = [self.documentsDirectory stringByAppendingPathComponent:[self hashedFileNameForURL:url]];
+    NSString* filePath = [self filePath:url];
     BOOL fileExists = [self.fileManager fileExistsAtPath:filePath];
     return fileExists;
 }
@@ -213,7 +213,7 @@
             }
         }
         
-        NSString *destinationPath = [self.documentsDirectory stringByAppendingPathComponent:[self hashedFileNameForURL:url]];
+        NSString *destinationPath = [self filePath:url];
         NSURL *destinationURL = [NSURL fileURLWithPath:destinationPath];
         NSError *fileError;
         // Check if the file exists at the destination
@@ -249,7 +249,7 @@
         return;
     }
 
-    NSString *filePath = [self.documentsDirectory stringByAppendingPathComponent:[self hashedFileNameForURL:url]];
+    NSString *filePath = [self filePath:url];
     NSError *error;
     BOOL success = [self.fileManager removeItemAtPath:filePath error:&error];
     if (!success) {

--- a/CleverTapSDK/FileDownload/CTFileDownloader.m
+++ b/CleverTapSDK/FileDownload/CTFileDownloader.m
@@ -65,14 +65,13 @@
 }
 
 - (nullable NSString *)fileDownloadPath:(NSString *)url {
-    NSString *filePath = nil;
     if ([self isFileAlreadyPresent:url]) {
         NSURL *fileURL = [NSURL URLWithString:url];
         return [self.fileDownloadManager filePath:fileURL];
     } else {
         CleverTapLogInternal(self.config.logLevel, @"%@ File %@ is not present.", self, url);
     }
-    return filePath;
+    return nil;
 }
 
 - (nullable UIImage *)loadImageFromDisk:(NSString *)imageURL {


### PR DESCRIPTION
## Overview
- `removeAllFilesWithCompletionBlockReturn:` return after the completion if there is an error
- `synchronize` the `dispatch_group_leave(group)` call from the downloads in progress callback. The callback is executed from the concurrent queue async. Ensurez that `dispatch_group_leave(group)` is called exactly once for each `dispatch_group_enter(group)`.