### PR TITLE
 [MC - 2090] In-memory storage events

### DIFF
--- a/CleverTapSDK/CTLocalDataStore.h
+++ b/CleverTapSDK/CTLocalDataStore.h
@@ -44,4 +44,6 @@
 
 - (void)changeUser;
 
+- (BOOL)isEventLoggedFirstTime:(NSString*)eventName;
+
 @end

--- a/CleverTapSDK/CTLocalDataStore.m
+++ b/CleverTapSDK/CTLocalDataStore.m
@@ -619,6 +619,7 @@ NSString *const CT_ENCRYPTION_KEY = @"CLTAP_ENCRYPTION_KEY";
 
 - (BOOL)isEventLoggedFirstTime:(NSString*)eventName {
     @synchronized (self.userEventLogs) {
+    // TODO: add normalisation 
         if ([self.userEventLogs containsObject:eventName]) {
             return NO;
         }


### PR DESCRIPTION
## Overview
We need to add in-memory storage for first time events and profile

## Implementation
Added in-memory collection (NSSet) for quickly accessing already tracked events. Add the event to this NSSet when the event is checked for First-time and the event exists in the database