### PR TITLE
Add template and template context debug descriptions (Custom Templates Part 9)

### DIFF
--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplate.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplate.m
@@ -51,4 +51,12 @@
     return [self.name hash];
 }
 
+- (NSString *)debugDescription {
+    return [NSString stringWithFormat:@"<%@: %p> name: %@, args: {\n%@\n}",
+            [self class],
+            self,
+            self.name,
+            [self.arguments componentsJoinedByString:@",\n"]];
+}
+
 @end

--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
@@ -261,4 +261,24 @@
     return nil;
 }
 
+- (NSString *)debugDescription {
+    NSMutableArray<NSString *> *argsDescription = [NSMutableArray array];
+    for (NSString *key in self.argumentValues) {
+        NSString *value;
+        if ([self.argumentValues[key] isKindOfClass:[CTNotificationAction class]]) {
+            CTNotificationAction *action = self.argumentValues[key];
+            NSString *name = action.customTemplateInAppData.templateName ? action.customTemplateInAppData.templateName : @"";
+            value = [NSString stringWithFormat:@"Action: %@", name];
+        } else {
+            value = [self.argumentValues[key] debugDescription];
+        }
+        [argsDescription addObject:[NSString stringWithFormat:@"%@: %@", key, value]];
+    }
+    return [NSString stringWithFormat:@"<%@: %p> templateName: %@, args: {\n%@\n}",
+            [self class],
+            self,
+            self.templateName,
+            [argsDescription componentsJoinedByString:@",\n"]];
+}
+
 @end


### PR DESCRIPTION
## Overview
Overwrite debug description to return detailed information on `CTTemplateContext` and `CTCustomTemplate`.

## Implementation
`CTTemplateContext` - returns the template name and argument values description. Uses the template name or empty string for actions.
`CTCustomTemplate` - returns the template name and arguments description. The arguments are `CTTemplateArgument` which already overrides the description.