### PR TITLE
[MC-2363] Add parsing of url params on open-url action

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 		6B32A0AD2B9DBE31009ADC57 /* CTTemplatePresenterMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B32A0AC2B9DBE31009ADC57 /* CTTemplatePresenterMock.m */; };
 		6B32A0B02B9DC374009ADC57 /* CTTemplateArgumentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B32A0AF2B9DC374009ADC57 /* CTTemplateArgumentTest.m */; };
 		6B32A0B42B9F2E8F009ADC57 /* CTTestTemplateProducer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B32A0B32B9F2E8F009ADC57 /* CTTestTemplateProducer.m */; };
+		6B453EF92CF621E3003C7A89 /* CTInAppDisplayViewControllerMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B453EF82CF621E3003C7A89 /* CTInAppDisplayViewControllerMock.m */; };
 		6B4A0F912B45EF6D00A42C6D /* CTInAppTriggerManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B4A0F902B45EF6D00A42C6D /* CTInAppTriggerManagerTest.m */; };
 		6B535FB62AD56C60002A2663 /* CTMultiDelegateManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B535FB42AD56C60002A2663 /* CTMultiDelegateManager.h */; };
 		6B535FB72AD56C60002A2663 /* CTMultiDelegateManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B535FB42AD56C60002A2663 /* CTMultiDelegateManager.h */; };
@@ -913,6 +914,8 @@
 		6B32A0B12B9F2A75009ADC57 /* CTCustomTemplatesManager+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CTCustomTemplatesManager+Tests.h"; sourceTree = "<group>"; };
 		6B32A0B22B9F2E8F009ADC57 /* CTTestTemplateProducer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTTestTemplateProducer.h; sourceTree = "<group>"; };
 		6B32A0B32B9F2E8F009ADC57 /* CTTestTemplateProducer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTTestTemplateProducer.m; sourceTree = "<group>"; };
+		6B453EF72CF621E3003C7A89 /* CTInAppDisplayViewControllerMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTInAppDisplayViewControllerMock.h; sourceTree = "<group>"; };
+		6B453EF82CF621E3003C7A89 /* CTInAppDisplayViewControllerMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTInAppDisplayViewControllerMock.m; sourceTree = "<group>"; };
 		6B4A0F902B45EF6D00A42C6D /* CTInAppTriggerManagerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTInAppTriggerManagerTest.m; sourceTree = "<group>"; };
 		6B535FB42AD56C60002A2663 /* CTMultiDelegateManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTMultiDelegateManager.h; sourceTree = "<group>"; };
 		6B535FB52AD56C60002A2663 /* CTMultiDelegateManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTMultiDelegateManager.m; sourceTree = "<group>"; };
@@ -1474,6 +1477,8 @@
 				6B4A0F902B45EF6D00A42C6D /* CTInAppTriggerManagerTest.m */,
 				6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */,
 				4806346E2CEB620400E39E9B /* CTInAppDisplayViewControllerTests.m */,
+				6B453EF72CF621E3003C7A89 /* CTInAppDisplayViewControllerMock.h */,
+				6B453EF82CF621E3003C7A89 /* CTInAppDisplayViewControllerMock.m */,
 			);
 			path = InApps;
 			sourceTree = "<group>";
@@ -2528,6 +2533,7 @@
 				6B32A0A32B99EA9D009ADC57 /* CTCustomTemplateBuilderTest.m in Sources */,
 				6B9E95B52C29C2F40002D557 /* NSFileManagerMock.m in Sources */,
 				6A7BB8DC29E47CFF00651584 /* CTVarTest.m in Sources */,
+				6B453EF92CF621E3003C7A89 /* CTInAppDisplayViewControllerMock.m in Sources */,
 				6B32A0AD2B9DBE31009ADC57 /* CTTemplatePresenterMock.m in Sources */,
 				6A2E0B9129CCCC8600FCEA5F /* ContentMergerTest.m in Sources */,
 				6A2E0B9529D49D0200FCEA5F /* CTVariables+Tests.m in Sources */,

