### PR TITLE
[MC-1883] File download concurrency

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 		6BB778D62BFD26E000A41628 /* CTInAppNotificationDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB778D52BFD26DF00A41628 /* CTInAppNotificationDisplayDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6BB778D72BFD26E000A41628 /* CTInAppNotificationDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB778D52BFD26DF00A41628 /* CTInAppNotificationDisplayDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6BB778D92BFD277400A41628 /* CTCustomTemplatesManager-Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB778D82BFD277400A41628 /* CTCustomTemplatesManager-Internal.h */; };
+		6BBF05CE2C58E3FB0047E3D9 /* NSURLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BBF05CD2C58E3FB0047E3D9 /* NSURLSessionMock.m */; };
 		6BD334EA2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */; };
 		6BD334EB2AF2A41F0099E33E /* CTBatchSentDelegateHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */; };
 		6BD334EC2AF2A41F0099E33E /* CTBatchSentDelegateHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */; };
@@ -953,6 +954,8 @@
 		6BB778D12BF267B600A41628 /* CTTemplateContextTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTTemplateContextTest.m; sourceTree = "<group>"; };
 		6BB778D52BFD26DF00A41628 /* CTInAppNotificationDisplayDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTInAppNotificationDisplayDelegate.h; sourceTree = "<group>"; };
 		6BB778D82BFD277400A41628 /* CTCustomTemplatesManager-Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CTCustomTemplatesManager-Internal.h"; sourceTree = "<group>"; };
+		6BBF05CC2C58E3FB0047E3D9 /* NSURLSessionMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionMock.h; sourceTree = "<group>"; };
+		6BBF05CD2C58E3FB0047E3D9 /* NSURLSessionMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionMock.m; sourceTree = "<group>"; };
 		6BD334E82AF2A41F0099E33E /* CTBatchSentDelegateHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTBatchSentDelegateHelper.h; sourceTree = "<group>"; };
 		6BD334E92AF2A41F0099E33E /* CTBatchSentDelegateHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTBatchSentDelegateHelper.m; sourceTree = "<group>"; };
 		6BD334EF2AF545C70099E33E /* CTInAppStoreTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTInAppStoreTest.m; sourceTree = "<group>"; };
@@ -1514,6 +1517,8 @@
 				6B9E95B22C2868470002D557 /* CTFileDownloadManager+Tests.h */,
 				6B9E95B32C29C2F30002D557 /* NSFileManagerMock.h */,
 				6B9E95B42C29C2F30002D557 /* NSFileManagerMock.m */,
+				6BBF05CC2C58E3FB0047E3D9 /* NSURLSessionMock.h */,
+				6BBF05CD2C58E3FB0047E3D9 /* NSURLSessionMock.m */,
 			);
 			path = FileDownload;
 			sourceTree = "<group>";
@@ -2495,6 +2500,7 @@
 				32394C2529FA272600956058 /* CTValidatorTest.m in Sources */,
 				6BB778CE2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m in Sources */,
 				6BA3B2E82B07E207004E834B /* CTTriggersMatcher+Tests.m in Sources */,
+				6BBF05CE2C58E3FB0047E3D9 /* NSURLSessionMock.m in Sources */,
 				6B32A0A52B9A0F17009ADC57 /* CTCustomTemplateTest.m in Sources */,
 				4E1F155B276B662C009387AE /* EventDetail.m in Sources */,
 				6B4A0F912B45EF6D00A42C6D /* CTInAppTriggerManagerTest.m in Sources */,

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -96,7 +96,8 @@ static NSString *const kCLTAP_COMMAND_DELETE = @"$delete";
 #define CLTAP_FILE_URLS_EXPIRY_DICT @"file_urls_expiry_dict"
 #define CLTAP_FILE_ASSETS_LAST_DELETED_TS @"cs_file_assets_last_deleted_timestamp"
 #define CLTAP_FILE_EXPIRY_OFFSET (60 * 60 * 24 * 7 * 2) // 2 weeks
