### PR TITLE
[MC-2082] Implement new event storage

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		48080312292EB50D00C06E2F /* CTLocalInApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 48080310292EB50D00C06E2F /* CTLocalInApp.m */; };
 		4847D16D2CCB90E0008DC327 /* CTEventDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4847D16C2CCB90E0008DC327 /* CTEventDatabase.h */; };
 		4847D16F2CCB90F5008DC327 /* CTEventDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4847D16E2CCB90F5008DC327 /* CTEventDatabase.m */; };
+		4847D1722CDA17C2008DC327 /* CTEventDatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4847D1712CDA17C2008DC327 /* CTEventDatabaseTests.m */; };
 		487854072BF4BC4E00565685 /* CTFileDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 487854062BF4BC4E00565685 /* CTFileDownloaderTests.m */; };
 		48A2C4B92BD67DDC006C61BC /* sampleTXTStub.txt in Resources */ = {isa = PBXBuildFile; fileRef = 48A2C4B72BD67DDB006C61BC /* sampleTXTStub.txt */; };
 		48A2C4BA2BD67DDC006C61BC /* samplePDFStub.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 48A2C4B82BD67DDB006C61BC /* samplePDFStub.pdf */; };
@@ -776,6 +777,7 @@
 		48080310292EB50D00C06E2F /* CTLocalInApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTLocalInApp.m; sourceTree = "<group>"; };
 		4847D16C2CCB90E0008DC327 /* CTEventDatabase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTEventDatabase.h; sourceTree = "<group>"; };
 		4847D16E2CCB90F5008DC327 /* CTEventDatabase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTEventDatabase.m; sourceTree = "<group>"; };
+		4847D1712CDA17C2008DC327 /* CTEventDatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTEventDatabaseTests.m; sourceTree = "<group>"; };
 		487854062BF4BC4E00565685 /* CTFileDownloaderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloaderTests.m; sourceTree = "<group>"; };
 		48A2C4B72BD67DDB006C61BC /* sampleTXTStub.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sampleTXTStub.txt; sourceTree = "<group>"; };
 		48A2C4B82BD67DDB006C61BC /* samplePDFStub.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = samplePDFStub.pdf; sourceTree = "<group>"; };
@@ -1320,6 +1322,14 @@
 			path = EventDatabase;
 			sourceTree = "<group>";
 		};
+		4847D1702CDA1788008DC327 /* EventDatabase */ = {
+			isa = PBXGroup;
+			children = (
+				4847D1712CDA17C2008DC327 /* CTEventDatabaseTests.m */,
+			);
+			path = EventDatabase;
+			sourceTree = "<group>";
+		};
 		495EA4BE25554718006CADFF /* resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1592,6 +1602,7 @@
 		D02AC2D9276044F70031C1BE /* CleverTapSDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				4847D1702CDA1788008DC327 /* EventDatabase */,
 				6B9E95AD2C285F2F0002D557 /* FileDownload */,
 				4E2CF1432AC56D8F00441E8B /* CTEncryptionTests.m */,
 				6A4427C32AA6513C0098866F /* InApps */,
@@ -2528,6 +2539,7 @@
 			files = (
 				6BA3B2E12B05411C004E834B /* InAppHelper.m in Sources */,
 				32394C2529FA272600956058 /* CTValidatorTest.m in Sources */,
+				4847D1722CDA17C2008DC327 /* CTEventDatabaseTests.m in Sources */,
 				6BB778CE2BEE48C300A41628 /* CTCustomTemplateInAppDataTest.m in Sources */,
 				6BA3B2E82B07E207004E834B /* CTTriggersMatcher+Tests.m in Sources */,
 				6BBF05CE2C58E3FB0047E3D9 /* NSURLSessionMock.m in Sources */,

--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -165,6 +165,8 @@
 		4808030E292EB4FB00C06E2F /* CleverTap+PushPermission.h in Headers */ = {isa = PBXBuildFile; fileRef = 4808030D292EB4FB00C06E2F /* CleverTap+PushPermission.h */; };
 		48080311292EB50D00C06E2F /* CTLocalInApp.h in Headers */ = {isa = PBXBuildFile; fileRef = 4808030F292EB50D00C06E2F /* CTLocalInApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48080312292EB50D00C06E2F /* CTLocalInApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 48080310292EB50D00C06E2F /* CTLocalInApp.m */; };
+		4847D16D2CCB90E0008DC327 /* CTEventDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4847D16C2CCB90E0008DC327 /* CTEventDatabase.h */; };
+		4847D16F2CCB90F5008DC327 /* CTEventDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4847D16E2CCB90F5008DC327 /* CTEventDatabase.m */; };
 		487854072BF4BC4E00565685 /* CTFileDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 487854062BF4BC4E00565685 /* CTFileDownloaderTests.m */; };
 		48A2C4B92BD67DDC006C61BC /* sampleTXTStub.txt in Resources */ = {isa = PBXBuildFile; fileRef = 48A2C4B72BD67DDB006C61BC /* sampleTXTStub.txt */; };
 		48A2C4BA2BD67DDC006C61BC /* samplePDFStub.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 48A2C4B82BD67DDB006C61BC /* samplePDFStub.pdf */; };
