### PR TITLE
Added push and pop validation in synchronized block

### DIFF
--- a/CleverTapSDK/CTValidationResultStack.m
+++ b/CleverTapSDK/CTValidationResultStack.m
@@ -41,20 +41,26 @@
         CleverTapLogInternal(self.config.logLevel, @"%@: no object in the validation result", self);
         return;
     }
-    [self.pendingValidationResults addObject:vr];
-    if (self.pendingValidationResults && [self.pendingValidationResults count] > 50) {
-        [self.pendingValidationResults removeObjectAtIndex:0];
+    
+    @synchronized (self.pendingValidationResults) {
+        [self.pendingValidationResults addObject:vr];
+        if (self.pendingValidationResults.count > 50) {
+            [self.pendingValidationResults removeObjectAtIndex:0];
+        }
     }
 }
 
 - (CTValidationResult *)popValidationResult {
     CTValidationResult *vr = nil;
-    if (self.pendingValidationResults && [self.pendingValidationResults count] > 0) {
-        vr = self.pendingValidationResults[0];
-        [self.pendingValidationResults removeObjectAtIndex:0];
+    
+    @synchronized (self.pendingValidationResults) {
+        if (self.pendingValidationResults.count > 0) {
+            vr = self.pendingValidationResults[0];
+            [self.pendingValidationResults removeObjectAtIndex:0];
+        }
     }
+    
     return vr;
 }
-
 
 @end


### PR DESCRIPTION
| What           | Where/Who                         |
|----------------|-----------------------------------|
| JIRA Issue     | [SDK-4102](https://wizrocket.atlassian.net/browse/SDK-4102)                           |
| People Involved| [@akashvercetti](https://github.com/akashvercetti) [@kushCT](https://github.com/kushCT)  |


## Background

Some clients are facing crashes in their application from the CTValidator class. The issue might be due to accessing invalid memory while the validations results are been added to the stack or been removed. To avoid this, we have added them in synchronized blocks

## Implementation

- Updated CTValidator class with synchronized blocks while pushing and popping Validation results.

## Testing steps

Manual.

## Is this change backwards-compatible?

No.

[SDK-4102]: https://wizrocket.atlassian.net/browse/SDK-4102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