### PR TITLE
[MC-1755] Implement custom templates file arguments (Custom Templates Part 8) 

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 		6BA3B2DC2B03E926004E834B /* CTQueueType.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BA3B2DA2B03E926004E834B /* CTQueueType.h */; };
 		6BA3B2E12B05411C004E834B /* InAppHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BA3B2E02B05411C004E834B /* InAppHelper.m */; };
 		6BA3B2E82B07E207004E834B /* CTTriggersMatcher+Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BA3B2E72B07E207004E834B /* CTTriggersMatcher+Tests.m */; };
+		6BAFFE9C2C371B4500654CAF /* CTFileDownloaderCustomTemplatesMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BAFFE9B2C371B4500654CAF /* CTFileDownloaderCustomTemplatesMock.m */; };
 		6BB727122B8E458D009CE7D0 /* CTTemplateProducer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB727112B8E458D009CE7D0 /* CTTemplateProducer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6BB727152B8E463C009CE7D0 /* CTCustomTemplate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB727132B8E463C009CE7D0 /* CTCustomTemplate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6BB727162B8E463C009CE7D0 /* CTCustomTemplate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB727142B8E463C009CE7D0 /* CTCustomTemplate.m */; };
@@ -912,6 +913,8 @@
 		6BA3B2E52B07E1D0004E834B /* CTImpressionManager+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CTImpressionManager+Tests.h"; sourceTree = "<group>"; };
 		6BA3B2E62B07E207004E834B /* CTTriggersMatcher+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CTTriggersMatcher+Tests.h"; sourceTree = "<group>"; };
 		6BA3B2E72B07E207004E834B /* CTTriggersMatcher+Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CTTriggersMatcher+Tests.m"; sourceTree = "<group>"; };
+		6BAFFE9A2C371B4500654CAF /* CTFileDownloaderCustomTemplatesMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTFileDownloaderCustomTemplatesMock.h; sourceTree = "<group>"; };
+		6BAFFE9B2C371B4500654CAF /* CTFileDownloaderCustomTemplatesMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloaderCustomTemplatesMock.m; sourceTree = "<group>"; };
 		6BB727112B8E458D009CE7D0 /* CTTemplateProducer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTTemplateProducer.h; sourceTree = "<group>"; };
 		6BB727132B8E463C009CE7D0 /* CTCustomTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTCustomTemplate.h; sourceTree = "<group>"; };
 		6BB727142B8E463C009CE7D0 /* CTCustomTemplate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTCustomTemplate.m; sourceTree = "<group>"; };
@@ -1480,36 +1483,8 @@
 				6BB778D12BF267B600A41628 /* CTTemplateContextTest.m */,
 				6B9157B72C10F40C00B1C907 /* CTInAppNotificationDisplayDelegateMock.h */,
 				6B9157B82C10F40C00B1C907 /* CTInAppNotificationDisplayDelegateMock.m */,
