### PR TITLE
[MC-2263] Use weak reference check in controller hide

### DIFF
--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -196,17 +196,30 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
 }
 
 - (void)hideFromWindow:(BOOL)animated {
+    [self hideFromWindow:animated withCompletion:nil];
+}
+
+- (void)hideFromWindow:(BOOL)animated withCompletion:(void (^)(void))completion {
+    __weak typeof(self) weakSelf = self;
     void (^completionBlock)(void) = ^ {
-        [self.window removeFromSuperview];
-        self.window = nil;
-        if (self.delegate && [self.delegate respondsToSelector:@selector(notificationDidDismiss:fromViewController:)]) {
-            [self.delegate notificationDidDismiss:self.notification fromViewController:self];
+        if (!weakSelf) {
+            return;
+        }
+        if (weakSelf.window) {
+            [weakSelf.window removeFromSuperview];
+            weakSelf.window = nil;
+        }
+        if (weakSelf.delegate && [weakSelf.delegate respondsToSelector:@selector(notificationDidDismiss:fromViewController:)]) {
+            [weakSelf.delegate notificationDidDismiss:weakSelf.notification fromViewController:weakSelf];
+        }
+        if (completion) {
+            completion();
         }
     };
     
     if (animated) {
         [UIView animateWithDuration:0.25 animations:^{
-            self.window.alpha = 0;
+            weakSelf.window.alpha = 0;
         } completion:^(BOOL finished) {
             completionBlock();
         }];
@@ -215,7 +228,6 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
         completionBlock();
     }
 }
-
 
 #pragma mark - CTInAppPassThroughViewDelegate
 

--- a/CleverTapSDK/CTInAppDisplayViewControllerPrivate.h
+++ b/CleverTapSDK/CTInAppDisplayViewControllerPrivate.h
@@ -22,6 +22,7 @@
 
 - (void)showFromWindow:(BOOL)animated;
 - (void)hideFromWindow:(BOOL)animated;
+- (void)hideFromWindow:(BOOL)animated withCompletion:(void (^)(void))completion;
 
 - (void)tappedDismiss;
 - (void)buttonTapped:(UIButton*)button;

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -510,29 +510,6 @@ typedef enum {
     }
 }
 
-- (void)hideFromWindow:(BOOL)animated {
-    void (^completionBlock)(void) = ^ {
-        [self->webView.configuration.userContentController removeScriptMessageHandlerForName:@"clevertap"];
-        [self.window removeFromSuperview];
-        self.window = nil;
-        if (self.delegate && [self.delegate respondsToSelector:@selector(notificationDidDismiss:fromViewController:)]) {
-            [self.delegate notificationDidDismiss:self.notification fromViewController:self];
-        }
-    };
-    
-    if (animated) {
-        [UIView animateWithDuration:0.25 animations:^{
-            self.window.alpha = 0;
-        } completion:^(BOOL finished) {
-            completionBlock();
-        }];
-    }
-    else {
-        completionBlock();
-    }
-}
-
-
 #pragma mark - Public
 
 - (void)show:(BOOL)animated {
@@ -541,7 +518,14 @@ typedef enum {
 }
 
 - (void)hide:(BOOL)animated {
-    [self hideFromWindow:animated];
+    __weak typeof(self) weakSelf = self;
+    [self hideFromWindow:animated withCompletion:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        [strongSelf->webView.configuration.userContentController removeScriptMessageHandlerForName:@"clevertap"];
+    }];
 }
 
 @end


### PR DESCRIPTION
## Overview
- Use weak reference check in in-apps controller `hideFromWindow:` which dismisses the in-apps
- Mitigate potential crash on `[CTInAppHTMLViewController hideFromWindow:]`

## Implementation
- Add a new method `hideFromWindow:completion` to `CTInAppDisplayViewController` which provides a completionBlock for `hideFromWindow:`
- Add weak reference check in `hideFromWindow:`
- Use the super `hideFromWindow:completion` in `CTInAppHTMLViewController`