### PR TITLE
[FileDownloader] Remove SDWebImage download files when migrating

### DIFF
--- a/CleverTapSDK/FileDownload/CTFileDownloader.m
+++ b/CleverTapSDK/FileDownload/CTFileDownloader.m
@@ -2,6 +2,7 @@
 #import "CTConstants.h"
 #import "CTPreferences.h"
 #import "CTFileDownloadManager.h"
+#import <SDWebImage/SDImageCache.h>
 
 @interface CTFileDownloader()
 
@@ -92,7 +93,7 @@
     self.fileDownloadManager = [CTFileDownloadManager sharedInstanceWithConfig:self.config];
     self.fileExpiryTime = CLTAP_FILE_EXPIRY_OFFSET;
 
-    [self migrateActiveAndInactiveUrls];
+    [self removeLegacyAssets:nil];
     
     @synchronized (self) {
         NSDictionary *cachedUrlsExpiry = [CTPreferences getObjectForKey:[self storageKeyWithSuffix:CLTAP_FILE_URLS_EXPIRY_DICT]];
@@ -200,7 +201,7 @@
     return [[NSDate date] timeIntervalSince1970];
 }
 
-- (void)migrateActiveAndInactiveUrls {
+- (void)removeLegacyAssets:(void (^)(void))completion {
     NSArray<NSString *> *activeAssetsArray = [CTPreferences getObjectForKey:[self storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ACTIVE_ASSETS]];
     NSArray<NSString *> *inactiveAssetsArray = [CTPreferences getObjectForKey:[self storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_INACTIVE_ASSETS]];
     NSMutableSet<NSString *> *urls = [NSMutableSet new];
@@ -210,23 +211,33 @@
     if (inactiveAssetsArray && inactiveAssetsArray.count > 0) {
         [urls addObjectsFromArray:inactiveAssetsArray];
     }
-    NSMutableDictionary<NSString *, NSNumber *> *urlsExpiry = [NSMutableDictionary new];
-    NSNumber *expiry = @([self currentTimeInterval] + self.fileExpiryTime);
-    for (NSString *url in urls) {
-        urlsExpiry[url] = expiry;
+    
+    if (!inactiveAssetsArray && !activeAssetsArray) {
+        return;
     }
     
-    if (urlsExpiry.count > 0) {
-        [CTPreferences putObject:urlsExpiry forKey:[self storageKeyWithSuffix:CLTAP_FILE_URLS_EXPIRY_DICT]];
+    dispatch_group_t deleteGroup = dispatch_group_create();
+    dispatch_queue_t deleteConcurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    SDImageCache *sdImageCache = [SDImageCache sharedImageCache];
+    for (NSString *url in urls) {
+        dispatch_group_enter(deleteGroup);
+        dispatch_async(deleteConcurrentQueue, ^{
+            [sdImageCache removeImageForKey:url
+                                   fromDisk:YES
+                             withCompletion:^{
+                dispatch_group_leave(deleteGroup);
+            }];
+        });
+    }
+    
+    dispatch_group_notify(deleteGroup, deleteConcurrentQueue, ^{
         [CTPreferences removeObjectForKey:[self storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ACTIVE_ASSETS]];
         [CTPreferences removeObjectForKey:[self storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_INACTIVE_ASSETS]];
-    }
-    id inAppAssetsDeletedTs = [CTPreferences getObjectForKey:[self storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ASSETS_LAST_DELETED_TS]];
-    if ([inAppAssetsDeletedTs isKindOfClass:[NSNumber class]]) {
-        long ts = [inAppAssetsDeletedTs longLongValue];
-        [CTPreferences putInt:ts forKey:[self storageKeyWithSuffix:CLTAP_FILE_ASSETS_LAST_DELETED_TS]];
         [CTPreferences removeObjectForKey:[self storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ASSETS_LAST_DELETED_TS]];
-    }
+        if (completion) {
+            completion();
+        }
+    });
 }
 
 @end

--- a/CleverTapSDK/FileDownload/CTFileDownloader.m
+++ b/CleverTapSDK/FileDownload/CTFileDownloader.m
@@ -222,11 +222,15 @@
     for (NSString *url in urls) {
         dispatch_group_enter(deleteGroup);
         dispatch_async(deleteConcurrentQueue, ^{
-            [sdImageCache removeImageForKey:url
-                                   fromDisk:YES
-                             withCompletion:^{
+            if ([sdImageCache diskImageDataExistsWithKey:url]) {
+                [sdImageCache removeImageForKey:url
+                                       fromDisk:YES
+                                 withCompletion:^{
+                    dispatch_group_leave(deleteGroup);
+                }];
+            } else {
                 dispatch_group_leave(deleteGroup);
-            }];
+            }
         });
     }
     

--- a/CleverTapSDKTests/FileDownload/CTFileDownloadManagerTests.m
+++ b/CleverTapSDKTests/FileDownload/CTFileDownloadManagerTests.m
@@ -178,7 +178,7 @@
 
     // Download 5 files
     [self.fileDownloadManager downloadFiles:self.fileURLs withCompletionBlock:^(NSDictionary<NSString *,id> * _Nullable status) {
-        [expectation1 fulfill];
+
         // Assert files are already downloaded
         XCTAssertTrue([self.fileDownloadManager isFileAlreadyPresent:urls[0]]);
         XCTAssertTrue([self.fileDownloadManager isFileAlreadyPresent:urls[1]]);
@@ -186,6 +186,8 @@
         [self.fileDownloadManager downloadFiles:urls withCompletionBlock:^(NSDictionary<NSString *,id> * _Nullable status) {
             [expectation2 fulfill];
         }];
+        
+        [expectation1 fulfill];
     }];
     
     // Enforce the order

--- a/CleverTapSDKTests/FileDownload/CTFileDownloader+Tests.h
+++ b/CleverTapSDKTests/FileDownload/CTFileDownloader+Tests.h
@@ -23,7 +23,7 @@
 - (void)updateLastDeletedTimestamp;
 - (long)lastDeletedTimestamp;
 - (void)deleteFiles:(NSArray<NSString *> *)urls withCompletionBlock:(CTFilesDeleteCompletedBlock)completion;
-- (void)migrateActiveAndInactiveUrls;
+- (void)removeLegacyAssets:(void (^)(void))completion;
 - (NSString *)storageKeyWithSuffix:(NSString *)suffix;
 - (void)updateFilesExpiry:(NSDictionary<NSString *, NSNumber *> *)status;
 - (void)removeAllAssetsWithCompletion:(void(^)(NSDictionary<NSString *,NSNumber *> *status))completion;

--- a/CleverTapSDKTests/FileDownload/CTFileDownloaderTests.m
+++ b/CleverTapSDKTests/FileDownload/CTFileDownloaderTests.m
@@ -6,6 +6,8 @@
 #import "CTFileDownloadTestHelper.h"
 #import "CTFileDownloader+Tests.h"
 #import "CTFileDownloaderMock.h"
+#import <SDWebImage/SDImageCache.h>
+#import <SDWebImage/SDWebImageManager.h>
 
 @interface CTFileDownloaderTests : XCTestCase
 
@@ -45,9 +47,16 @@
     [self waitForExpectations:@[expectation] timeout:2.0];
 }
 
-- (void)testMigration {
-    NSArray<NSString *> *activeAssetsArray = @[@"url0", @"url1"];
-    NSArray<NSString *> *inactiveAssetsArray = @[@"url2", @"url3"];
+- (void)testRemoveLegacyAssets {
+    // Setup
+    NSArray *urls = @[
+        [NSString stringWithFormat:@"https://clevertap.com/%@_0.png", self.helper.fileURL],
+        [NSString stringWithFormat:@"https://clevertap.com/%@_1.jpg", self.helper.fileURL],
+        [NSString stringWithFormat:@"https://clevertap.com/%@_2.jpeg", self.helper.fileURL],
+        [NSString stringWithFormat:@"https://clevertap.com/%@_3.png", self.helper.fileURL]
+    ];
+    NSArray<NSString *> *activeAssetsArray = @[urls[0], urls[1]];
+    NSArray<NSString *> *inactiveAssetsArray = @[urls[2], urls[3]];
     [CTPreferences putObject:activeAssetsArray forKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ACTIVE_ASSETS]];
     [CTPreferences putObject:inactiveAssetsArray forKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_INACTIVE_ASSETS]];
     
@@ -55,22 +64,45 @@
     self.fileDownloader.mockCurrentTimeInterval = ts;
     [CTPreferences putInt:ts forKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ASSETS_LAST_DELETED_TS]];
     
