### PR TITLE
Sync templates enumerate synchronously

### DIFF
--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager.m
@@ -172,7 +172,7 @@ static NSMutableArray<id<CTTemplateProducer>> *templateProducers;
     
     NSMutableDictionary *definitions = [NSMutableDictionary dictionary];
     NSDictionary *templates = [self templates];
-    [templates enumerateKeysAndObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(NSString * _Nonnull templateKey, CTCustomTemplate * _Nonnull template, BOOL * _Nonnull stop) {
+    [templates enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull templateKey, CTCustomTemplate * _Nonnull template, BOOL * _Nonnull stop) {
         NSMutableDictionary *templateData = [NSMutableDictionary dictionary];
         templateData[@"type"] = template.templateType;
 


### PR DESCRIPTION
## Overview
The number of templates defined is expected to be a relatively small number. The sync is performed only during integration to register the templates in the Dashboard. There is no need to enumerate concurrently.

## Implementation
Enumerate synchronously.