-#define CLTAP_FILE_RESOURCE_TIME_OUT_INTERVAL 15
+#define CLTAP_FILE_RESOURCE_TIME_OUT_INTERVAL 25
+#define CLTAP_FILE_MAX_CONCURRENCY_COUNT 10
 #define CLTAP_FILES_DIRECTORY_NAME @"CleverTap_Files"
 
 #pragma mark Constants for App fields

--- a/CleverTapSDK/FileDownload/CTFileDownloadManager.m
+++ b/CleverTapSDK/FileDownload/CTFileDownloadManager.m
@@ -170,7 +170,10 @@
             if (!success) {
                 CleverTapLogInternal(self.config.logLevel, @"%@ Failed to remove file %@ - %@", self, [file absoluteString], error);
             }
-            [filesDeleteStatus setObject:@(success) forKey:[file path]];
+            // Synchronize access to the dictionary
+            @synchronized (filesDeleteStatus) {
+                [filesDeleteStatus setObject:@(success) forKey:[file path]];
+            }
             dispatch_group_leave(deleteGroup);
         });
     }

--- a/CleverTapSDK/FileDownload/CTFileDownloadManager.m
+++ b/CleverTapSDK/FileDownload/CTFileDownloadManager.m
@@ -10,6 +10,7 @@
 @property (nonatomic, strong) NSMutableDictionary<NSURL *, NSMutableArray<DownloadCompletionHandler> *> *downloadInProgressHandlers;
 @property (nonatomic, strong) NSURLSession *session;
 @property (nonatomic, strong) NSFileManager* fileManager;
+@property NSTimeInterval semaphoreTimeout;
 
 @end
 
@@ -37,6 +38,8 @@
         NSURLSessionConfiguration *sc = [NSURLSessionConfiguration defaultSessionConfiguration];
         sc.timeoutIntervalForRequest = CLTAP_REQUEST_TIME_OUT_INTERVAL;
         sc.timeoutIntervalForResource = CLTAP_FILE_RESOURCE_TIME_OUT_INTERVAL;
+        // Timeout of (request timeout + 5) seconds for acquiring semaphore
+        self.semaphoreTimeout = CLTAP_FILE_RESOURCE_TIME_OUT_INTERVAL + 5;
         
         self.session = [NSURLSession sessionWithConfiguration:sc];
         self.fileManager = [NSFileManager defaultManager];
@@ -50,9 +53,20 @@
   withCompletionBlock:(nonnull CTFilesDownloadCompletedBlock)completion {
     dispatch_group_t group = dispatch_group_create();
     dispatch_queue_t concurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(CLTAP_FILE_MAX_CONCURRENCY_COUNT);
+
     NSMutableDictionary<NSString *,id> *filesDownloadStatus = [NSMutableDictionary new];
     for (NSURL *url in urls) {
         dispatch_group_enter(group);
+        
+        dispatch_time_t semaphore_timeout = dispatch_time(DISPATCH_TIME_NOW,
+                                                          self.semaphoreTimeout * NSEC_PER_SEC);
+        if (dispatch_semaphore_wait(semaphore, semaphore_timeout) != 0) {
+            [filesDownloadStatus setObject:@0 forKey:[url absoluteString]];
+            dispatch_group_leave(group);
+            continue; // Proceed to next URL
+        }
+        
         @synchronized (self) {
             BOOL isAlreadyDownloading = [_downloadInProgressUrls containsObject:url];
             if (isAlreadyDownloading) {
@@ -65,6 +79,7 @@
                     @synchronized (self) {
                         [filesDownloadStatus setObject:[NSNumber numberWithBool:success] forKey:[completedURL absoluteString]];
                         dispatch_group_leave(group);
+                        dispatch_semaphore_signal(semaphore); // Signal that a slot is free
                     }
                 }];
                 continue;
@@ -91,14 +106,17 @@
                         handler(url, success);
                     }
                     dispatch_group_leave(group);
+                    dispatch_semaphore_signal(semaphore); // Signal that a slot is free
                 }];
             });
         } else {
             // Add the file url to callback as success true as it is already present
             [filesDownloadStatus setObject:@1 forKey:[url absoluteString]];
             dispatch_group_leave(group);
+            dispatch_semaphore_signal(semaphore); // Signal that a slot is free
         }
     }