-    [self.fileDownloader migrateActiveAndInactiveUrls];
+    SDWebImageManager *sdWebImageManager = [SDWebImageManager sharedManager];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImage loadImageWithURL"];
+    dispatch_group_t downloads = dispatch_group_create();
+    dispatch_queue_t concurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    for (NSString *url in urls) {
+        dispatch_group_enter(downloads);
+        dispatch_async(concurrentQueue, ^{
+            [sdWebImageManager loadImageWithURL:[NSURL URLWithString:url]
+                                        options:SDWebImageRetryFailed
+                                        context:@{SDWebImageContextStoreCacheType : @(SDImageCacheTypeDisk)}
+                                       progress:nil
+                                      completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+                dispatch_group_leave(downloads);
+            }];
+        });
+    }
+    dispatch_group_notify(downloads, concurrentQueue, ^{
+        [expectation fulfill];
+    });
     
-    XCTAssertNil([CTPreferences getObjectForKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ACTIVE_ASSETS]]);
-    XCTAssertNil([CTPreferences getObjectForKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_INACTIVE_ASSETS]]);
-    NSDictionary *urlsExpiry = [CTPreferences getObjectForKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_FILE_URLS_EXPIRY_DICT]];
-    NSDictionary *urlsExpiryExpected = @{
-        @"url0": @(ts + self.fileDownloader.fileExpiryTime),
-        @"url1": @(ts + self.fileDownloader.fileExpiryTime),
-        @"url2": @(ts + self.fileDownloader.fileExpiryTime),
-        @"url3": @(ts + self.fileDownloader.fileExpiryTime)
-    };
-    XCTAssertTrue([urlsExpiryExpected isEqualToDictionary:urlsExpiry]);
+    [self waitForExpectations:@[expectation] timeout:2.0];
+    SDImageCache *sdImageCache = [SDImageCache sharedImageCache];
+    for (NSString *url in urls) {
+        XCTAssertNotNil([sdImageCache imageFromDiskCacheForKey:url]);
+    }
     