@@ -772,6 +774,8 @@
 		4808030D292EB4FB00C06E2F /* CleverTap+PushPermission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CleverTap+PushPermission.h"; sourceTree = "<group>"; };
 		4808030F292EB50D00C06E2F /* CTLocalInApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTLocalInApp.h; sourceTree = "<group>"; };
 		48080310292EB50D00C06E2F /* CTLocalInApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTLocalInApp.m; sourceTree = "<group>"; };
+		4847D16C2CCB90E0008DC327 /* CTEventDatabase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTEventDatabase.h; sourceTree = "<group>"; };
+		4847D16E2CCB90F5008DC327 /* CTEventDatabase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTEventDatabase.m; sourceTree = "<group>"; };
 		487854062BF4BC4E00565685 /* CTFileDownloaderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTFileDownloaderTests.m; sourceTree = "<group>"; };
 		48A2C4B72BD67DDB006C61BC /* sampleTXTStub.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sampleTXTStub.txt; sourceTree = "<group>"; };
 		48A2C4B82BD67DDB006C61BC /* samplePDFStub.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = samplePDFStub.pdf; sourceTree = "<group>"; };
@@ -1307,6 +1311,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		4847D16B2CCB9018008DC327 /* EventDatabase */ = {
+			isa = PBXGroup;
+			children = (
+				4847D16C2CCB90E0008DC327 /* CTEventDatabase.h */,
+				4847D16E2CCB90F5008DC327 /* CTEventDatabase.m */,
+			);
+			path = EventDatabase;
+			sourceTree = "<group>";
+		};
 		495EA4BE25554718006CADFF /* resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1706,6 +1719,7 @@
 		D0C7BBBF207D82C0001345EF /* CleverTapSDK */ = {
 			isa = PBXGroup;
 			children = (
+				4847D16B2CCB9018008DC327 /* EventDatabase */,
 				6B9E95B62C2AE6740002D557 /* FileDownload */,
 				3242D7DA2B1DDA2E00A5E37A /* PrivacyInfo.xcprivacy */,
 				4803951A2A7ABAD200C4D254 /* CTAES.h */,
@@ -1972,6 +1986,7 @@
 				4E25E3C1278887A70008C888 /* CTIdentityRepo.h in Headers */,
 				071EB4F3217F6427008F0FAB /* CTInAppNotification.h in Headers */,
 				F9356ED42487FE4600B4F507 /* CleverTapPushNotificationDelegate.h in Headers */,
+				4847D16D2CCB90E0008DC327 /* CTEventDatabase.h in Headers */,
 				07B9453B219EA34300D4C542 /* CTInboxSimpleMessageCell.h in Headers */,
 				6BF5A5982ACEE22100CDED20 /* CleverTapJSInterfacePrivate.h in Headers */,
 				07053B7221E653E70085B44A /* UIView+CTToast.h in Headers */,
@@ -2704,6 +2719,7 @@
 				07B94540219EA34300D4C542 /* CTInboxController.m in Sources */,
 				4E25E3C4278887A70008C888 /* CTLegacyIdentityRepo.m in Sources */,
 				078C63AA22420321001FDDB8 /* CleverTapJSInterface.m in Sources */,
+				4847D16F2CCB90F5008DC327 /* CTEventDatabase.m in Sources */,
 				4E49AE55275D24570074A774 /* CTValidationResultStack.m in Sources */,
 				D01A0895207EC2D400423D6F /* CleverTapInstanceConfig.m in Sources */,
 				071EB4C8217F6427008F0FAB /* CTDismissButton.m in Sources */,

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.h
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.h
@@ -1,0 +1,29 @@
+//
+//  CTEventDatabase.h
+//  CleverTapSDK
+//
+//  Created by Nishant Kumar on 25/10/24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <sqlite3.h>
+#import "CleverTapInstanceConfig.h"
+
+@interface CTEventDatabase : NSObject
+
++ (instancetype)sharedInstanceWithConfig:(CleverTapInstanceConfig *)config;
+- (instancetype)initWithConfig:(CleverTapInstanceConfig *)config;
+
+- (BOOL)createTable;
+
+- (BOOL)insertData:(NSString *)eventName
+          deviceID:(NSString *)deviceID;
+
+- (BOOL)updateEvent:(NSString *)eventName
+        forDeviceID:(NSString *)deviceID;
+
+- (BOOL)eventExists:(NSString *)eventName
+        forDeviceID:(NSString *)deviceID;
+
+@end

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.h
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.h
@@ -26,4 +26,15 @@
 - (BOOL)eventExists:(NSString *)eventName
         forDeviceID:(NSString *)deviceID;
 
+- (NSInteger)getCountForEventName:(NSString *)eventName
+                         deviceID:(NSString *)deviceID;
+
+- (NSInteger)getFirstTimestampForEventName:(NSString *)eventName
+                                  deviceID:(NSString *)deviceID;
+
+- (NSInteger)getLastTimestampForEventName:(NSString *)eventName
+                                 deviceID:(NSString *)deviceID;
+
+- (BOOL)deleteTable;
+
 @end

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.m
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.m
@@ -1,0 +1,173 @@
+//
+//  CTEventDatabase.m
+//  CleverTapSDK
+//
+//  Created by Nishant Kumar on 25/10/24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import "CTEventDatabase.h"
+#import "CTConstants.h"
+
+@interface CTEventDatabase()
+
+@property (nonatomic, strong) CleverTapInstanceConfig *config;
+
+@end
+
+@implementation CTEventDatabase {
+    sqlite3 *_eventDatabase;
+    dispatch_queue_t _databaseQueue;
+}
+
++ (instancetype)sharedInstanceWithConfig:(CleverTapInstanceConfig *)config {
+    static CTEventDatabase *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] initWithConfig:config];
+    });
+    return sharedInstance;
+}
+
+- (instancetype)initWithConfig:(CleverTapInstanceConfig *)config {
+    if (self = [super init]) {
+        _config = config;
+        _databaseQueue = dispatch_queue_create([[NSString stringWithFormat:@"com.clevertap.eventDatabaseQueue:%@", _config.accountId] UTF8String], DISPATCH_QUEUE_CONCURRENT);
+        [self openDatabase];
+    }
+    return self;
+}
+
+- (NSString *)databasePath {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths objectAtIndex:0];
+    return [documentsDirectory stringByAppendingPathComponent:@"CleverTap-Events.db"];
+}
+
+- (BOOL)openDatabase {
+    NSString *databasePath = [self databasePath];
+    
+    if (sqlite3_open([databasePath UTF8String], &_eventDatabase) == SQLITE_OK) {
+        return YES;
+    } else {
+        CleverTapLogInternal(self.config.logLevel, @"%@ Failed to open database - CleverTap-Events.db", self);
+        return NO;
+    }
+}
+
+- (void)closeDatabase {
+    if (_eventDatabase) {
+        sqlite3_close(_eventDatabase);
+        _eventDatabase = NULL;
+    }
+}
+
+- (BOOL)createTable {
+    __block BOOL success = NO;
+    
+    dispatch_sync(_databaseQueue, ^{
+        char *errMsg;
+        const char *createTableSQL = "CREATE TABLE IF NOT EXISTS CTUserEventLogs (eventName TEXT, count INTEGER, firstTs INTEGER, lastTs INTEGER, deviceID TEXT, PRIMARY KEY (eventName, deviceID))";
+        if (sqlite3_exec(self->_eventDatabase, createTableSQL, NULL, NULL, &errMsg) == SQLITE_OK) {
+            success = YES;
+        } else {
+            CleverTapLogInternal(self.config.logLevel, @"%@ Create Table SQL error: %s", self, errMsg);
+            sqlite3_free(errMsg);
+        }
+    });
+    
+    return success;
+}
+
+- (BOOL)insertData:(NSString *)eventName
+          deviceID:(NSString *)deviceID {
+    BOOL eventExists = [self eventExists:eventName forDeviceID:deviceID];
+    if (eventExists) {
+        CleverTapLogInternal(self.config.logLevel, @"%@ Insert SQL - Event name: %@ and DeviceID: %@ already exists.", self, eventName, deviceID);
+        return NO;
+    }
+    
+    __block BOOL success = NO;
+    // For new event, set count as 1
+    NSInteger count = 1;
+    NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
+    
+    dispatch_sync(_databaseQueue, ^{
+        char *errMsg;
+        NSString *insertSQL = [NSString stringWithFormat:@"INSERT INTO CTUserEventLogs (eventName, count, firstTs, lastTs, deviceID) VALUES ('%@', %ld, %ld, %ld, '%@')", eventName, (long)count, (long)currentTs, (long)currentTs, deviceID];
+        if (sqlite3_exec(_eventDatabase, [insertSQL UTF8String], NULL, NULL, &errMsg) == SQLITE_OK) {
+            success = YES;
+        } else {
+            CleverTapLogInternal(self.config.logLevel, @"%@ Insert Table SQL error: %s", self, errMsg);
+            sqlite3_free(errMsg);
+        }
+    });
+    
+    return success;
+}
+
+- (BOOL)updateEvent:(NSString *)eventName
+        forDeviceID:(NSString *)deviceID {
+    BOOL eventExists = [self eventExists:eventName forDeviceID:deviceID];
+    if (!eventExists) {
+        CleverTapLogInternal(self.config.logLevel, @"%@ Update SQL - Event name: %@ and DeviceID: %@ doesn't exists.", self, eventName, deviceID);
+        return NO;
+    }
+    
+    NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
+    NSString *updateSQL = [NSString stringWithFormat:
+                               @"UPDATE CTUserEventLogs SET count = count + 1, lastTs = %ld WHERE eventName = '%@' AND deviceID = '%@';",
+                               (long)currentTs, eventName, deviceID];
+    __block BOOL success = NO;
+
+    dispatch_sync(_databaseQueue, ^{
+        char *errMsg;
+        int result = sqlite3_exec(_eventDatabase, [updateSQL UTF8String], NULL, NULL, &errMsg);
+
+        if (result == SQLITE_OK) {
+            success = YES;
+        } else {
+            CleverTapLogInternal(self.config.logLevel, @"%@ Update Table SQL error: %s", self, errMsg);
+        }
+    });
+
+    return success;
+}
+
+- (BOOL)eventExists:(NSString *)eventName 
+        forDeviceID:(NSString *)deviceID {
+    NSString *query = [NSString stringWithFormat:@"SELECT COUNT(*) FROM CTUserEventLogs WHERE eventName = ? AND deviceID = ?"];
+    __block BOOL exists = NO;
+    
+    dispatch_sync(_databaseQueue, ^{
+        sqlite3_stmt *statement;
+        
+        if (sqlite3_prepare_v2(_eventDatabase, [query UTF8String], -1, &statement, NULL) == SQLITE_OK) {
+            sqlite3_bind_text(statement, 1, [eventName UTF8String], -1, SQLITE_TRANSIENT);
+            sqlite3_bind_text(statement, 2, [deviceID UTF8String], -1, SQLITE_TRANSIENT);
+            
+            if (sqlite3_step(statement) == SQLITE_ROW) {
+                // Check if the count is greater than 0
+                int count = sqlite3_column_int(statement, 0);
+                if (count > 0) {
+                    exists = YES;
+                }
+            } else {
+                CleverTapLogInternal(self.config.logLevel, @"%@ SQL check query error: %s", self, sqlite3_errmsg(_eventDatabase));
+            }
+            sqlite3_finalize(statement);
+        } else {
+            CleverTapLogInternal(self.config.logLevel, @"%@ SQL prepare query error: %s", self, sqlite3_errmsg(_eventDatabase));
+        }
+    });
+    
+    return exists;
+}
+
+- (void)dealloc {
+    dispatch_sync(_databaseQueue, ^{
+        [self closeDatabase];
+    });
+}
+
+@end

