### PR TITLE
Fix tests build

### DIFF
--- a/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplatesManager+Tests.h
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplatesManager+Tests.h
@@ -9,6 +9,7 @@
 #ifndef CTCustomTemplatesManager_Tests_h
 #define CTCustomTemplatesManager_Tests_h
 #import "CTCustomTemplatesManager.h"
+#import "CTCustomTemplatesManager-Internal.h"
 
 @interface CTCustomTemplatesManager (Tests)
 

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplatesManagerTest.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplatesManagerTest.m
@@ -8,7 +8,6 @@
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
-#import "CTCustomTemplatesManager-Internal.h"
 #import "CTCustomTemplatesManager+Tests.h"
 #import "CTInAppTemplateBuilder.h"
 #import "CTAppFunctionBuilder.h"


### PR DESCRIPTION
## Overview
Fix CleverTapSDKTests build.
Errors are `Duplicate interface declaration for class` and `Ambiguous reference`.

## Implementation 
Change where `CTCustomTemplatesManager-Internal.h` is imported.