--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		32790959299F4B29001FE140 /* CTDeviceInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 32790958299F4B29001FE140 /* CTDeviceInfoTest.m */; };
 		4803951B2A7ABAD200C4D254 /* CTAES.m in Sources */ = {isa = PBXBuildFile; fileRef = 480395192A7ABAD200C4D254 /* CTAES.m */; };
 		4803951C2A7ABAD200C4D254 /* CTAES.h in Headers */ = {isa = PBXBuildFile; fileRef = 4803951A2A7ABAD200C4D254 /* CTAES.h */; };
+		4806346F2CEB620400E39E9B /* CTInAppDisplayViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4806346E2CEB620400E39E9B /* CTInAppDisplayViewControllerTests.m */; };
 		4808030E292EB4FB00C06E2F /* CleverTap+PushPermission.h in Headers */ = {isa = PBXBuildFile; fileRef = 4808030D292EB4FB00C06E2F /* CleverTap+PushPermission.h */; };
 		48080311292EB50D00C06E2F /* CTLocalInApp.h in Headers */ = {isa = PBXBuildFile; fileRef = 4808030F292EB50D00C06E2F /* CTLocalInApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48080312292EB50D00C06E2F /* CTLocalInApp.m in Sources */ = {isa = PBXBuildFile; fileRef = 48080310292EB50D00C06E2F /* CTLocalInApp.m */; };
@@ -769,6 +770,7 @@
 		32790958299F4B29001FE140 /* CTDeviceInfoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTDeviceInfoTest.m; sourceTree = "<group>"; };
 		480395192A7ABAD200C4D254 /* CTAES.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTAES.m; sourceTree = "<group>"; };
 		4803951A2A7ABAD200C4D254 /* CTAES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTAES.h; sourceTree = "<group>"; };
+		4806346E2CEB620400E39E9B /* CTInAppDisplayViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTInAppDisplayViewControllerTests.m; sourceTree = "<group>"; };
 		4808030D292EB4FB00C06E2F /* CleverTap+PushPermission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CleverTap+PushPermission.h"; sourceTree = "<group>"; };
 		4808030F292EB50D00C06E2F /* CTLocalInApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTLocalInApp.h; sourceTree = "<group>"; };
 		48080310292EB50D00C06E2F /* CTLocalInApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTLocalInApp.m; sourceTree = "<group>"; };
@@ -1471,6 +1473,7 @@
 				6BA3B2E72B07E207004E834B /* CTTriggersMatcher+Tests.m */,
 				6B4A0F902B45EF6D00A42C6D /* CTInAppTriggerManagerTest.m */,
 				6BB778CF2BEE4C3400A41628 /* CTNotificationActionTest.m */,
+				4806346E2CEB620400E39E9B /* CTInAppDisplayViewControllerTests.m */,
 			);
 			path = InApps;
 			sourceTree = "<group>";
@@ -2532,6 +2535,7 @@
 				6A2E0B9829D49D5100FCEA5F /* CTVarCacheMock.m in Sources */,
 				4EAF05022A495DD5009D9D61 /* CleverTapInstanceTests.m in Sources */,
 				6BB778D22BF267B600A41628 /* CTTemplateContextTest.m in Sources */,
+				4806346F2CEB620400E39E9B /* CTInAppDisplayViewControllerTests.m in Sources */,
 				6A2E0B9329D0A5CF00FCEA5F /* CTVariablesTest.m in Sources */,
 				D02AC2DB276044F70031C1BE /* CleverTapSDKTests.m in Sources */,
 				32394C2129FA264B00956058 /* CTPreferencesTest.m in Sources */,

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -235,6 +235,8 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_INAPP_HTML_SPLIT @"\"##Vars##\""
 #define CLTAP_INAPP_IMAGE_INTERSTITIAL_HTML_NAME @"image_interstitial"
 