-			);
-			path = CustomTemplates;
-			sourceTree = "<group>";
-		};
-		6BB727102B8E455B009CE7D0 /* CustomTemplates */ = {
-			isa = PBXGroup;
-			children = (
-				6BB727112B8E458D009CE7D0 /* CTTemplateProducer.h */,
-				6BB727132B8E463C009CE7D0 /* CTCustomTemplate.h */,
-				6BB727142B8E463C009CE7D0 /* CTCustomTemplate.m */,
-				6BB727172B8E469B009CE7D0 /* CTInAppTemplateBuilder.h */,
-				6BB727182B8E469B009CE7D0 /* CTInAppTemplateBuilder.m */,
-				6BB7271B2B8E46AB009CE7D0 /* CTAppFunctionBuilder.h */,
-				6BB7271C2B8E46AB009CE7D0 /* CTAppFunctionBuilder.m */,
-				6BB7271F2B8E55CD009CE7D0 /* CTTemplateContext.h */,
-				6BB727202B8E55CD009CE7D0 /* CTTemplateContext.m */,
-				6BB727232B8E55DE009CE7D0 /* CTTemplatePresenter.h */,
-				6BB727252B8E5839009CE7D0 /* CTTemplateContext-Internal.h */,
-				6BB727292B8E5C66009CE7D0 /* CTTemplateArgument.h */,
-				6BB7272A2B8E5C66009CE7D0 /* CTTemplateArgument.m */,
-				6BB7272D2B8F3D79009CE7D0 /* CTCustomTemplate-Internal.h */,
-				6BB727312B8F787D009CE7D0 /* CTCustomTemplatesManager.h */,
-				6BB727322B8F787D009CE7D0 /* CTCustomTemplatesManager.m */,
-				6B32A09C2B9901AA009ADC57 /* CTCustomTemplateBuilder.h */,
-				6B32A09D2B9901AA009ADC57 /* CTCustomTemplateBuilder.m */,
-				6B32A0A02B99033F009ADC57 /* CTCustomTemplateBuilder-Internal.h */,
-				6BB778C52BECEC2700A41628 /* CTCustomTemplateInAppData.h */,
-				6BB778C62BECEC2700A41628 /* CTCustomTemplateInAppData.m */,
-				6BB778D82BFD277400A41628 /* CTCustomTemplatesManager-Internal.h */,
-				6B9157BA2C11D07200B1C907 /* CTCustomTemplateInAppData-Internal.h */,
+				6BAFFE9A2C371B4500654CAF /* CTFileDownloaderCustomTemplatesMock.h */,
+				6BAFFE9B2C371B4500654CAF /* CTFileDownloaderCustomTemplatesMock.m */,
 			);
 			path = CustomTemplates;
 			sourceTree = "<group>";
@@ -1540,6 +1515,36 @@
 				487854042BF4B7D800565685 /* CTFileDownloader.m */,
 			);
 			path = FileDownload;
