### PR TITLE
Expose activeContextForTemplate

### DIFF
--- a/CleverTapSDK/CleverTap.h
+++ b/CleverTapSDK/CleverTap.h
@@ -24,6 +24,7 @@
 @protocol CleverTapPushNotificationDelegate;
 #if !CLEVERTAP_NO_INAPP_SUPPORT
 @protocol CleverTapInAppNotificationDelegate;
+@class CTTemplateContext;
 #endif
 
 @protocol CTBatchSentDelegate;
@@ -1457,6 +1458,21 @@ extern NSString * _Nonnull const CleverTapProfileDidInitializeNotification;
  @param isProduction Provide `true` if Custom in-app templates and app functions must be sync in Productuon build/configuration.
  */
 - (void)syncCustomTemplates:(BOOL)isProduction;
+
+/*!
+ @method
+ 
+ @abstract
+ Retrieves the active context for a template that is currently displaying. If the provided template
+ name is not of a currently active template, this method returns nil.
+ 
+ @param templateName The template name to get the active context for.
+ 
+ @return
+ A CTTemplateContext object representing the active context for the given template name, or nil if no active context exists.
+ 
+ */
+- (CTTemplateContext * _Nullable)activeContextForTemplate:(NSString * _Nonnull)templateName;
 
 #endif
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1586,6 +1586,11 @@ static BOOL sharedInstanceErrorLogged;
 - (void)clearInAppResources:(BOOL)expiredOnly {
     [self.fileDownloader clearFileAssets:expiredOnly];
 }
+
+- (CTTemplateContext * _Nullable)activeContextForTemplate:(NSString * _Nonnull)templateName {
+    return [[self customTemplatesManager] activeContextForTemplate:templateName];
+}
+
 #endif
 
 #pragma mark Private Method


### PR DESCRIPTION
## Overview
Add `activeContextForTemplate:` to `CleverTap.h` so customers can use it for convenience.

## Implementation
Use the `CTCustomTemplatesManager` custom template manager `activeContextForTemplate:`.