--- a/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
+++ b/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
@@ -1,0 +1,144 @@
+//
+//  CTEventDatabaseTests.m
+//  CleverTapSDKTests
+//
+//  Created by Nishant Kumar on 05/11/24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "CTEventDatabase.h"
+#import "CleverTapInstanceConfig.h"
+
+static NSString *kEventName = @"Test Event";
+static NSString *kDeviceID = @"Test Device";
+
+@interface CTEventDatabaseTests : XCTestCase
+
+@property (nonatomic, strong) CleverTapInstanceConfig *config;
+@property (nonatomic, strong) CTEventDatabase *eventDatabase;
+
+@end
+
+@implementation CTEventDatabaseTests
+
+- (void)setUp {
+    [super setUp];
+    
+    self.config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"testAccountId" accountToken:@"testAccountToken"];
+    self.eventDatabase = [CTEventDatabase sharedInstanceWithConfig:self.config];
+    [self.eventDatabase createTable];
+    
+}
+
+- (void)tearDown {
+    [super tearDown];
+    
+    [self.eventDatabase deleteTable];
+}
+
+- (void)testInsertEventName {
+    BOOL insertSuccess = [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    XCTAssertTrue(insertSuccess);
+}
+
+- (void)testInsertEventNameAgain {
+    BOOL insertSuccess = [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    XCTAssertTrue(insertSuccess);
+    
+    // Insert same eventName and deviceID again
+    BOOL insertSuccessAgain = [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    XCTAssertFalse(insertSuccessAgain);
+}
+
+- (void)testEventNameExists {
+    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    
+    BOOL eventExists = [self.eventDatabase eventExists:kEventName forDeviceID:kDeviceID];
+    XCTAssertTrue(eventExists);
+}
+
+- (void)testEventNameNotExists {
+    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    
+    BOOL eventExists = [self.eventDatabase eventExists:@"Test Event 1" forDeviceID:kDeviceID];
+    XCTAssertFalse(eventExists);
+}
+
+- (void)testUpdateEventSuccess {
+    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    
+    BOOL updateSuccess = [self.eventDatabase updateEvent:kEventName forDeviceID:kDeviceID];
+    XCTAssertTrue(updateSuccess);
+}
+
+- (void)testUpdateEventFailure {
+    BOOL updateSuccess = [self.eventDatabase updateEvent:kEventName forDeviceID:kDeviceID];
+    XCTAssertFalse(updateSuccess);
+}
+
+- (void)testGetCountForEventName {
+    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    
+    [self.eventDatabase updateEvent:kEventName forDeviceID:kDeviceID];
+    
+    // count should be 2.
+    NSInteger eventCount = [self.eventDatabase getCountForEventName:kEventName deviceID:kDeviceID];
+    XCTAssertEqual(eventCount, 2);
+}
+
+- (void)testGetCountForEventNameNotExists {
+    // count should be 0.
+    NSInteger eventCount = [self.eventDatabase getCountForEventName:kEventName deviceID:kDeviceID];
+    XCTAssertEqual(eventCount, 0);
+}
+
+- (void)testFirstTimestampForEventName {
+    NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
+    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    
+    NSInteger firstTs = [self.eventDatabase getFirstTimestampForEventName:kEventName deviceID:kDeviceID];
+    XCTAssertEqual(firstTs, currentTs);
+}
+
+- (void)testLastTimestampForEventName {
+    NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
+    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    
+    NSInteger lastTs = [self.eventDatabase getLastTimestampForEventName:kEventName deviceID:kDeviceID];
+    XCTAssertEqual(lastTs, currentTs);
+}
+
+- (void)testLastTimestampForEventNameUpdated {
+    NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
+    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    
+    NSInteger lastTs = [self.eventDatabase getLastTimestampForEventName:kEventName deviceID:kDeviceID];
+    XCTAssertEqual(lastTs, currentTs);
+    
+    NSInteger newCurrentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
+    NSInteger newLastTs = [self.eventDatabase getLastTimestampForEventName:kEventName deviceID:kDeviceID];
+    XCTAssertEqual(newLastTs, newCurrentTs);
+    
+}
+
+- (void)testDeleteTableSuccess {
+    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    NSInteger eventCount = [self.eventDatabase getCountForEventName:kEventName deviceID:kDeviceID];
+    XCTAssertEqual(eventCount, 1);
+    
+    // Delete table.
+    BOOL deleteSuccess = [self.eventDatabase deleteTable];
+    XCTAssertTrue(deleteSuccess);
+    NSInteger eventCountAfterDelete = [self.eventDatabase getCountForEventName:kEventName deviceID:kDeviceID];
+    XCTAssertEqual(eventCountAfterDelete, 0);
+    
+}
+
+- (NSString *)databasePath {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths objectAtIndex:0];
+    return [documentsDirectory stringByAppendingPathComponent:@"CleverTap-Events.db"];
+}
+
+@end


### PR DESCRIPTION
## Overview
We need to implement new events storage that is persisted across sessions and on user switches. We have used `SQLite` to store data based on our requirement and it is also light weighted.

## Implementation
Created class `CTEventDatabase` which will handle storing of user events data in table `CTUserEventLogs`. The schema used is as - eventName, count, firstTs,  lastTs, deviceID where eventName and deviceID combined is used as primary key. We have added methods to create table, insert data, update data, check if event exists or not, and to get count, first and last time stamp of event for particular deviceID. Added unit tests also for these methods.