-    XCTAssertNil([CTPreferences getObjectForKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ASSETS_LAST_DELETED_TS]]);
-    id filesLastDeletedTs = [CTPreferences getObjectForKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_FILE_ASSETS_LAST_DELETED_TS]];
-    XCTAssertEqual(ts, [filesLastDeletedTs longValue]);
+    // Remove legacy assets
+    XCTestExpectation *expectationRemoveLegacyAssets = [self expectationWithDescription:@"RemoveLegacyAssets"];
+    [self.fileDownloader removeLegacyAssets:^{
+        XCTAssertNil([CTPreferences getObjectForKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ACTIVE_ASSETS]]);
+        XCTAssertNil([CTPreferences getObjectForKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_INACTIVE_ASSETS]]);
+        XCTAssertNil([CTPreferences getObjectForKey:[self.fileDownloader storageKeyWithSuffix:CLTAP_PREFS_CS_INAPP_ASSETS_LAST_DELETED_TS]]);
+        for (NSString *url in urls) {
+            XCTAssertNil([sdImageCache imageFromDiskCacheForKey:url]);
+        }
+        [expectationRemoveLegacyAssets fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectationRemoveLegacyAssets] timeout:2.0];
 }
 
 - (void)testSetup {


### PR DESCRIPTION
## Overview
Remove the files downloaded by SDWebImage and clear the previous preferences when migrating to the new File Downloader. 
SDWebImage does not provide direct API to move the files to a different location, hence it is safer to remove them and the File Downloader will download the actively used files.

## Implementation
Use SDWebImage to remove the files from the previous storage.
Add unit test which downloads files mimicking the legacy logic and then asserts the files are deleted after migration.