### PR TITLE
[MC-1823] Fix html view controller presented before scene became active

### DIFF
--- a/CleverTapSDK/CTInAppDisplayViewController.h
+++ b/CleverTapSDK/CTInAppDisplayViewController.h
@@ -13,6 +13,8 @@
 - (instancetype)init __unavailable;
 - (instancetype)initWithNotification:(CTInAppNotification*)notification;
 
+- (void)initializeWindowOfClass:(Class)windowClass animated:(BOOL)animated;
+
 - (void)show:(BOOL)animated;
 - (void)hide:(BOOL)animated;
 - (BOOL)deviceOrientationIsLandscape;

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -38,7 +38,7 @@
     self = [super init];
     if (self) {
         _notification = notification;
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13, tvOS 13.0, *)) {
             [[NSNotificationCenter defaultCenter] addObserver:self
                                                      selector:@selector(sceneDidActivate:) name:UISceneDidActivateNotification
                                                        object:nil];
@@ -51,7 +51,7 @@
 // However, this means that there is already an active scene when the controller is initialized.
 // In this case, we do not need the notification, since showFromWindow will directly find the window from the already active scene and not wait for it.
 - (void)sceneDidActivate:(NSNotification *)notification
-API_AVAILABLE(ios(13.0)) {
+API_AVAILABLE(ios(13.0), tvos(13.0)) {
     if (!self.window && self.waitingForSceneWindow) {
         CleverTapLogStaticDebug(@"%@:%@: Scene did activate. Showing from window.", [CTInAppDisplayViewController class], self);
         self.waitingForSceneWindow = NO;
@@ -129,7 +129,7 @@ API_AVAILABLE(ios(13.0)) {
 }
 
 - (void)initializeWindowOfClass:(Class)windowClass animated:(BOOL)animated {
-    if (@available(iOS 13, *)) {
+    if (@available(iOS 13, tvOS 13.0, *)) {
         NSSet *connectedScenes = [CTUIUtils getSharedApplication].connectedScenes;
         for (UIScene *scene in connectedScenes) {
             if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
@@ -335,7 +335,7 @@ API_AVAILABLE(ios(13.0)) {
 }
 
 - (void)dealloc {
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, tvOS 13.0, *)) {
         [[NSNotificationCenter defaultCenter] removeObserver:self];
     }
 }

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -481,19 +481,9 @@ typedef enum {
 - (void)showFromWindow:(BOOL)animated {
     if (!self.notification) return;
     Class windowClass = self.shouldPassThroughTouches ? CTInAppPassThroughWindow.class : UIWindow.class;
-    
-    if (@available(iOS 13, *)) {
-        NSSet *connectedScenes = [CTUIUtils getSharedApplication].connectedScenes;
-        for (UIScene *scene in connectedScenes) {
-            if (scene.activationState == UISceneActivationStateForegroundActive && [scene isKindOfClass:[UIWindowScene class]]) {
-                UIWindowScene *windowScene = (UIWindowScene *)scene;
-                self.window = [[windowClass alloc] initWithFrame:
-                               windowScene.coordinateSpace.bounds];
-                self.window.windowScene = windowScene;
-            }
-        }
-    } else {
-        self.window = [[windowClass alloc] initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height)];
+    [self initializeWindowOfClass:windowClass animated:animated];
+    if (!self.window) {
+        return;
     }
     
     self.window.alpha = 0;


### PR DESCRIPTION
## Overview
Fix html view controller presented before scene became active. See details in the initial PR which fixes this in the `CTInAppDisplayViewController`: #309 

## Implementation
Move the initialization and setting of the window to a separate method. Reuse the method in the `CTInAppHTMLViewController`.

## Notes
These changes and PR are to the `custom_inapp_templates` branch since there are other changes to the `CTInAppHTMLViewController` and this will make the merging easier later on.