### PR TITLE
[PE File Vars] Updated file expiry logic

### DIFF
--- a/CleverTapSDK/FileDownload/CTFileDownloader.h
+++ b/CleverTapSDK/FileDownload/CTFileDownloader.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithConfig:(CleverTapInstanceConfig *)config;
 - (void)downloadFiles:(NSArray<NSString *> *)fileURLs withCompletionBlock:(void (^ _Nullable)(NSDictionary<NSString *, NSNumber *> *status))completion;
-- (BOOL)isFileAlreadyPresent:(NSString *)url;
+- (BOOL)isFileAlreadyPresent:(NSString *)url andUpdateExpiryTime:(BOOL)updateExpiryTime;
 - (void)clearFileAssets:(BOOL)expiredOnly;
 - (nullable NSString *)fileDownloadPath:(NSString *)url;
 - (nullable UIImage *)loadImageFromDisk:(NSString *)imageURL;

--- a/CleverTapSDK/ProductExperiences/CTVarCache.m
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.m
@@ -314,7 +314,7 @@
 }
 
 - (BOOL)isFileAlreadyPresent:(NSString *)fileURL {
-    return [self.fileDownloader isFileAlreadyPresent:fileURL];
+    return [self.fileDownloader isFileAlreadyPresent:fileURL andUpdateExpiryTime:YES];
 }
 
 - (NSMutableArray<NSString *> *)fileURLs:(NSArray *)fileVars {
@@ -323,7 +323,7 @@
         if (var.fileURL) {
             // If file is already present, call fileIsReady
             // else download the file and call fileIsReady when downloaded
-            if ([self.fileDownloader isFileAlreadyPresent:var.fileURL]) {
+            if ([self isFileAlreadyPresent:var.fileURL]) {
                 [var triggerFileIsReady];
             } else {
                 [downloadURLs addObject:var.fileURL];
@@ -362,7 +362,7 @@
         return;
     }
     
-    if ([self.fileDownloader isFileAlreadyPresent:url]) {
+    if ([self isFileAlreadyPresent:url]) {
         [fileVar triggerFileIsReady];
     } else {
         [self.fileDownloader downloadFiles:@[url] withCompletionBlock:^(NSDictionary<NSString *,NSNumber *> * _Nonnull status) {


### PR DESCRIPTION
- The file expiry timestamp were not getting updated for PE File vars if file was already present because we were only updating the expiry timestamp when `downloadFiles:` is called. For InApps downloadFiles: are called for all urls, but for PE File Var we are calling it for urls which are not present.
- The expired files were not getting deleted if we don't call `downloadFiles:` anywhere. So added logic to check for expired files and delete them when `CTFileDownloader` is initialised only, ie on every App launch.
