### PR TITLE
[MC-2106] Add event storage limits

### DIFF
--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -274,3 +274,6 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_ENCRYPTION_LEVEL @"CleverTapEncryptionLevel"
 #define CLTAP_ENCRYPTION_IV @"__CL3>3Rt#P__1V_"
 #define CLTAP_ENCRYPTION_PII_DATA (@[@"Identity", @"Email", @"Phone", @"Name"]);
+
+#define CLTAP_EVENT_DB_MAX_ROW_LIMIT (2048 + 256) * 5;
+#define CLTAP_EVENT_DB_ROWS_TO_CLEANUP 2048 + 256; // (2048 events + 256 profile props = 1 user)

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.h
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.h
@@ -43,4 +43,7 @@
 
 - (BOOL)deleteTable;
 
+- (BOOL)deleteLeastRecentlyUsedRows:(NSInteger)maxRowLimit
+              numberOfRowsToCleanup:(NSInteger)numberOfRowsToCleanup;
+
 @end

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.m
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.m
@@ -9,9 +9,6 @@
 #import "CTEventDatabase.h"
 #import "CTConstants.h"
 
-static const NSInteger kMaxRowLimit = (2048 + 256) * 5;
-static const NSInteger kNumberOfRowsToCleanup = 2048 + 256; // (2048 events + 256 profile props = 1 user)
-
 @interface CTEventDatabase()
 
 @property (nonatomic, strong) CleverTapInstanceConfig *config;
@@ -40,7 +37,9 @@ static const NSInteger kNumberOfRowsToCleanup = 2048 + 256; // (2048 events + 25
         
         // Perform cleanup/deletion of rows on instance creation if total row count
         // exceeds mac threshold limit.
-        [self deleteLeastRecentlyUsedRows:kMaxRowLimit numberOfRowsToCleanup:kNumberOfRowsToCleanup];
+        NSInteger maxRowLimit = CLTAP_EVENT_DB_MAX_ROW_LIMIT;
+        NSInteger numberOfRowsToCleanup = CLTAP_EVENT_DB_ROWS_TO_CLEANUP;
+        [self deleteLeastRecentlyUsedRows:maxRowLimit numberOfRowsToCleanup:numberOfRowsToCleanup];
     }
     return self;
 }

--- a/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
+++ b/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
@@ -161,6 +161,42 @@ static NSString *kDeviceID = @"Test Device";
     XCTAssertEqual(allEvents.count, 1);
 }
 
+- (void)testLeastRecentlyUsedRowsDeleted {
+    int maxRow = 10;
+    int numberOfRowsToCleanup = 2;
+    int totalRowCount = 13;
+    for (int i = 0; i < totalRowCount; i++) {
+        NSString *eventName = [NSString stringWithFormat:@"Test Event %d", i];
+        [self.eventDatabase insertData:eventName deviceID:kDeviceID];
+    }
+    NSArray<CleverTapEventDetail *>*  allEvents = [self.eventDatabase getAllEventsForDeviceID:kDeviceID];
+    XCTAssertEqual(allEvents.count, totalRowCount);
+    
+    // When deleteLeastRecentlyUsedRows is called using max row limit and numberOfRowsToCleanup
+    // the deleted row count will be `totalRowCount - (maxRow - numberOfRowsToCleanup)`
+    [self.eventDatabase deleteLeastRecentlyUsedRows:maxRow numberOfRowsToCleanup:numberOfRowsToCleanup];
+    allEvents = [self.eventDatabase getAllEventsForDeviceID:kDeviceID];
+    int deletedRowCount = totalRowCount - (maxRow - numberOfRowsToCleanup);
+    XCTAssertEqual(allEvents.count, totalRowCount - deletedRowCount);
+}
+
+- (void)testLeastRecentlyUsedRowsNotDeleted {
+    int maxRow = 10;
+    int numberOfRowsToCleanup = 2;
+    int totalRowCount = 7;
+    for (int i = 0; i < totalRowCount; i++) {
+        NSString *eventName = [NSString stringWithFormat:@"Test Event %d", i];
+        [self.eventDatabase insertData:eventName deviceID:kDeviceID];
+    }
+    NSArray<CleverTapEventDetail *>*  allEvents = [self.eventDatabase getAllEventsForDeviceID:kDeviceID];
+    XCTAssertEqual(allEvents.count, totalRowCount);
+    
+    // Here any row will not be deleted as it is within limit.
+    [self.eventDatabase deleteLeastRecentlyUsedRows:maxRow numberOfRowsToCleanup:numberOfRowsToCleanup];
+    allEvents = [self.eventDatabase getAllEventsForDeviceID:kDeviceID];
+    XCTAssertEqual(allEvents.count, totalRowCount);
+}
+
 - (NSString *)databasePath {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDirectory = [paths objectAtIndex:0];


### PR DESCRIPTION
## Overview
We need to add limits to event stored in storage. Based on discussion, the max row limit for table will be `(2048 unique events + 256 unique profile properties) * 5 users = 11520 rows`. The number of rows to cleanup is (2048+256). So number of rows to be deleted will be equal to (totalRowCount - (maxLimit - numberOfRowsToCleanup)). Rows will be deleted based on last timestamp where least recently used will be deleted first and the cleanup is done when instance is created or every app launch.

## Implementation
- Added method `deleteLeastRecentlyUsedRows:numberOfRowsToCleanup:` which is called when instance is created. Added index on `lastTs` column which enhance performance while deletion when table is large. We have also added functionality to rollback if deletion gives any error and commit when success.
- Added unit tests.