### PR TITLE
[MC-2003] Custom template dictionary swift bool

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4331,9 +4331,9 @@ static BOOL sharedInstanceErrorLogged;
 - (void)syncWithBlock:(void(^)(void))syncBlock methodName:(NSString *)methodName isProduction:(BOOL)isProduction {
     if (isProduction) {
 #if DEBUG
-        CleverTapLogInfo(_config.logLevel, @"%@: Calling %@: with isProduction:YES from Debug configuration/build. Use syncVariables in this case", self, methodName);
+        CleverTapLogInfo(_config.logLevel, @"%@: Calling %@ with isProduction:YES from Debug configuration/build. Do not use isProduction:YES in this case", self, methodName);
 #else
-        CleverTapLogInfo(_config.logLevel, @"%@: Calling %@: with isProduction:YES from Release configuration/build. Do not release this build and use with caution", self, methodName);
+        CleverTapLogInfo(_config.logLevel, @"%@: Calling %@ with isProduction:YES from Release configuration/build. Do not release this build and use with caution", self, methodName);
 #endif
         [self runSerialAsyncEnsureHandshake:syncBlock];
     } else {

--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplateBuilder.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplateBuilder.m
@@ -130,7 +130,16 @@
         if ([value isKindOfClass:[NSString class]]) {
             [self addArgument:argName withString:value];
         } else if ([value isKindOfClass:[NSNumber class]]) {
-            [self addArgument:argName withNumber:value];
+            // If the NSNumber is a boolean, use addArgument:withBool:
+            // so the values are correctly mapped to the type.
+            // This is required so dictionary arguments with booleans defined in Swift
+            // have correct type and value.
+            // Booleans are of class __NSCFBoolean, Numbers are of class __NSCFNumber.
+            if ([value isKindOfClass:NSClassFromString(@"__NSCFBoolean")]) {
+                [self addArgument:argName withBool:[value boolValue]];
+            } else {
+                [self addArgument:argName withNumber:value];
+            }
         } else if ([value isKindOfClass:[NSDictionary class]]) {
             [self flatten:value name:argName];
         }

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplatesManagerTest.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTCustomTemplatesManagerTest.m
@@ -278,6 +278,77 @@
     XCTAssertEqualObjects(syncPayload, expectedPayload);
 }
 
+- (void)testSyncPayloadDictionaryBooleans {
+    NSMutableSet *templates = [NSMutableSet set];
+    CTInAppTemplateBuilder *templateBuilder = [[CTInAppTemplateBuilder alloc] init];
+    [templateBuilder setName:@"Template 1"];
+    [templateBuilder addArgument:@"dictionary.booleanYes" withBool:YES];
+    [templateBuilder addArgument:@"dictionary.booleanNo" withBool:NO];
+    [templateBuilder addArgument:@"dictionary.number" withNumber:@1];
+    [templateBuilder addArgument:@"dictionary" withDictionary:@{
+        @"double": @1.0,
+        @"int": @0,
+        @"boolYes": @(YES),
+        @"boolNo": @(NO)
+    }];
+    [templateBuilder setPresenter:[CTTemplatePresenterMock new]];
+    [templates addObject:[templateBuilder build]];
+    
+    CTTestTemplateProducer *producer = [[CTTestTemplateProducer alloc] initWithTemplates:templates];
+    [CTCustomTemplatesManager registerTemplateProducer:producer];
+    CTCustomTemplatesManager *manager = [self templatesManager];
+    
+    NSDictionary *syncPayload = [manager syncPayload];
+    NSDictionary *expectedPayload = @{
+        @"type": @"templatePayload",
+        @"definitions": @{
+            @"Template 1": @{
+                @"type": TEMPLATE_TYPE,
+                @"vars": @{
+                    @"dictionary.booleanNo": @{
+                        @"defaultValue": @0,
+                        @"order": @0,
+                        @"type": @"boolean"
+                    },
+                    @"dictionary.booleanYes": @{
+                        @"defaultValue": @1,
+                        @"order": @1,
+                        @"type": @"boolean"
+                    },
+                    @"dictionary.boolNo": @{
+                        @"defaultValue": @0,
+                        @"order": @2,
+                        @"type": @"boolean"
+                    },
+                    @"dictionary.boolYes": @{
+                        @"defaultValue": @1,
+                        @"order": @3,
+                        @"type": @"boolean"
+                    },
+                    @"dictionary.double": @{
+                        @"defaultValue": @1.0,
+                        @"order": @4,
+                        @"type": @"number"
+                    },
+                    @"dictionary.int": @{
+                        @"defaultValue": @0,
+                        @"order": @5,
+                        @"type": @"number"
+                    },
+                    @"dictionary.number": @{
+                        @"defaultValue": @1,
+                        @"order": @6,
+                        @"type": @"number"
+                    }
+                }
+            }
+        }
+    };
+    
+    XCTAssertEqual([syncPayload[@"definitions"] count], 1);
+    XCTAssertEqualObjects(syncPayload, expectedPayload);
+}
+
 - (void)testTemplatesRegistered {
     NSMutableSet *templates = [NSMutableSet set];
     

--- a/CleverTapSDKTests/InApps/CustomTemplates/CTTemplateContextTest.m
+++ b/CleverTapSDKTests/InApps/CustomTemplates/CTTemplateContextTest.m
@@ -270,6 +270,45 @@
     XCTAssertTrue([innermostMap isEqualToDictionary:[self.templateContext dictionaryNamed:@"map.innerMap.innermostMap"]]);
 }
 
+- (void)testDictionaryBoolArguments {
+    NSDictionary *notificationJson = @{
+        @"templateName": TEMPLATE_NAME_NESTED,
+        @"type": @"custom-code",
+        @"vars": @{
+            @"map.double": @(0.0),
+            @"map.boolFalse": @(YES),
+            @"map.bool": @(NO)
+        }
+    };
+    CTInAppNotification *notification = [[CTInAppNotification alloc] initWithJSON:notificationJson];
+    
+    CTInAppTemplateBuilder *templateBuilder = [[CTInAppTemplateBuilder alloc] init];
+    [templateBuilder setName:TEMPLATE_NAME_NESTED];
+    [templateBuilder addArgument:@"map" withDictionary:@{
+        @"int": @0,
+        @"double": @1.0,
+        @"boolFalse": @(NO),
+        @"boolTrue": @(YES),
+        @"bool": @(YES)
+    }];
+    [templateBuilder setPresenter:[CTTemplatePresenterMock new]];
+    CTCustomTemplate *template = [templateBuilder build];
+    
+    CTTemplateContext *context = [[CTTemplateContext alloc] initWithTemplate:template notification:notification andFileDownloader:self.fileDownloader];
+    
+    NSDictionary *map = [context dictionaryNamed:@"map"];
+    NSDictionary *notificationVars = notificationJson[@"vars"];
+    XCTAssertEqualObjects(@0, map[@"int"]);
+    XCTAssertEqualObjects(notificationVars[@"map.double"], map[@"double"]);
+    XCTAssertEqualObjects(@YES, map[@"boolTrue"]);
+    XCTAssertEqualObjects(notificationVars[@"map.boolFalse"], map[@"boolFalse"]);
+    XCTAssertEqualObjects(@([context boolNamed:@"map.boolFalse"]), map[@"boolFalse"]);
+    XCTAssertEqualObjects(@([context boolNamed:@"map.boolFalse"]), @(YES));
+    XCTAssertEqualObjects(notificationVars[@"map.bool"], map[@"bool"]);
+    XCTAssertEqualObjects(@([context boolNamed:@"map.bool"]), map[@"bool"]);
+    XCTAssertEqualObjects(@([context boolNamed:@"map.bool"]), @(NO));
+}
+
 - (void)testActionsValueInDictionary {
     NSDictionary *actionsMap = [self.templateContext dictionaryNamed:@"map.actions"];
     XCTAssertEqualObjects(VARS_ACTION_FUNCTION_NAME, actionsMap[@"function"]);


### PR DESCRIPTION
| JIRA | [MC-2003](https://wizrocket.atlassian.net/browse/MC-2003) |
|-|-|

## Overview
Defining a boolean inside a dictionary in swift, results in an error when syncing it.
The definition is:
```swift
templateBuilder.addArgument("map", dictionary: [
    "int": 0,
    "bool": true
])
```
Error:
```
Define Custom Templates error: Variable `map.bool` has value that does not conform to its type.
```
The default value is sent as `true` but the type is set as `number`.

The same definition works in objective-c. 
The `bool` can be defined inside the map using dot notation `map.bool` successfully.

## Implementation
Check the inner type of the `NSNumber` to find if it is a boolean `__NSCFBoolean` or a number `__NSCFNumber`.

## Testing
Unit tests and Manual QA

[MC-2003]: https://wizrocket.atlassian.net/browse/MC-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