+			sourceTree = "<group>";
+		};
+		6BB727102B8E455B009CE7D0 /* CustomTemplates */ = {
+			isa = PBXGroup;
+			children = (
+				6BB727112B8E458D009CE7D0 /* CTTemplateProducer.h */,
+				6BB727132B8E463C009CE7D0 /* CTCustomTemplate.h */,
+				6BB727142B8E463C009CE7D0 /* CTCustomTemplate.m */,
+				6BB727172B8E469B009CE7D0 /* CTInAppTemplateBuilder.h */,
+				6BB727182B8E469B009CE7D0 /* CTInAppTemplateBuilder.m */,
+				6BB7271B2B8E46AB009CE7D0 /* CTAppFunctionBuilder.h */,
+				6BB7271C2B8E46AB009CE7D0 /* CTAppFunctionBuilder.m */,
+				6BB7271F2B8E55CD009CE7D0 /* CTTemplateContext.h */,
+				6BB727202B8E55CD009CE7D0 /* CTTemplateContext.m */,
+				6BB727232B8E55DE009CE7D0 /* CTTemplatePresenter.h */,
+				6BB727252B8E5839009CE7D0 /* CTTemplateContext-Internal.h */,
+				6BB727292B8E5C66009CE7D0 /* CTTemplateArgument.h */,
+				6BB7272A2B8E5C66009CE7D0 /* CTTemplateArgument.m */,
+				6BB7272D2B8F3D79009CE7D0 /* CTCustomTemplate-Internal.h */,
+				6BB727312B8F787D009CE7D0 /* CTCustomTemplatesManager.h */,
+				6BB727322B8F787D009CE7D0 /* CTCustomTemplatesManager.m */,
+				6B32A09C2B9901AA009ADC57 /* CTCustomTemplateBuilder.h */,
+				6B32A09D2B9901AA009ADC57 /* CTCustomTemplateBuilder.m */,
+				6B32A0A02B99033F009ADC57 /* CTCustomTemplateBuilder-Internal.h */,
+				6BB778C52BECEC2700A41628 /* CTCustomTemplateInAppData.h */,
+				6BB778C62BECEC2700A41628 /* CTCustomTemplateInAppData.m */,
+				6BB778D82BFD277400A41628 /* CTCustomTemplatesManager-Internal.h */,
+				6B9157BA2C11D07200B1C907 /* CTCustomTemplateInAppData-Internal.h */,
+			);
+			path = CustomTemplates;
 			sourceTree = "<group>";
 		};
 		D02AC2D9276044F70031C1BE /* CleverTapSDKTests */ = {
@@ -2492,6 +2497,7 @@
 				32394C1F29FA251E00956058 /* CTEventBuilderTest.m in Sources */,
 				6BB778D02BEE4C3400A41628 /* CTNotificationActionTest.m in Sources */,
 				D02AC2EB2767F4590031C1BE /* BaseTestCase.m in Sources */,
+				6BAFFE9C2C371B4500654CAF /* CTFileDownloaderCustomTemplatesMock.m in Sources */,
 				6BEEC2CE2AEC49F100BD4EC5 /* CTImpressionManagerTest.m in Sources */,
 				6A2E4C18291E8A4A00385536 /* CleverTapInstanceConfigTests.m in Sources */,
 				4E2BFB9C2AD69BCA00DEB247 /* XCTestCase+XCTestCase_Tests.m in Sources */,

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -161,6 +161,10 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_INAPP_TOTAL_LIFETIME_COUNT @"tlc"
 #define CLTAP_INAPP_EXCLUDE_FROM_CAPS @"efc"
 #define CLTAP_INAPP_EXCLUDE_GLOBAL_CAPS @"excludeGlobalFCaps"
+#define CLTAP_INAPP_MEDIA @"media"
+#define CLTAP_INAPP_MEDIA_LANDSCAPE @"mediaLandscape"
+#define CLTAP_INAPP_MEDIA_CONTENT_TYPE @"content_type"
+#define CLTAP_INAPP_MEDIA_URL @"url"
 
 #define CLTAP_TRIGGER_BOOL_STRING_YES @"true"
 #define CLTAP_TRIGGER_BOOL_STRING_NO @"false"

--- a/CleverTapSDK/CTInAppNotification.m
+++ b/CleverTapSDK/CTInAppNotification.m
@@ -135,10 +135,10 @@
     self.tablet = [jsonObject[@"tablet"] boolValue];
     self.hasPortrait = jsonObject[@"hasPortrait"] ? [jsonObject[@"hasPortrait"] boolValue] : YES;
     self.hasLandscape = jsonObject[@"hasLandscape"] ? [jsonObject[@"hasLandscape"] boolValue] : NO;
-    NSDictionary *_media = (NSDictionary*) jsonObject[@"media"];
+    NSDictionary *_media = (NSDictionary*) jsonObject[CLTAP_INAPP_MEDIA];
     if (_media) {
-        self.contentType = _media[@"content_type"];
-        NSString *_mediaUrl = _media[@"url"];
+        self.contentType = _media[CLTAP_INAPP_MEDIA_CONTENT_TYPE];
+        NSString *_mediaUrl = _media[CLTAP_INAPP_MEDIA_URL];
         if (_mediaUrl && _mediaUrl.length > 0) {
             if ([self.contentType hasPrefix:@"image"]) {
                 self.imageURL = [NSURL URLWithString:_mediaUrl];
@@ -159,10 +159,10 @@
         }
     }
     
-    NSDictionary *_mediaLandscape = (NSDictionary*) jsonObject[@"mediaLandscape"];
+    NSDictionary *_mediaLandscape = (NSDictionary*) jsonObject[CLTAP_INAPP_MEDIA_LANDSCAPE];
     if (_mediaLandscape) {
-        self.landscapeContentType = _mediaLandscape[@"content_type"];
-        NSString *_mediaUrlLandscape = _mediaLandscape[@"url"];
+        self.landscapeContentType = _mediaLandscape[CLTAP_INAPP_MEDIA_CONTENT_TYPE];
+        NSString *_mediaUrlLandscape = _mediaLandscape[CLTAP_INAPP_MEDIA_URL];
         if (_mediaUrlLandscape && _mediaUrlLandscape.length > 0) {
             if ([self.landscapeContentType hasPrefix:@"image"]) {
                 self.imageUrlLandscape = [NSURL URLWithString:_mediaUrlLandscape];

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -234,19 +234,19 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 @property (atomic, weak) id <CTBatchSentDelegate> batchSentDelegate;
 @property (nonatomic, strong, readwrite) CTMultiDelegateManager *delegateManager;
 
+@property (nonatomic, strong, readwrite) CTFileDownloader *fileDownloader;
+
 #if !CLEVERTAP_NO_INAPP_SUPPORT
 @property (atomic, weak) id <CleverTapPushPermissionDelegate> pushPermissionDelegate;
-@property (strong, nonatomic, nullable) CleverTapFetchInAppsBlock fetchInAppsBlock;
 @property (atomic, strong) CTPushPrimerManager *pushPrimerManager;
 
+@property (strong, nonatomic, nullable) CleverTapFetchInAppsBlock fetchInAppsBlock;
 @property (nonatomic, strong, readwrite) CTInAppFCManager *inAppFCManager;
 @property (nonatomic, strong, readwrite) CTInAppEvaluationManager *inAppEvaluationManager;
 @property (nonatomic, strong, readwrite) CTInAppDisplayManager *inAppDisplayManager;
 @property (nonatomic, strong, readwrite) CTImpressionManager *impressionManager;
-@property (nonatomic, strong, readwrite) CTFileDownloader *fileDownloader;
 @property (nonatomic, strong, readwrite) CTInAppStore * _Nullable inAppStore;
-
-@property (nonatomic, strong) CTCustomTemplatesManager *customTemplatesManager;
+@property (nonatomic, strong, readwrite) CTCustomTemplatesManager *customTemplatesManager;
 #endif
 
 @property (atomic, strong) NSString *processingLoginUserIdentifier;
@@ -513,7 +513,6 @@ static BOOL sharedInstanceErrorLogged;
 - (void)initializeInAppSupport {
     CTInAppStore *inAppStore = [[CTInAppStore alloc] initWithConfig:self.config
                                                     delegateManager:self.delegateManager
-                                                     fileDownloader:self.fileDownloader
                                                            deviceId:self.deviceInfo.deviceId];
     self.inAppStore = inAppStore;
     

--- a/CleverTapSDK/CleverTapInternal.h
+++ b/CleverTapSDK/CleverTapInternal.h
@@ -31,7 +31,10 @@ typedef NS_ENUM(NSInteger, CleverTapEventType) {
 @property (nonatomic, assign, readonly) BOOL isAppForeground;
 @property (nonatomic, strong, readonly) CTDeviceInfo * _Nonnull deviceInfo;
 @property (atomic, strong, readonly) CTSessionManager * _Nonnull sessionManager;
+@property (nonatomic, strong, readonly) CTCustomTemplatesManager * _Nullable customTemplatesManager;
 #endif
+
+@property (nonatomic, strong, readonly) CTFileDownloader * _Nullable fileDownloader;
 
 + (NSMutableDictionary<NSString *, CleverTap *> * _Nullable)getInstances;
 

--- a/CleverTapSDK/InApps/CTInAppStore.h
+++ b/CleverTapSDK/InApps/CTInAppStore.h
@@ -11,7 +11,6 @@
 
 @class CleverTapInstanceConfig;
 @class CTMultiDelegateManager;
-@class CTFileDownloader;
 
 @interface CTInAppStore : NSObject <CTSwitchUserDelegate>
 
@@ -20,7 +19,6 @@
 - (instancetype _Nonnull)init NS_UNAVAILABLE;
 - (instancetype _Nonnull)initWithConfig:(CleverTapInstanceConfig * _Nonnull)config
                         delegateManager:(CTMultiDelegateManager * _Nonnull)delegateManager
-                         fileDownloader:(CTFileDownloader * _Nonnull)fileDownloader
                                deviceId:(NSString * _Nonnull)deviceId;
 
 - (NSArray * _Nonnull)clientSideInApps;

--- a/CleverTapSDK/InApps/CTLocalInApp.m
+++ b/CleverTapSDK/InApps/CTLocalInApp.m
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "CTLocalInApp.h"
+#import "CTConstants.h"
 
 @interface CTLocalInApp () {}
 @property (nonatomic, strong) NSString *inAppType;
@@ -113,11 +114,11 @@ static NSDictionary *_inAppTypeMap;
 
 - (void)setImageUrl:(NSString *)imageUrl {
     NSMutableDictionary *mediaObj = [NSMutableDictionary new];
-    mediaObj[@"content_type"] = @"image";
-    mediaObj[@"url"] = imageUrl;
-    self.inAppSettings[@"media"] = mediaObj;
+    mediaObj[CLTAP_INAPP_MEDIA_CONTENT_TYPE] = @"image";
+    mediaObj[CLTAP_INAPP_MEDIA_URL] = imageUrl;
+    self.inAppSettings[CLTAP_INAPP_MEDIA] = mediaObj;
     if (self.followDeviceOrientation) {
-        self.inAppSettings[@"mediaLandscape"] = mediaObj;
+        self.inAppSettings[CLTAP_INAPP_MEDIA_LANDSCAPE] = mediaObj;
     }
 }
 

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -14,6 +14,7 @@
 #import "CTConstants.h"
 #import "CleverTapInternal.h"
 #import "CTUtils.h"
+#import "CTCustomTemplatesManager-Internal.h"
 
 @implementation CleverTap(InAppsResponseHandler)
 
@@ -44,6 +45,11 @@
     NSArray *csInAppNotifs = jsonResp[CLTAP_INAPP_CS_JSON_RESPONSE_KEY];
     if (csInAppNotifs) {
         [self.inAppStore storeClientSideInApps:csInAppNotifs];
+        
+        // Preload CS in-app images to disk cache
+        [self downloadMediaURLs:csInAppNotifs];
+        // Preload CS custom template in-app files to disk cache
+        [self downloadCustomTemplatesFileURLs:csInAppNotifs];
     }
     
     // Parse in-app Mode
@@ -91,6 +97,53 @@
     }
     
     [self triggerFetchInApps:YES];
+}
+
+- (void)downloadMediaURLs:(NSArray *)inApps {
+    NSArray<NSString *> *imageURLs = [self imageURLs:inApps];
+    [self.fileDownloader downloadFiles:imageURLs withCompletionBlock:nil];
+}
+
+- (void)downloadCustomTemplatesFileURLs:(NSArray *)inApps {
+    NSMutableSet *urls = [NSMutableSet set];
+    for (NSDictionary *inApp in inApps) {
+        NSSet *inAppFileArgsUrls = [self.customTemplatesManager fileArgsURLs:inApp];
+        [urls unionSet:inAppFileArgsUrls];
+    }
+    [self.fileDownloader downloadFiles:[urls allObjects] withCompletionBlock:nil];
+}
+
+- (NSArray<NSString *> *)imageURLs:(NSArray *)inApps {
+    NSMutableSet<NSString *> *mediaURLs = [NSMutableSet new];
+    for (NSDictionary *jsonInApp in inApps) {
+        NSDictionary *media = (NSDictionary *)jsonInApp[CLTAP_INAPP_MEDIA];
+        if (media) {
+            NSString *imageURL = [self URLFromMedia:media];
+            if (imageURL) {
+                [mediaURLs addObject:imageURL];
+            }
+        }
+        NSDictionary *mediaLandscape = (NSDictionary *)jsonInApp[CLTAP_INAPP_MEDIA_LANDSCAPE];
+        if (mediaLandscape) {
+            NSString *imageURL = [self URLFromMedia:mediaLandscape];
+            if (imageURL) {
+                [mediaURLs addObject:imageURL];
+            }
+        }
+    }
+    return [mediaURLs allObjects];
+}
+
+- (NSString *)URLFromMedia:(NSDictionary *)media {
+    NSString *contentType = media[CLTAP_INAPP_MEDIA_CONTENT_TYPE];
+    NSString *mediaUrl = media[CLTAP_INAPP_MEDIA_URL];
+    if (mediaUrl && mediaUrl.length > 0) {
+        // Preload contentType with image/jpeg or image/gif
+        if ([contentType hasPrefix:@"image"]) {
+            return mediaUrl;
+        }
+    }
+    return nil;
 }
 
 - (void)triggerFetchInApps:(BOOL)success {

--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager-Internal.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager-Internal.h
@@ -13,13 +13,18 @@
 #import "CleverTapInstanceConfig.h"
 #import "CTInAppNotification.h"
 #import "CTInAppNotificationDisplayDelegate.h"
+#import "CTFileDownloader.h"
 
 @interface CTCustomTemplatesManager (Internal)
 
 - (instancetype)initWithConfig:(CleverTapInstanceConfig *)instanceConfig;
 
+- (NSSet<NSString *> *)fileArgsURLsForInAppData:(CTCustomTemplateInAppData *)inAppData;
+- (NSSet<NSString *> *)fileArgsURLs:(NSDictionary *)inAppJSON;
+
 - (BOOL)presentNotification:(CTInAppNotification *)notification
-               withDelegate:(id<CTInAppNotificationDisplayDelegate>)delegate;
+               withDelegate:(id<CTInAppNotificationDisplayDelegate>)delegate
+          andFileDownloader:(CTFileDownloader *)fileDownloader;
 
 - (void)closeNotification:(CTInAppNotification *)notification;
 

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext-Internal.h
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext-Internal.h
@@ -13,6 +13,7 @@
 #import "CTCustomTemplate.h"
 #import "CTTemplateContext.h"
 #import "CTInAppNotificationDisplayDelegate.h"
+#import "CTFileDownloader.h"
 
 @protocol CTTemplateContextDismissDelegate <NSObject>
 
@@ -22,7 +23,9 @@
 
 @interface CTTemplateContext (Internal)
 
-- (instancetype)initWithTemplate:(CTCustomTemplate *)customTemplate andNotification:(CTInAppNotification *)notification;
+- (instancetype)initWithTemplate:(CTCustomTemplate *)customTemplate
+                    notification:(CTInAppNotification *)notification
+               andFileDownloader:(CTFileDownloader *)fileDownloader;
 
 - (void)setNotificationDelegate:(id<CTInAppNotificationDisplayDelegate>)delegate;
 

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
@@ -22,6 +22,7 @@
 @property (nonatomic) id<CTInAppNotificationDisplayDelegate> notificationDelegate;
 @property (nonatomic) id<CTTemplateContextDismissDelegate> dismissDelegate;
 @property (nonatomic) BOOL isAction;
+@property (nonatomic) CTFileDownloader *fileDownloader;
 
 @end
 
@@ -29,11 +30,14 @@
 
 @synthesize argumentValues = _argumentValues;
 
-- (instancetype)initWithTemplate:(CTCustomTemplate *)customTemplate andNotification:(CTInAppNotification *)notification {
+- (instancetype)initWithTemplate:(CTCustomTemplate *)customTemplate
+                    notification:(CTInAppNotification *)notification
+               andFileDownloader:(CTFileDownloader *)fileDownloader {
     if (self = [super init]) {
         self.notification = notification;
         self.template = customTemplate;
         self.isAction = notification.customTemplateInAppData.isAction;
+        self.fileDownloader = fileDownloader;
     }
     return self;
 }
@@ -141,7 +145,6 @@
 }
 
 - (NSString *)fileNamed:(NSString *)name {
-    // TODO: add when implementing file handling
     return self.argumentValues[name];
 }
 
@@ -238,7 +241,9 @@
                 }
                 break;
             case CTTemplateArgumentTypeFile:
-                // TODO: add when implementing file handling
+                if ([override isKindOfClass:[NSString class]]) {
+                    return [self.fileDownloader fileDownloadPath:override];
+                }
                 break;
             case CTTemplateArgumentTypeAction: {
                 CTNotificationAction *action = [[CTNotificationAction alloc] initWithJSON:override[CLTAP_INAPP_ACTIONS]];

--- a/CleverTapSDKTests/InApps/CTInAppStoreTest.m
+++ b/CleverTapSDKTests/InApps/CTInAppStoreTest.m
@@ -330,7 +330,7 @@
 - (void)testSwitchUserDelegateAdded {
     CTMultiDelegateManager *delegateManager = [[CTMultiDelegateManager alloc] init];
     NSUInteger count = [[delegateManager switchUserDelegates] count];
-    __unused CTInAppStore *store = [[CTInAppStore alloc] initWithConfig:self.helper.config delegateManager:delegateManager fileDownloader:self.helper.fileDownloader deviceId:self.helper.deviceId];
+    __unused CTInAppStore *store = [[CTInAppStore alloc] initWithConfig:self.helper.config delegateManager:delegateManager deviceId:self.helper.deviceId];
     
     XCTAssertEqual([[delegateManager switchUserDelegates] count], count + 1);
 }

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTFileDownloaderCustomTemplatesMock.h
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTFileDownloaderCustomTemplatesMock.h
@@ -1,0 +1,18 @@
+//
+//  CTFileDownloaderCustomTemplatesMock.h
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 4.07.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CTFileDownloader.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CTFileDownloaderCustomTemplatesMock : CTFileDownloader
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTFileDownloaderCustomTemplatesMock.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTFileDownloaderCustomTemplatesMock.m
@@ -1,0 +1,32 @@
+//
+//  CTFileDownloaderCustomTemplatesMock.m
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 4.07.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import "CTFileDownloaderCustomTemplatesMock.h"
+
+@implementation CTFileDownloaderCustomTemplatesMock
+
+- (void)downloadFiles:(NSArray<NSString *> *)fileURLs withCompletionBlock:(void (^ _Nullable)(NSDictionary<NSString *, NSNumber *> *status))completion {
+    completion(@{});
+}
+
+- (BOOL)isFileAlreadyPresent:(NSString *)url {
+    return NO;
+}
+
+- (void)clearFileAssets:(BOOL)expiredOnly {
+}
+
+- (nullable NSString *)fileDownloadPath:(NSString *)url {
+    return url;
+}
+
+- (nullable UIImage *)loadImageFromDisk:(NSString *)imageURL {
+    return nil;
+}
+
+@end

--- a/CleverTapSDKTests/InApps/InAppHelper.m
+++ b/CleverTapSDKTests/InApps/InAppHelper.m
@@ -55,7 +55,6 @@ NSString *const CLTAP_TEST_CAMPAIGN_ID = @"testCampaignId";
         
         self.inAppStore = [[CTInAppStore alloc] initWithConfig:self.config
                                                delegateManager:self.delegateManager
-                                                fileDownloader:self.fileDownloader
                                                       deviceId:self.deviceId];
         
         self.inAppTriggerManager = [[CTInAppTriggerManager alloc] initWithAccountId:self.accountId


### PR DESCRIPTION
## Overview
Download files for Custom Templates and App Functions. Preload the files in Client side mode. Download the files before showing the notification and presenting a custom app function action.

## Implementation
- Preload the files in CS mode when the in-app notifications are fetched (see `InAppsResponseHandler fileArgsURLsForInAppData:`). 
- Preload the files for actions of custom templates (see `CTCustomTemplatesManager fileArgsURLsForInAppData:`).
- Download the files when preparing the notification for display (see `CTInAppDisplayManager`). 
- Download the files when triggering a custom action with visual=false and presenting it (see `CTInAppDisplayManager triggerCustomTemplateAction:forNotification:`). 