### PR TITLE
Enable internal logs and debugger if log level is Debug

### DIFF
--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -10,10 +10,10 @@ extern NSString *const kSessionId;
 
 #define CleverTapLogInfo(level, fmt, ...)  if(level >= 0) { NSLog((@"%@" fmt), @"[CleverTap]: ", ##__VA_ARGS__); }
 #define CleverTapLogDebug(level, fmt, ...) if(level > 0) { NSLog((@"%@" fmt), @"[CleverTap]: ", ##__VA_ARGS__); }
-#define CleverTapLogInternal(level, fmt, ...) if (level > 1) { NSLog((@"%@" fmt), @"[CleverTap]: ", ##__VA_ARGS__); }
+#define CleverTapLogInternal(level, fmt, ...) if (level >= 1) { NSLog((@"%@" fmt), @"[CleverTap]: ", ##__VA_ARGS__); }
 #define CleverTapLogStaticInfo(fmt, ...)  if([CTLogger getDebugLevel] >= 0) { NSLog((@"%@" fmt), @"[CleverTap]: ", ##__VA_ARGS__); }
 #define CleverTapLogStaticDebug(fmt, ...) if([CTLogger getDebugLevel] > 0) { NSLog((@"%@" fmt), @"[CleverTap]: ", ##__VA_ARGS__); }
-#define CleverTapLogStaticInternal(fmt, ...) if([CTLogger getDebugLevel] > 1) { NSLog((@"%@" fmt), @"[CleverTap]: ", ##__VA_ARGS__); }
+#define CleverTapLogStaticInternal(fmt, ...) if([CTLogger getDebugLevel] >= 1) { NSLog((@"%@" fmt), @"[CleverTap]: ", ##__VA_ARGS__); }
 
 #define CT_TRY @try {
 #define CT_END_TRY }\

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -873,7 +873,7 @@ static BOOL sharedInstanceErrorLogged;
     }
     
     // Adds debug flag to show errors and events on the dashboard - integration-debugger when dubug level is set to 3
-    if ([CleverTap getDebugLevel] == 3){
+    if ([CleverTap getDebugLevel] >= CleverTapLogDebug){
         header[@"debug"] = @YES;
     }
     


### PR DESCRIPTION
## Overview 
1. Log Internal logs (`CleverTapLogInternal` and `CleverTapLogStaticInternal`) if the log level is Debug.
2. Enable the Integration Debugger if the log level is Debug.

The log level enum for reference:
```
typedef NS_ENUM(int, CleverTapLogLevel) {
    CleverTapLogOff = -1,
    CleverTapLogInfo = 0,
    CleverTapLogDebug = 1
};
```

## Implementation
Check if the log level is `CleverTapLogDebug` (1) or greater.