+    
     dispatch_group_notify(group, concurrentQueue, ^{
         // Callback when all files are downloaded with their success status
         completion(filesDownloadStatus);

--- a/CleverTapSDKTests/FileDownload/CTFileDownloadManager+Tests.h
+++ b/CleverTapSDKTests/FileDownload/CTFileDownloadManager+Tests.h
@@ -15,6 +15,9 @@
 
 @property (nonatomic, strong) NSURLSession *session;
 @property (nonatomic, strong) NSFileManager* fileManager;
+@property NSTimeInterval semaphoreTimeout;
+
+- (instancetype)initWithConfig:(CleverTapInstanceConfig *)config;
 
 - (void)downloadSingleFile:(NSURL *)url
 completed:(void(^)(BOOL success))completedBlock;

--- a/CleverTapSDKTests/FileDownload/NSURLSessionMock.h
+++ b/CleverTapSDKTests/FileDownload/NSURLSessionMock.h
@@ -1,0 +1,29 @@
+//
+//  NSURLSessionMock.h
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 30.07.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSURLSessionMock : NSURLSession
+
+@property (nonatomic, assign) NSTimeInterval delayInterval;
+
+@end
+
+@interface NSURLSessionDownloadTaskMock : NSURLSessionDownloadTask
+
+@property (nonatomic, copy) void (^completionHandler)(NSURL * _Nullable, NSURLResponse * _Nullable, NSError * _Nullable);
+@property (nonatomic, assign) NSTimeInterval delayInterval;
+
+- (instancetype)initWithCompletionHandler:(void (^)(NSURL *, NSURLResponse *, NSError *))completionHandler
+                            delayInterval:(NSTimeInterval)delayInterval;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTapSDKTests/FileDownload/NSURLSessionMock.m
+++ b/CleverTapSDKTests/FileDownload/NSURLSessionMock.m
@@ -1,0 +1,41 @@
+//
+//  NSURLSessionMock.m
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 30.07.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import "NSURLSessionMock.h"
+
+@implementation NSURLSessionMock
+
+- (NSURLSessionDownloadTask *)downloadTaskWithURL:(NSURL *)url completionHandler:(void (^)(NSURL * _Nullable, NSURLResponse * _Nullable, NSError * _Nullable))completionHandler {
+    return [[NSURLSessionDownloadTaskMock alloc] initWithCompletionHandler:completionHandler delayInterval:self.delayInterval];
+}
+
+@end
+
+@implementation NSURLSessionDownloadTaskMock
+
+- (instancetype)initWithCompletionHandler:(void (^)(NSURL *, NSURLResponse *, NSError *))completionHandler
+                            delayInterval:(NSTimeInterval)delayInterval {
+    self = [super init];
+    if (self) {
+        _completionHandler = [completionHandler copy];
+        _delayInterval = delayInterval;
+    }
+    return self;
+}
+
+- (void)resume {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.delayInterval * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if (self.completionHandler) {
+            self.completionHandler(nil, nil, [NSError errorWithDomain:@"MockErrorDomain" code:-1001 userInfo:@{NSLocalizedDescriptionKey: @"Timeout"}]);
+        }
+    });
+}
+
+@end
+
+


### PR DESCRIPTION
## Overview
Set maximum concurrent downloads. Increate the resource timeout. Wait for slow downloads to complete.

## Implementation
1. Add semaphore with max concurrent download count. Set the timeout of the semaphore to be slightly longer than the request timeout. Signal the semaphore when a request has finished so that the next one can start.
2. Set max concurrent count to 10. Increase resource timeout to 25 seconds. Those counts are based on testing - downloading multiple files on different network speeds.
3. Synchronize the access to the status dictionary when downloading and deleting files to prevent concurrency errors