+#define CLTAP_URL_PARAM_DL_SEPARATOR @"__dl__"
+
 #pragma mark Constants for persisting system data
 #define CLTAP_SYS_CARRIER @"sysCarrier"
 #define CLTAP_SYS_CC @"sysCountryCode"

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -315,27 +315,27 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
 
 - (void)triggerInAppAction:(CTNotificationAction *)action callToAction:(NSString *)callToAction buttonId:(NSString *)buttonId {
     NSMutableDictionary *extras = [NSMutableDictionary new];
-    NSString *urlString = [action.actionURL absoluteString];
     
     if (action.type == CTInAppActionTypeOpenURL) {
+        NSString *urlString = [action.actionURL absoluteString];
         NSMutableDictionary *mutableParams = [CTInAppUtils getParametersFromURL:urlString];
         
         if (mutableParams[@"params"]) {
             extras = [mutableParams[@"params"] mutableCopy];
             
-            // Use the url from the callToAction param to update action
+            // Use the url from the deeplink to update the action if such is set
             if (mutableParams[@"deeplink"]) {
                 action = [[CTNotificationAction alloc] initWithOpenURL:mutableParams[@"deeplink"]];
             }
         }
     }
     
-    // Added NSNull class check as we may receive callToAction value as NULL class
-    // when null is passed as value for key callToAction in webView message.
-    if (callToAction && ![callToAction isKindOfClass:[NSNull class]]) {
+    // callToAction, buttonId and notification id take precedence over
+    // the URL parameters if those have been set in the URL
+    if (callToAction) {
         extras[CLTAP_PROP_WZRK_CTA] = callToAction;
     }
-    if (buttonId && ![buttonId isKindOfClass:[NSNull class]]) {
+    if (buttonId) {
         extras[@"button_id"] = buttonId;
     }
     NSString *campaignId = self.notification.campaignId;

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -353,10 +353,12 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
         }
     }
     
-    if (callToAction) {
+    // Added NSNull class check as we may receive callToAction value as NULL class
+    // when null is passed as value for key callToAction in webView message.
+    if (callToAction && ![callToAction isKindOfClass:[NSNull class]]) {
         extras[CLTAP_PROP_WZRK_CTA] = callToAction;
     }
-    if (buttonId) {
+    if (buttonId && ![buttonId isKindOfClass:[NSNull class]]) {
         extras[@"button_id"] = buttonId;
     }
     NSString *campaignId = self.notification.campaignId;

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -315,41 +315,18 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
 
 - (void)triggerInAppAction:(CTNotificationAction *)action callToAction:(NSString *)callToAction buttonId:(NSString *)buttonId {
     NSMutableDictionary *extras = [NSMutableDictionary new];
+    NSString *urlString = [action.actionURL absoluteString];
+    
     if (action.type == CTInAppActionTypeOpenURL) {
-        NSMutableDictionary *mutableParams = [NSMutableDictionary new];
-        NSString *urlString = [action.actionURL absoluteString];
-        NSURL *dl = [NSURL URLWithString:urlString];
+        NSMutableDictionary *mutableParams = [CTInAppUtils getParametersFromURL:urlString];
         
-        // Try to extract the parameters from the URL and overrite default dl if applicable
-        NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
-        NSArray *comps = [urlString componentsSeparatedByString:@"?"];
-        if ([comps count] >= 2) {
-            // Extract the parameters and store in params dictionary
-            NSString *query = comps[1];
-            for (NSString *param in [query componentsSeparatedByString:@"&"]) {
-                NSArray *elts = [param componentsSeparatedByString:@"="];
-                if ([elts count] < 2) continue;
-                params[elts[0]] = [elts[1] stringByRemovingPercentEncoding];
-            };
-            mutableParams = [params mutableCopy];
+        if (mutableParams[@"params"]) {
+            extras = [mutableParams[@"params"] mutableCopy];
             
-            // Check for wzrk_c2a key, if present update its value after parsing with __dl__
-            NSString *c2a = params[CLTAP_PROP_WZRK_CTA];
-            if (c2a) {
-                c2a = [c2a stringByRemovingPercentEncoding];
-                NSArray *parts = [c2a componentsSeparatedByString:@"__dl__"];
-                if (parts && [parts count] == 2) {
-                    dl = [NSURL URLWithString:parts[1]];
-                    mutableParams[CLTAP_PROP_WZRK_CTA] = parts[0];
-                    
-                    // Use the url from the callToAction param to update action
-                    action = [[CTNotificationAction alloc] initWithOpenURL:dl];
-                }
+            // Use the url from the callToAction param to update action
+            if (mutableParams[@"deeplink"]) {
+                action = [[CTNotificationAction alloc] initWithOpenURL:mutableParams[@"deeplink"]];
             }
-        }
-        
-        if (mutableParams) {
-            extras = mutableParams;
         }
     }
     

--- a/CleverTapSDK/CTInAppUtils.h
+++ b/CleverTapSDK/CTInAppUtils.h
@@ -31,8 +31,13 @@ typedef NS_ENUM(NSUInteger, CTInAppActionType){
 + (NSString * _Nonnull)inAppTypeString:(CTInAppType)type;
 + (CTInAppActionType)inAppActionTypeFromString:(NSString *_Nonnull)type;
 + (NSString * _Nonnull)inAppActionTypeString:(CTInAppActionType)type;
-+ (NSBundle *_Nullable)bundle;
-+ (NSString *_Nullable)getXibNameForControllerName:(NSString *_Nonnull)controllerName;
-+ (NSMutableDictionary *_Nonnull)getParametersFromURL:(NSString *_Nonnull)url;
++ (NSBundle * _Nullable)bundle;
++ (NSString * _Nullable)getXibNameForControllerName:(NSString * _Nonnull)controllerName;
+ /**
+  * Extracts the parameters from the URL and extracts the deeplink from the call to action if applicable.
+  * @param url The URL to process.
+  * @return Returns a dictionary with "deeplink" and "params" keys holding the respective values.
+  */
++ (NSMutableDictionary * _Nonnull)getParametersFromURL:(NSString * _Nonnull)url;
 
 @end

--- a/CleverTapSDK/CTInAppUtils.h
+++ b/CleverTapSDK/CTInAppUtils.h
@@ -33,5 +33,6 @@ typedef NS_ENUM(NSUInteger, CTInAppActionType){
 + (NSString * _Nonnull)inAppActionTypeString:(CTInAppActionType)type;
 + (NSBundle *_Nullable)bundle;
 + (NSString *_Nullable)getXibNameForControllerName:(NSString *_Nonnull)controllerName;
++ (NSMutableDictionary *_Nonnull)getParametersFromURL:(NSString *_Nonnull)url;
 
 @end

--- a/CleverTapSDK/CTInAppUtils.m
+++ b/CleverTapSDK/CTInAppUtils.m
@@ -124,4 +124,36 @@ static NSDictionary<NSNumber *, NSString *> *_inAppActionTypeTypeToStringMap;
 #endif
 }
 
++ (NSMutableDictionary *)getParametersFromURL:(NSString *)urlString {
+    NSMutableDictionary *mutableParams = [NSMutableDictionary new];
+    
+    // Try to extract the parameters from the URL and overrite default dl if applicable
+    NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
+    NSArray *comps = [urlString componentsSeparatedByString:@"?"];
+    if ([comps count] >= 2) {
+        // Extract the parameters and store in params dictionary
+        NSString *query = comps[1];
+        for (NSString *param in [query componentsSeparatedByString:@"&"]) {
+            NSArray *elts = [param componentsSeparatedByString:@"="];
+            if ([elts count] < 2) continue;
+            params[elts[0]] = [elts[1] stringByRemovingPercentEncoding];
+        };
+        
+        // Check for wzrk_c2a key, if present update its value after parsing with __dl__
+        NSString *c2a = params[CLTAP_PROP_WZRK_CTA];
+        if (c2a) {
+            c2a = [c2a stringByRemovingPercentEncoding];
+            NSArray *parts = [c2a componentsSeparatedByString:@"__dl__"];
+            if (parts && [parts count] == 2) {
+                params[CLTAP_PROP_WZRK_CTA] = parts[0];
+                mutableParams[@"deeplink"] = [NSURL URLWithString:parts[1]];
+            }
+        }
+        
+        mutableParams[@"params"] = [params mutableCopy];
+    }
+    
+    return mutableParams;
+}
+
 @end

--- a/CleverTapSDK/CTInAppUtils.m
+++ b/CleverTapSDK/CTInAppUtils.m
@@ -125,8 +125,7 @@ static NSDictionary<NSNumber *, NSString *> *_inAppActionTypeTypeToStringMap;
 }
 
 + (NSMutableDictionary *)getParametersFromURL:(NSString *)urlString {
-    NSMutableDictionary *mutableParams = [NSMutableDictionary new];
-    
+    NSMutableDictionary *mutableParams = [[NSMutableDictionary alloc] init];
     // Try to extract the parameters from the URL and overrite default dl if applicable
     NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
     NSArray *comps = [urlString componentsSeparatedByString:@"?"];
@@ -137,13 +136,13 @@ static NSDictionary<NSNumber *, NSString *> *_inAppActionTypeTypeToStringMap;
             NSArray *elts = [param componentsSeparatedByString:@"="];
             if ([elts count] < 2) continue;
             params[elts[0]] = [elts[1] stringByRemovingPercentEncoding];
-        };
+        }
         
         // Check for wzrk_c2a key, if present update its value after parsing with __dl__
         NSString *c2a = params[CLTAP_PROP_WZRK_CTA];
         if (c2a) {
             c2a = [c2a stringByRemovingPercentEncoding];
-            NSArray *parts = [c2a componentsSeparatedByString:@"__dl__"];
+            NSArray *parts = [c2a componentsSeparatedByString:CLTAP_URL_PARAM_DL_SEPARATOR];
             if (parts && [parts count] == 2) {
                 params[CLTAP_PROP_WZRK_CTA] = parts[0];
                 mutableParams[@"deeplink"] = [NSURL URLWithString:parts[1]];

--- a/CleverTapSDK/CleverTapJSInterface.m
+++ b/CleverTapSDK/CleverTapJSInterface.m
@@ -100,6 +100,14 @@
         return;
     }
     
+    // Check for NSNull in case null is passed from the WebView message
+    if ([callToAction isKindOfClass:[NSNull class]]) {
+        callToAction = nil;
+    }
+    if ([buttonId isKindOfClass:[NSNull class]]) {
+        buttonId = nil;
+    }
+    
     CTNotificationAction *action = [[CTNotificationAction alloc] initWithJSON:actionJson];
     if (action && !action.error) {
         [self.controller triggerInAppAction:action callToAction:callToAction buttonId:buttonId];

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -230,34 +230,18 @@ typedef enum {
         return;
     }
     
-    NSMutableDictionary *mutableParams = [NSMutableDictionary new];
     NSString *urlString = [navigationAction.request.URL absoluteString];
     NSURL *dl = [NSURL URLWithString:urlString];
+    NSMutableDictionary *mutableParams = [CTInAppUtils getParametersFromURL:urlString];
     
-    // Try to extract the parameters from the URL and overrite default dl if applicable
-    NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
-    NSArray *comps = [urlString componentsSeparatedByString:@"?"];
-    if ([comps count] >= 2) {
-        NSString *query = comps[1];
-        for (NSString *param in [query componentsSeparatedByString:@"&"]) {
-            NSArray *elts = [param componentsSeparatedByString:@"="];
-            if ([elts count] < 2) continue;
-            params[elts[0]] = [elts[1] stringByRemovingPercentEncoding];
-        };
-        mutableParams = [params mutableCopy];
-        NSString *c2a = params[CLTAP_PROP_WZRK_CTA];
-        if (c2a) {
-            c2a = [c2a stringByRemovingPercentEncoding];
-            NSArray *parts = [c2a componentsSeparatedByString:@"__dl__"];
-            if (parts && [parts count] == 2) {
-                dl = [NSURL URLWithString:parts[1]];
-                mutableParams[CLTAP_PROP_WZRK_CTA] = parts[0];
-            }
-        }
+    // Use the url from the callToAction param to update action
+    if (mutableParams[@"deeplink"]) {
+        dl = mutableParams[@"deeplink"];
     }
+    
     if (self.delegate && [self.delegate respondsToSelector:@selector(handleNotificationAction:forNotification:withExtras:)]) {
         CTNotificationAction *action = [[CTNotificationAction alloc] initWithOpenURL:dl];
-        [self.delegate handleNotificationAction:action forNotification:self.notification withExtras:mutableParams];
+        [self.delegate handleNotificationAction:action forNotification:self.notification withExtras:mutableParams[@"params"]];
     }
     [self hide:YES];
     decisionHandler(WKNavigationActionPolicyCancel);

--- a/CleverTapSDKTests/InApps/CTInAppDisplayViewControllerMock.h
+++ b/CleverTapSDKTests/InApps/CTInAppDisplayViewControllerMock.h
@@ -1,0 +1,18 @@
+//
+//  CTInAppDisplayViewControllerMock.h
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 26.11.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CTInAppDisplayViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CTInAppDisplayViewControllerMock : CTInAppDisplayViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTapSDKTests/InApps/CTInAppDisplayViewControllerMock.m
+++ b/CleverTapSDKTests/InApps/CTInAppDisplayViewControllerMock.m
@@ -1,0 +1,19 @@
+//
+//  CTInAppDisplayViewControllerMock.m
+//  CleverTapSDKTests
+//
+//  Created by Nikola Zagorchev on 26.11.24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import "CTInAppDisplayViewControllerMock.h"
+
+@implementation CTInAppDisplayViewControllerMock
+
+- (void)show:(BOOL)animated {
+}
+
+- (void)hide:(BOOL)animated {
+}
+
+@end

--- a/CleverTapSDKTests/InApps/CTInAppDisplayViewControllerTests.m
+++ b/CleverTapSDKTests/InApps/CTInAppDisplayViewControllerTests.m
@@ -1,0 +1,193 @@
+//
+//  CTInAppDisplayViewControllerTests.m
+//  CleverTapSDKTests
+//
+//  Created by Nishant Kumar on 18/11/24.
+//  Copyright © 2024 CleverTap. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "CTInAppDisplayViewController.h"
+#import "CTInAppNotificationDisplayDelegateMock.h"
+
+@interface CTInAppDisplayViewControllerTests : XCTestCase
+
+@property (nonatomic, strong) CTInAppDisplayViewController *viewController;
+@property (nonatomic, strong) CTInAppNotification *inAppNotification;
+
+@end
+
+@implementation CTInAppDisplayViewControllerTests
+
+- (void)setUp {
+    [super setUp];
+    
+    NSDictionary *inApp = @{
+        @"ti": @1
+    };
+    self.inAppNotification = [[CTInAppNotification alloc] initWithJSON:inApp];
+    self.viewController = [[CTInAppDisplayViewController alloc] initWithNotification:self.inAppNotification];
+}
+
+- (void)tearDown {
+    self.viewController = nil;
+
+    [super tearDown];
+}
+
+#pragma mark triggerInAppAction Tests
+
+- (void)testAddURLParamsOnly {
+    // triggerAction should add url parameters only in extras dictionary
+    // if callToAction and buttonId is not present.
+    NSURL *url = [NSURL URLWithString:@"https://clevertap.com?param1=value1&param2=value2"];
+    NSDictionary *expectedExtras = @{
+        @"wzrk_id": @"",
+        @"param1": @"value1",
+        @"param2": @"value2"
+    };
+    
+    CTNotificationAction *action = [[CTNotificationAction alloc] initWithOpenURL:url];
+    
+    CTInAppNotificationDisplayDelegateMock *delegate = [[CTInAppNotificationDisplayDelegateMock alloc] init];
+    [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
+        XCTAssertEqualObjects(expectedExtras, extras);
+    }];
+    self.viewController.delegate = delegate;
+    id mockViewController = OCMPartialMock(self.viewController);
+    OCMExpect([mockViewController hide:YES]);
+
+    // Trigger the action
+    [self.viewController triggerInAppAction:action callToAction:nil buttonId:nil];
+    OCMVerifyAll(mockViewController);
+}
+
+- (void)testAddURLParamsAlongWithC2A {
+    // triggerAction should add url parameters along with callToAction and buttonId
+    // in extras dictionary.
+    NSURL *url = [NSURL URLWithString:@"https://clevertap.com?param1=value1&param2=value2"];
+    NSString *callToAction = @"Test CTA";
+    NSString *buttonId = @"button1";
+    NSDictionary *expectedExtras = @{
+        @"wzrk_id": @"",
+        @"wzrk_c2a": callToAction,
+        @"button_id": buttonId,
+        @"param1": @"value1",
+        @"param2": @"value2"
+    };
+    
+    CTNotificationAction *action = [[CTNotificationAction alloc] initWithOpenURL:url];
+    
+    CTInAppNotificationDisplayDelegateMock *delegate = [[CTInAppNotificationDisplayDelegateMock alloc] init];
+    [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
+        XCTAssertEqualObjects(expectedExtras, extras);
+    }];
+    self.viewController.delegate = delegate;
+    id mockViewController = OCMPartialMock(self.viewController);
+    OCMExpect([mockViewController hide:YES]);
+
+    // Trigger the action
+    [self.viewController triggerInAppAction:action callToAction:callToAction buttonId:buttonId];
+    OCMVerifyAll(mockViewController);
+}
+
+- (void)testC2AParamsParseFromDL {
+    // triggerAction should parse c2a url params with __dl__ data
+    // when callToAction is not provided.
+    NSURL *url = [NSURL URLWithString:@"https://clevertap.com?wzrk_c2a=c2aParam__dl__https%3A%2F%2Fdeeplink.com%3Fparam1%3Dasd%26param2%3Dvalue2&asd=value"];
+    NSString *buttonId = @"button1";
+    NSDictionary *expectedExtras = @{
+        @"wzrk_id": @"",
+        @"wzrk_c2a": @"c2aParam",
+        @"button_id": buttonId,
+        @"asd": @"value"
+    };
+    
+    CTNotificationAction *action = [[CTNotificationAction alloc] initWithOpenURL:url];
+    
+    CTInAppNotificationDisplayDelegateMock *delegate = [[CTInAppNotificationDisplayDelegateMock alloc] init];
+    [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
+        XCTAssertEqualObjects(expectedExtras, extras);
+    }];
+    self.viewController.delegate = delegate;
+    id mockViewController = OCMPartialMock(self.viewController);
+    OCMExpect([mockViewController hide:YES]);
+
+    // Trigger the action
+    [self.viewController triggerInAppAction:action callToAction:nil buttonId:buttonId];
+    OCMVerifyAll(mockViewController);
+}
+
+- (void)testC2AParamsDoesNotParseFromDL {
+    // triggerAction does not parse c2a url params with __dl__ data when callToAction
+    // is provided, wzrk_c2a should have callToAction value only if provided.
+    NSURL *url = [NSURL URLWithString:@"https://clevertap.com?wzrk_c2a=c2aParam__dl__https%3A%2F%2Fdeeplink.com%3Fparam1%3Dasd%26param2%3Dvalue2&asd=value"];
+    NSString *callToAction = @"Test CTA";
+    NSString *buttonId = @"button1";
+    NSDictionary *expectedExtras = @{
+        @"wzrk_id": @"",
+        @"wzrk_c2a": callToAction,
+        @"button_id": buttonId,
+        @"asd": @"value"
+    };
+    
+    CTNotificationAction *action = [[CTNotificationAction alloc] initWithOpenURL:url];
+    
+    CTInAppNotificationDisplayDelegateMock *delegate = [[CTInAppNotificationDisplayDelegateMock alloc] init];
+    [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
+        XCTAssertEqualObjects(expectedExtras, extras);
+    }];
+    self.viewController.delegate = delegate;
+    id mockViewController = OCMPartialMock(self.viewController);
+    OCMExpect([mockViewController hide:YES]);
+
+    // Trigger the action
+    [self.viewController triggerInAppAction:action callToAction:callToAction buttonId:buttonId];
+    OCMVerifyAll(mockViewController);
+}
+
+- (void)testActionURLWhenDLDataPresent {
+    // triggerAction should open deeplink url if __dl__ data is present.
+    NSURL *url = [NSURL URLWithString:@"https://clevertap.com?wzrk_c2a=c2aParam__dl__https%3A%2F%2Fdeeplink.com%3Fparam1%3Dasd%26param2%3Dvalue2&asd=value"];
+    NSString *callToAction = @"Test CTA";
+    NSString *buttonId = @"button1";
+    NSURL *expectedURL = [NSURL URLWithString:@"https://deeplink.com?param1=asd&param2=value2"];
+    
+    CTNotificationAction *action = [[CTNotificationAction alloc] initWithOpenURL:url];
+    
+    CTInAppNotificationDisplayDelegateMock *delegate = [[CTInAppNotificationDisplayDelegateMock alloc] init];
+    [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
+        XCTAssertEqualObjects(action.actionURL, expectedURL);
+    }];
+    self.viewController.delegate = delegate;
+    id mockViewController = OCMPartialMock(self.viewController);
+    OCMExpect([mockViewController hide:YES]);
+
+    // Trigger the action
+    [self.viewController triggerInAppAction:action callToAction:callToAction buttonId:buttonId];
+    OCMVerifyAll(mockViewController);
+}
+
+- (void)testActionURLWhenDLDataNotPresent {
+    // triggerAction should open original url if __dl__ data is not present.
+    NSURL *url = [NSURL URLWithString:@"https://clevertap.com?param1=value1&param2=value2"];
+    NSString *callToAction = @"Test CTA";
+    NSString *buttonId = @"button1";
+    NSURL *expectedURL = url;
+    CTNotificationAction *action = [[CTNotificationAction alloc] initWithOpenURL:url];
+    
+    CTInAppNotificationDisplayDelegateMock *delegate = [[CTInAppNotificationDisplayDelegateMock alloc] init];
+    [delegate setHandleNotificationAction:^(CTNotificationAction *action, CTInAppNotification *notification, NSDictionary *extras) {
+        XCTAssertEqualObjects(action.actionURL, expectedURL);
+    }];
+    self.viewController.delegate = delegate;
+    id mockViewController = OCMPartialMock(self.viewController);
+    OCMExpect([mockViewController hide:YES]);
+
+    // Trigger the action
+    [self.viewController triggerInAppAction:action callToAction:callToAction buttonId:buttonId];
+    OCMVerifyAll(mockViewController);
+}
+
+@end


### PR DESCRIPTION
- Added parsing of urls on open-url action.
- This will track the parameters in url for in-app in Notification Clicked event.
- This will also parse `__dl__` if `wzrk_c2a` is present in query parameters or action URL.
- Fixes an issue where wzrk_c2a value is passed as null to backend when we receive null for callToAction value in webView message handler. Example: 
```
var message = { action:'triggerInAppAction', actionJson: actionJson, callToAction: null, buttonId: null };
window.webkit.messageHandlers.clevertap.postMessage(message);
```
For above script we get message as below where value for callToAction is of NSNull class:
```
{
    ...
    buttonId = "<null>";
    callToAction = "<null>";
}
```