### PR TITLE
Create the syncPayload and meta outside the syncWithBlock

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4300,9 +4300,9 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)syncVariables:(BOOL)isProduction {
+    NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
+    NSDictionary *varsPayload = [[self variables] varsPayload];
     [self syncWithBlock:^{
-        NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
-        NSDictionary *varsPayload = [[self variables] varsPayload];
         CTRequest *ctRequest = [CTRequestFactory syncVarsRequestWithConfig:self.config params:@[meta, varsPayload] domain:self.domainFactory.redirectDomain];
         [self syncRequest:ctRequest logMessage:@"Vars sync"];
     } methodName:NSStringFromSelector(_cmd) isProduction:isProduction];
@@ -4314,9 +4314,9 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)syncCustomTemplates:(BOOL)isProduction {
+    NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
+    NSDictionary *syncPayload = [[self customTemplatesManager] syncPayload];
     [self syncWithBlock:^{
-        NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
-        NSDictionary *syncPayload = [[self customTemplatesManager] syncPayload];
         CTRequest *ctRequest = [CTRequestFactory syncTemplatesRequestWithConfig:self.config params:@[meta, syncPayload] domain:self.domainFactory.redirectDomain];
         [self syncRequest:ctRequest logMessage:@"Define Custom Templates"];
     } methodName:NSStringFromSelector(_cmd) isProduction:isProduction];


### PR DESCRIPTION
## Overview
Create the `syncPayload` and `meta` outside the `syncWithBlock` block. The block is executed on a separate queue. 
_This can cause crashes on_ `syncCustomTemplates`.

## Implementation
Create the `syncPayload` and `meta` on the main thread (`syncCustomTemplates` needs to be called from the main thread) outside the block.

## Notes
Crash at:
```
definitions[template.name] = templateData;
Thread 9: EXC_BAD_ACCESS (code=1, address=0xbeadde6d19e0)
```

Crash log:
```
Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000
Triggered by Thread:  7

Thread 1::  Dispatch queue: com.clevertap.serialQueue:67Z-RRK-696Z
0   libsystem_kernel.dylib                 0x1b17dc10c semaphore_wait_trap + 8
1   libdispatch.dylib                      0x180134bc0 _dispatch_sema4_wait + 24
2   libdispatch.dylib                      0x180135234 _dispatch_semaphore_wait_slow + 128
3   CleverTapSDK                           0x101c0160c -[CleverTap syncRequest:logMessage:] + 464
4   CleverTapSDK                           0x101c012e8 __33-[CleverTap syncCustomTemplates:]_block_invoke + 404
5   CleverTapSDK                           0x101bdff44 __43-[CleverTap runSerialAsyncEnsureHandshake:]_block_invoke.167 + 40
6   libdispatch.dylib                      0x180132ee4 _dispatch_call_block_and_release + 24
7   libdispatch.dylib                      0x180134708 _dispatch_client_callout + 16
8   libdispatch.dylib                      0x18013c77c _dispatch_lane_serial_drain + 776
9   libdispatch.dylib                      0x18013d3dc _dispatch_lane_invoke + 392
10  libdispatch.dylib                      0x180149608 _dispatch_workloop_worker_thread + 768
11  libsystem_pthread.dylib                0x1b1834878 _pthread_wqthread + 284
12  libsystem_pthread.dylib                0x1b183363c start_wqthread + 8
Thread 2:
0   libsystem_pthread.dylib                0x1b1833634 start_wqthread + 0
Thread 3:
0   libsystem_pthread.dylib                0x1b1833634 start_wqthread + 0
Thread 4:
0   libsystem_pthread.dylib                0x1b1833634 start_wqthread + 0
Thread 5:: com.apple.uikit.eventfetch-thread
0   libsystem_kernel.dylib                 0x1b17dc190 mach_msg2_trap + 8
1   libsystem_kernel.dylib                 0x1b17ed258 mach_msg2_internal + 76
2   libsystem_kernel.dylib                 0x1b17e4398 mach_msg_overwrite + 540
3   libsystem_kernel.dylib                 0x1b17dc500 mach_msg + 20
4   CoreFoundation                         0x18039a4a8 __CFRunLoopServiceMachPort + 156
5   CoreFoundation                         0x180394ad4 __CFRunLoopRun + 1128
6   CoreFoundation                         0x180394254 CFRunLoopRunSpecific + 584
7   Foundation                             0x180b994bc -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 208
8   Foundation                             0x180b996e0 -[NSRunLoop(NSRunLoop) runUntilDate:] + 60
9   UIKitCore                              0x109e22714 -[UIEventFetcher threadMain] + 404
10  Foundation                             0x180bbede0 __NSThread__start__ + 704
11  libsystem_pthread.dylib                0x1b1838428 _pthread_start + 116
12  libsystem_pthread.dylib                0x1b1833648 thread_start + 8

Thread 7 Crashed::  Dispatch queue: com.apple.NSURLSession-delegate
0   libsystem_kernel.dylib                 0x1b17e3fa8 __pthread_kill + 8
1   libsystem_pthread.dylib                0x1b183812c pthread_kill + 256
2   libsystem_c.dylib                      0x18012873c abort + 124
3   libsystem_malloc.dylib                 0x18019a418 malloc_vreport + 912
4   libsystem_malloc.dylib                 0x18019a698 malloc_zone_error + 100
5   libsystem_malloc.dylib                 0x18018a49c nanov2_guard_corruption_detected + 40
6   libsystem_malloc.dylib                 0x180188374 nanov2_allocate_outlined + 344
7   libsystem_malloc.dylib                 0x180188b10 nanov2_calloc + 540
8   libxpc.dylib                           0x18007dfac _xpc_alloc + 28
9   libxpc.dylib                           0x18008cf20 _xpc_dictionary_insert + 424
10  libxpc.dylib                           0x18008d604 xpc_dictionary_set_uint64 + 52
11  libsystem_trace.dylib                  0x1800656d0 _os_activity_stream_entry_encode + 72
12  libsystem_trace.dylib                  0x1800654c0 _os_activity_stream_reflect + 448
13  libsystem_trace.dylib                  0x180073470 _os_log_impl_stream + 516
14  libsystem_trace.dylib                  0x180072f70 _os_log_impl_flatten_and_send + 6924
15  libsystem_trace.dylib                  0x18007144c _os_log + 148
16  libsystem_trace.dylib                  0x180073b50 _os_log_impl + 16
17  CFNetwork                              0x183d30ce0 0x183d2a000 + 27872
18  CFNetwork                              0x183d4c170 0x183d2a000 + 139632
19  libdispatch.dylib                      0x180132ee4 _dispatch_call_block_and_release + 24
20  libdispatch.dylib                      0x180134708 _dispatch_client_callout + 16
21  libdispatch.dylib                      0x18013c77c _dispatch_lane_serial_drain + 776
22  libdispatch.dylib                      0x18013d414 _dispatch_lane_invoke + 448
23  libdispatch.dylib                      0x180149608 _dispatch_workloop_worker_thread + 768
24  libsystem_pthread.dylib                0x1b1834878 _pthread_wqthread + 284
25  libsystem_pthread.dylib                0x1b183363c start_wqthread + 8
```

Backtrace:
```
* thread #9, queue = 'com.apple.root.user-initiated-qos', stop reason = EXC_BAD_ACCESS (code=1, address=0xbeadde6d19e0)
    frame #0: 0x000000018005b808 libobjc.A.dylib`objc_msgSend + 8
    frame #1: 0x0000000180501398 CoreFoundation`mdict_rehashd + 180
    frame #2: 0x00000001804fdd3c CoreFoundation`-[__NSDictionaryM setObject:forKeyedSubscript:] + 568
  * frame #3: 0x0000000102df38dc CleverTapSDK`__39-[CTCustomTemplatesManager syncPayload]_block_invoke(.block_descriptor=0x0000600000cc5b00, templateKey="template1", template=0x0000600000c84b70, stop=NO) at CTCustomTemplatesManager.m:221:9
    frame #4: 0x00000001803d6bf0 CoreFoundation`__NSDICTIONARY_IS_CALLING_OUT_TO_A_BLOCK__ + 16
    frame #5: 0x00000001805014ec CoreFoundation`__mdict_enumerateKeysAndObjectsWithOptionsUsingBlock_block_invoke + 112
    frame #6: 0x00000001804b1e54 CoreFoundation`____NSCollectionHandleConcurrentEnumerationIfSpecified_block_invoke + 136
    frame #7: 0x0000000103a55978 libdispatch.dylib`_dispatch_client_callout2 + 16
    frame #8: 0x0000000103a6cf50 libdispatch.dylib`_dispatch_apply_invoke_and_wait + 180
    frame #9: 0x0000000103a6c33c libdispatch.dylib`_dispatch_apply_with_attr_f + 1384
    frame #10: 0x0000000103a6c4dc libdispatch.dylib`dispatch_apply + 56
    frame #11: 0x00000001804b1d8c CoreFoundation`__NSCollectionHandleConcurrentEnumerationIfSpecified + 164
    frame #12: 0x00000001804fed00 CoreFoundation`-[__NSDictionaryM enumerateKeysAndObjectsWithOptions:usingBlock:] + 188
    frame #13: 0x0000000102df2ff0 CleverTapSDK`-[CTCustomTemplatesManager syncPayload](self=0x0000600000268de0, _cmd="syncPayload") at CTCustomTemplatesManager.m:177:5
    frame #14: 0x0000000102dcd1cc CleverTapSDK`__33-[CleverTap syncCustomTemplates:]_block_invoke(.block_descriptor=0x0000600000ca8f00) at CleverTap.m:4321:37
    frame #15: 0x0000000102dabf44 CleverTapSDK`__43-[CleverTap runSerialAsyncEnsureHandshake:]_block_invoke.167(.block_descriptor=0x0000600000ca8570) at CleverTap.m:750:13
    frame #16: 0x0000000103a540f0 libdispatch.dylib`_dispatch_call_block_and_release + 24
    frame #17: 0x0000000103a5593c libdispatch.dylib`_dispatch_client_callout + 16
    frame #18: 0x0000000103a5dbd8 libdispatch.dylib`_dispatch_lane_serial_drain + 916
    frame #19: 0x0000000103a5e91c libdispatch.dylib`_dispatch_lane_invoke + 420
    frame #20: 0x0000000103a6b2f8 libdispatch.dylib`_dispatch_root_queue_drain_deferred_wlh + 324
    frame #21: 0x0000000103a6a754 libdispatch.dylib`_dispatch_workloop_worker_thread + 488
    frame #22: 0x0000000101fb7814 libsystem_pthread.dylib`_pthread_wqthread + 284
```