### PR TITLE
[MC-1788] Add SDK version as window variable to the JS interface

### DIFF
--- a/CleverTapSDK/CleverTapJSInterface.m
+++ b/CleverTapSDK/CleverTapJSInterface.m
@@ -8,6 +8,8 @@
 #import "CTNotificationAction.h"
 #import "CTInAppDisplayViewController.h"
 
+#import "CleverTapBuildInfo.h"
+
 @interface CleverTapJSInterface (){}
 
 @property (nonatomic, strong) CleverTapInstanceConfig *config;
@@ -32,6 +34,12 @@
         _controller = controller;
     }
     return self;
+}
+
+- (WKUserScript *)versionScript {
+    NSString *js = [NSString stringWithFormat:@"window.cleverTapIOSSDKVersion = %@;", WR_SDK_REVISION];
+    WKUserScript *wkScript = [[WKUserScript alloc] initWithSource:js injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
+    return wkScript;
 }
 
 - (void)userContentController:(nonnull WKUserContentController *)userContentController didReceiveScriptMessage:(nonnull WKScriptMessage *)message {

--- a/CleverTapSDK/CleverTapJSInterfacePrivate.h
+++ b/CleverTapSDK/CleverTapJSInterfacePrivate.h
@@ -5,4 +5,7 @@
 
 // SET ONLY WHEN THE USER INITIALISES A WEBVIEW WITH CT JS INTERFACE
 @property (nonatomic, assign) BOOL wv_init;
+
+- (WKUserScript *)versionScript;
+
 @end

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -77,6 +77,7 @@ typedef enum {
     WKUserScript *wkScript = [[WKUserScript alloc] initWithSource:js injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES];
     WKUserContentController *wkController = [[WKUserContentController alloc] init];
     [wkController addUserScript:wkScript];
+    [wkController addUserScript:_jsInterface.versionScript];
     [wkController addScriptMessageHandler:_jsInterface name:@"clevertap"];
     WKWebViewConfiguration *wkConfig = [[WKWebViewConfiguration alloc] init];
     wkConfig.userContentController = wkController;


### PR DESCRIPTION
## Overview
Include the CleverTap SDK version in the JS interface. The version should be accessible by the HTML in-app notifications. This enables the JavaScript in the Web View to get the version and execute code based on the SDK version capabilities and features.

## Implementation
Add `cleverTapIOSSDKVersion` variable to the `window`. The variable is set to the `WR_SDK_REVISION` which is the integer version of the SDK. The script is added at document start, only to the main frame.