### PR TITLE
[MC-1886] Do not handle push on launch if Leanplum library

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1168,7 +1168,11 @@ static BOOL sharedInstanceErrorLogged;
     if (launchOptions && launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey]) {
         NSDictionary *notification = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
         CleverTapLogDebug(self.config.logLevel, @"%@: found push notification at launch: %@", self, notification);
-        [self _handlePushNotification:notification];
+        if ([self.deviceInfo.library isEqualToString:@"Leanplum"]) {
+            CleverTapLogDebug(self.config.logLevel, @"%@: Leanplum will handle the notification: %@", self, notification);
+        } else {
+            [self _handlePushNotification:notification];
+        }
     }
 #endif
 }


### PR DESCRIPTION
| JIRA | [MC-1886](https://wizrocket.atlassian.net/browse/MC-1886) |
|-|-|

## Overview
CleverTap push notification open action is handled twice when using Leanplum SDK. The notification is handled by the `application:didFinishLaunchingWithOptions:` in CleverTap and also handled from `UNUserNotificationCenterDelegate` `didReceive` method.
If the notification is _not_ handled by Leanplum, there are cases where it is _not_ handled at all. This happens when the application already became active and CleverTap does _not_ handle the deeplink since app is in foreground. The method `_appEnteredForegroundWithLaunchingOptions` calls `_handlePushNotification` with the launch options which passes `openDeepLinksInForeground:NO`.

## Implementation
Check if the library is `Leanplum`. Do _not_ handle the notification in this case, and log a message.

## Testing
Manual QA

[MC-1886]: https://wizrocket.atlassian.net/browse/MC-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