### PR TITLE
Add import to resolve 'expected a type' error on CleverTapChannel

### DIFF
--- a/CleverTapSDK/CleverTapURLDelegate.h
+++ b/CleverTapSDK/CleverTapURLDelegate.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import "CleverTap.h"
 
 @protocol CleverTapURLDelegate <NSObject>
 


### PR DESCRIPTION
The CleverTapChannel type is not defined due to the missing header, which is causing the build error mentioned in this issue:
https://github.com/CleverTap/clevertap-react-native/issues/401