### PR TITLE
[MC-2430] Normalize event names

### DIFF
--- a/CleverTapSDK/CTLocalDataStore.m
+++ b/CleverTapSDK/CTLocalDataStore.m
@@ -627,7 +627,8 @@ NSString *const CT_ENCRYPTION_KEY = @"CLTAP_ENCRYPTION_KEY";
     if (!self.dbHelper) {
         self.dbHelper = [CTEventDatabase sharedInstanceWithConfig:self.config];
     }
-    NSInteger count = [self.dbHelper getCountForEventName:eventName deviceID:self.deviceInfo.deviceId];
+    // TODO: Add normalized name here
+    NSInteger count = [self.dbHelper getEventCount:eventName deviceID:self.deviceInfo.deviceId];
     if (count > 1) {
         @synchronized (self.userEventLogs) {
             [self.userEventLogs addObject:eventName];

--- a/CleverTapSDK/CleverTapEventDetail.h
+++ b/CleverTapSDK/CleverTapEventDetail.h
@@ -3,8 +3,10 @@
 @interface CleverTapEventDetail : NSObject
 
 @property (nonatomic, strong) NSString *eventName;
+@property (nonatomic, strong) NSString *normalizedEventName;
 @property (nonatomic) NSTimeInterval firstTime;
 @property (nonatomic) NSTimeInterval lastTime;
 @property (nonatomic) NSUInteger count;
+@property (nonatomic, strong) NSString *deviceID;
 
 @end

--- a/CleverTapSDK/CleverTapEventDetail.m
+++ b/CleverTapSDK/CleverTapEventDetail.m
@@ -3,8 +3,8 @@
 @implementation CleverTapEventDetail
 
 - (NSString*) description {
-    return [NSString stringWithFormat:@"CleverTapEventDetail (event name = %@; first time = %d, last time = %d; count = %lu)",
-            self.eventName, (int) self.firstTime, (int) self.lastTime, (unsigned long)self.count];
+    return [NSString stringWithFormat:@"CleverTapEventDetail (event name = %@; normalized event name = %@; first time = %d, last time = %d; count = %lu; device ID = %@)",
+            self.eventName, self.normalizedEventName, (int) self.firstTime, (int) self.lastTime, (unsigned long)self.count, self.deviceID];
 }
 
 @end

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.h
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.h
@@ -16,8 +16,6 @@
 + (instancetype)sharedInstanceWithConfig:(CleverTapInstanceConfig *)config;
 - (instancetype)initWithConfig:(CleverTapInstanceConfig *)config;
 
-- (BOOL)createTable;
-
 - (NSInteger)getDatabaseVersion;
 
 - (BOOL)insertEvent:(NSString *)eventName
@@ -44,7 +42,7 @@ normalizedEventName:(NSString *)normalizedEventName
 
 - (NSArray<CleverTapEventDetail *> *)getAllEventsForDeviceID:(NSString *)deviceID;
 
-- (BOOL)deleteTable;
+- (BOOL)deleteAllRows;
 
 - (BOOL)deleteLeastRecentlyUsedRows:(NSInteger)maxRowLimit
               numberOfRowsToCleanup:(NSInteger)numberOfRowsToCleanup;

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.h
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.h
@@ -25,6 +25,10 @@ normalizedEventName:(NSString *)normalizedEventName
 - (BOOL)updateEvent:(NSString *)normalizedEventName
         forDeviceID:(NSString *)deviceID;
 
+- (BOOL)upsertEvent:(NSString *)eventName
+normalizedEventName:(NSString *)normalizedEventName
+           deviceID:(NSString *)deviceID;
+
 - (BOOL)eventExists:(NSString *)normalizedEventName
         forDeviceID:(NSString *)deviceID;
 

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.h
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.h
@@ -20,26 +20,27 @@
 
 - (NSInteger)getDatabaseVersion;
 
-- (BOOL)insertData:(NSString *)eventName
-          deviceID:(NSString *)deviceID;
+- (BOOL)insertEvent:(NSString *)eventName
+normalizedEventName:(NSString *)normalizedEventName
+           deviceID:(NSString *)deviceID;
 
-- (BOOL)updateEvent:(NSString *)eventName
+- (BOOL)updateEvent:(NSString *)normalizedEventName
         forDeviceID:(NSString *)deviceID;
 
-- (BOOL)eventExists:(NSString *)eventName
+- (BOOL)eventExists:(NSString *)normalizedEventName
         forDeviceID:(NSString *)deviceID;
 
-- (NSInteger)getCountForEventName:(NSString *)eventName
-                         deviceID:(NSString *)deviceID;
+- (NSInteger)getEventCount:(NSString *)normalizedEventName
+                  deviceID:(NSString *)deviceID;
 
-- (NSInteger)getFirstTimestampForEventName:(NSString *)eventName
-                                  deviceID:(NSString *)deviceID;
+- (NSInteger)getFirstTimestamp:(NSString *)normalizedEventName
+                      deviceID:(NSString *)deviceID;
 
-- (NSInteger)getLastTimestampForEventName:(NSString *)eventName
-                                 deviceID:(NSString *)deviceID;
+- (NSInteger)getLastTimestamp:(NSString *)normalizedEventName
+                     deviceID:(NSString *)deviceID;
 
-- (CleverTapEventDetail *)getEventDetailForEventName:(NSString *)eventName
-                                            deviceID:(NSString *)deviceID;
+- (CleverTapEventDetail *)getEventDetail:(NSString *)normalizedEventName
+                                deviceID:(NSString *)deviceID;
 
 - (NSArray<CleverTapEventDetail *> *)getAllEventsForDeviceID:(NSString *)deviceID;
 

--- a/CleverTapSDK/EventDatabase/CTEventDatabase.m
+++ b/CleverTapSDK/EventDatabase/CTEventDatabase.m
@@ -75,12 +75,6 @@ normalizedEventName:(NSString *)normalizedEventName
         CleverTapLogInternal(self.config.logLevel, @"%@ Event database is not open, cannot execute SQL.", self);
         return NO;
     }
-
-    BOOL eventExists = [self eventExists:normalizedEventName forDeviceID:deviceID];
-    if (eventExists) {
-        CleverTapLogInternal(self.config.logLevel, @"%@ Insert SQL - Event name: %@ and DeviceID: %@ already exists.", self, eventName, deviceID);
-        return NO;
-    }
     
     __block BOOL success = NO;
     // For new event, set count as 1
@@ -120,12 +114,6 @@ normalizedEventName:(NSString *)normalizedEventName
         CleverTapLogInternal(self.config.logLevel, @"%@ Event database is not open, cannot execute SQL.", self);
         return NO;
     }
-
-    BOOL eventExists = [self eventExists:normalizedEventName forDeviceID:deviceID];
-    if (!eventExists) {
-        CleverTapLogInternal(self.config.logLevel, @"%@ Update SQL - Event name: %@ and DeviceID: %@ doesn't exists.", self, normalizedEventName, deviceID);
-        return NO;
-    }
     
     NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
     const char *updateSQL =
@@ -152,6 +140,21 @@ normalizedEventName:(NSString *)normalizedEventName
         }
     });
 
+    return success;
+}
+
+- (BOOL)upsertEvent:(NSString *)eventName
+normalizedEventName:(NSString *)normalizedEventName
+           deviceID:(NSString *)deviceID {
+    BOOL success = NO;
+
+    BOOL eventExists = [self eventExists:normalizedEventName forDeviceID:deviceID];
+    if (!eventExists) {
+        success = [self insertEvent:eventName normalizedEventName:normalizedEventName deviceID:deviceID];
+    } else {
+        success = [self updateEvent:normalizedEventName forDeviceID:deviceID];
+    }
+    
     return success;
 }
 

--- a/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
+++ b/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
@@ -103,9 +103,25 @@ static NSString *kDeviceID = @"Test Device";
     XCTAssertTrue(updateSuccess);
 }
 
-- (void)testUpdateEventFailure {
-    BOOL updateSuccess = [self.eventDatabase updateEvent:self.normalizedEventName forDeviceID:kDeviceID];
-    XCTAssertFalse(updateSuccess);
+- (void)testUpsertEventSuccessWhenInsert {
+    BOOL upsertSuccess = [self.eventDatabase upsertEvent:kEventName
+                                     normalizedEventName:self.normalizedEventName
+                                                deviceID:kDeviceID];
+    XCTAssertTrue(upsertSuccess);
+}
+
+- (void)testUpsertEventSuccessWhenUpdate {
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
+
+    BOOL upsertSuccess = [self.eventDatabase upsertEvent:kEventName
+                                     normalizedEventName:self.normalizedEventName
+                                                deviceID:kDeviceID];
+    XCTAssertTrue(upsertSuccess);
+    
+    NSInteger eventCount = [self.eventDatabase getEventCount:self.normalizedEventName deviceID:kDeviceID];
+    XCTAssertEqual(eventCount, 2);
 }
 
 - (void)testGetCountForEventName {

--- a/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
+++ b/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
@@ -30,14 +30,12 @@ static NSString *kDeviceID = @"Test Device";
     self.config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"testAccountId" accountToken:@"testAccountToken"];
     self.eventDatabase = [CTEventDatabase sharedInstanceWithConfig:self.config];
     self.normalizedEventName = [CTUtils getNormalizedName:kEventName];
-    [self.eventDatabase createTable];
-    
 }
 
 - (void)tearDown {
     [super tearDown];
     
-    [self.eventDatabase deleteTable];
+    [self.eventDatabase deleteAllRows];
 }
 
 - (void)testGetDatabaseVersion {
@@ -164,7 +162,7 @@ static NSString *kDeviceID = @"Test Device";
     
 }
 
-- (void)testDeleteTableSuccess {
+- (void)testDeleteAllRowsSuccess {
     [self.eventDatabase insertEvent:kEventName
                 normalizedEventName:self.normalizedEventName
                            deviceID:kDeviceID];
@@ -172,7 +170,7 @@ static NSString *kDeviceID = @"Test Device";
     XCTAssertEqual(eventCount, 1);
     
     // Delete table.
-    BOOL deleteSuccess = [self.eventDatabase deleteTable];
+    BOOL deleteSuccess = [self.eventDatabase deleteAllRows];
     XCTAssertTrue(deleteSuccess);
     NSInteger eventCountAfterDelete = [self.eventDatabase getEventCount:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(eventCountAfterDelete, 0);

--- a/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
+++ b/CleverTapSDKTests/EventDatabase/CTEventDatabaseTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import "CTEventDatabase.h"
 #import "CleverTapInstanceConfig.h"
+#import "CTUtils.h"
 
 static NSString *kEventName = @"Test Event";
 static NSString *kDeviceID = @"Test Device";
@@ -17,6 +18,7 @@ static NSString *kDeviceID = @"Test Device";
 
 @property (nonatomic, strong) CleverTapInstanceConfig *config;
 @property (nonatomic, strong) CTEventDatabase *eventDatabase;
+@property (nonatomic, strong) NSString *normalizedEventName;
 
 @end
 
@@ -27,6 +29,7 @@ static NSString *kDeviceID = @"Test Device";
     
     self.config = [[CleverTapInstanceConfig alloc] initWithAccountId:@"testAccountId" accountToken:@"testAccountToken"];
     self.eventDatabase = [CTEventDatabase sharedInstanceWithConfig:self.config];
+    self.normalizedEventName = [CTUtils getNormalizedName:kEventName];
     [self.eventDatabase createTable];
     
 }
@@ -43,126 +46,178 @@ static NSString *kDeviceID = @"Test Device";
 }
 
 - (void)testInsertEventName {
-    BOOL insertSuccess = [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    BOOL insertSuccess = [self.eventDatabase insertEvent:kEventName
+                                     normalizedEventName:self.normalizedEventName
+                                                deviceID:kDeviceID];
     XCTAssertTrue(insertSuccess);
 }
 
 - (void)testInsertEventNameAgain {
-    BOOL insertSuccess = [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    BOOL insertSuccess = [self.eventDatabase insertEvent:kEventName 
+                                     normalizedEventName:self.normalizedEventName
+                                                deviceID:kDeviceID];
     XCTAssertTrue(insertSuccess);
     
     // Insert same eventName and deviceID again
-    BOOL insertSuccessAgain = [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    BOOL insertSuccessAgain = [self.eventDatabase insertEvent:kEventName 
+                                          normalizedEventName:self.normalizedEventName
+                                                     deviceID:kDeviceID];
     XCTAssertFalse(insertSuccessAgain);
 }
 
 - (void)testEventNameExists {
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
     
-    BOOL eventExists = [self.eventDatabase eventExists:kEventName forDeviceID:kDeviceID];
+    BOOL eventExists = [self.eventDatabase eventExists:self.normalizedEventName forDeviceID:kDeviceID];
+    XCTAssertTrue(eventExists);
+    
+    NSString *normalizedEventName = [CTUtils getNormalizedName:@"TesT   EveNT"];
+    eventExists = [self.eventDatabase eventExists:normalizedEventName forDeviceID:kDeviceID];
+    XCTAssertTrue(eventExists);
+    
+    normalizedEventName = [CTUtils getNormalizedName:@"TEST EVENT"];
+    eventExists = [self.eventDatabase eventExists:normalizedEventName forDeviceID:kDeviceID];
     XCTAssertTrue(eventExists);
 }
 
 - (void)testEventNameNotExists {
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
     
-    BOOL eventExists = [self.eventDatabase eventExists:@"Test Event 1" forDeviceID:kDeviceID];
+    NSString *normalizedEventName = [CTUtils getNormalizedName:@"TesT   EveNT 1"];
+    BOOL eventExists = [self.eventDatabase eventExists:normalizedEventName forDeviceID:kDeviceID];
+    XCTAssertFalse(eventExists);
+    
+    normalizedEventName = [CTUtils getNormalizedName:@"Test.Event"];
+    eventExists = [self.eventDatabase eventExists:normalizedEventName forDeviceID:kDeviceID];
     XCTAssertFalse(eventExists);
 }
 
 - (void)testUpdateEventSuccess {
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
     
-    BOOL updateSuccess = [self.eventDatabase updateEvent:kEventName forDeviceID:kDeviceID];
+    BOOL updateSuccess = [self.eventDatabase updateEvent:self.normalizedEventName forDeviceID:kDeviceID];
     XCTAssertTrue(updateSuccess);
 }
 
 - (void)testUpdateEventFailure {
-    BOOL updateSuccess = [self.eventDatabase updateEvent:kEventName forDeviceID:kDeviceID];
+    BOOL updateSuccess = [self.eventDatabase updateEvent:self.normalizedEventName forDeviceID:kDeviceID];
     XCTAssertFalse(updateSuccess);
 }
 
 - (void)testGetCountForEventName {
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
     
-    [self.eventDatabase updateEvent:kEventName forDeviceID:kDeviceID];
+    [self.eventDatabase updateEvent:self.normalizedEventName forDeviceID:kDeviceID];
     
     // count should be 2.
-    NSInteger eventCount = [self.eventDatabase getCountForEventName:kEventName deviceID:kDeviceID];
+    NSInteger eventCount = [self.eventDatabase getEventCount:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(eventCount, 2);
 }
 
 - (void)testGetCountForEventNameNotExists {
     // count should be 0.
-    NSInteger eventCount = [self.eventDatabase getCountForEventName:kEventName deviceID:kDeviceID];
+    NSInteger eventCount = [self.eventDatabase getEventCount:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(eventCount, 0);
 }
 
 - (void)testFirstTimestampForEventName {
     NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
     
-    NSInteger firstTs = [self.eventDatabase getFirstTimestampForEventName:kEventName deviceID:kDeviceID];
+    NSInteger firstTs = [self.eventDatabase getFirstTimestamp:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(firstTs, currentTs);
 }
 
 - (void)testLastTimestampForEventName {
     NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
     
-    NSInteger lastTs = [self.eventDatabase getLastTimestampForEventName:kEventName deviceID:kDeviceID];
+    NSInteger lastTs = [self.eventDatabase getLastTimestamp:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(lastTs, currentTs);
 }
 
 - (void)testLastTimestampForEventNameUpdated {
     NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
     
-    NSInteger lastTs = [self.eventDatabase getLastTimestampForEventName:kEventName deviceID:kDeviceID];
+    NSInteger lastTs = [self.eventDatabase getLastTimestamp:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(lastTs, currentTs);
     
     NSInteger newCurrentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
-    NSInteger newLastTs = [self.eventDatabase getLastTimestampForEventName:kEventName deviceID:kDeviceID];
+    [self.eventDatabase updateEvent:self.normalizedEventName forDeviceID:kDeviceID];
+    NSInteger newLastTs = [self.eventDatabase getLastTimestamp:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(newLastTs, newCurrentTs);
     
 }
 
 - (void)testDeleteTableSuccess {
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
-    NSInteger eventCount = [self.eventDatabase getCountForEventName:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
+    NSInteger eventCount = [self.eventDatabase getEventCount:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(eventCount, 1);
     
     // Delete table.
     BOOL deleteSuccess = [self.eventDatabase deleteTable];
     XCTAssertTrue(deleteSuccess);
-    NSInteger eventCountAfterDelete = [self.eventDatabase getCountForEventName:kEventName deviceID:kDeviceID];
+    NSInteger eventCountAfterDelete = [self.eventDatabase getEventCount:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqual(eventCountAfterDelete, 0);
     
 }
 
 - (void)testEventDetailsForDeviceID {
     NSInteger currentTs = (NSInteger)[[NSDate date] timeIntervalSince1970];
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
     
-    CleverTapEventDetail *eventDetail = [self.eventDatabase getEventDetailForEventName:kEventName deviceID:kDeviceID];
+    CleverTapEventDetail *eventDetail = [self.eventDatabase getEventDetail:self.normalizedEventName deviceID:kDeviceID];
     XCTAssertEqualObjects(eventDetail.eventName, kEventName);
+    XCTAssertEqualObjects(eventDetail.normalizedEventName, self.normalizedEventName);
     XCTAssertEqual(eventDetail.firstTime, currentTs);
     XCTAssertEqual(eventDetail.lastTime, currentTs);
     XCTAssertEqual(eventDetail.count, 1);
+    XCTAssertEqualObjects(eventDetail.deviceID, kDeviceID);
 }
 
 - (void)testAllEventsForDeviceID {
-    [self.eventDatabase insertData:kEventName deviceID:kDeviceID];
-    [self.eventDatabase insertData:@"Test Event 1" deviceID:kDeviceID];
-    [self.eventDatabase insertData:@"Test Event 2" deviceID:@"Test Device 1"];
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:kDeviceID];
+    
+    // Insert to same device id kDeviceID
+    NSString *eventName = @"Test Event 1";
+    NSString *normalizedName = [CTUtils getNormalizedName:eventName];
+    [self.eventDatabase insertEvent:eventName
+                normalizedEventName:normalizedName
+                           deviceID:kDeviceID];
+    
+    // Insert to different device id
+    [self.eventDatabase insertEvent:kEventName
+                normalizedEventName:self.normalizedEventName
+                           deviceID:@"Test Device 1"];
     
     NSArray<CleverTapEventDetail *>*  allEvents = [self.eventDatabase getAllEventsForDeviceID:kDeviceID];
     XCTAssertEqualObjects(allEvents[0].eventName, kEventName);
-    XCTAssertEqualObjects(allEvents[1].eventName, @"Test Event 1");
+    XCTAssertEqualObjects(allEvents[1].eventName, eventName);
     XCTAssertEqual(allEvents.count, 2);
     
     allEvents = [self.eventDatabase getAllEventsForDeviceID:@"Test Device 1"];
-    XCTAssertEqualObjects(allEvents[0].eventName, @"Test Event 2");
+    XCTAssertEqualObjects(allEvents[0].eventName, kEventName);
     XCTAssertEqual(allEvents.count, 1);
 }
 
@@ -172,7 +227,10 @@ static NSString *kDeviceID = @"Test Device";
     int totalRowCount = 13;
     for (int i = 0; i < totalRowCount; i++) {
         NSString *eventName = [NSString stringWithFormat:@"Test Event %d", i];
-        [self.eventDatabase insertData:eventName deviceID:kDeviceID];
+        NSString *normalizedName = [CTUtils getNormalizedName:eventName];
+        [self.eventDatabase insertEvent:eventName
+                    normalizedEventName:normalizedName
+                               deviceID:kDeviceID];
     }
     NSArray<CleverTapEventDetail *>*  allEvents = [self.eventDatabase getAllEventsForDeviceID:kDeviceID];
     XCTAssertEqual(allEvents.count, totalRowCount);
@@ -191,7 +249,10 @@ static NSString *kDeviceID = @"Test Device";
     int totalRowCount = 7;
     for (int i = 0; i < totalRowCount; i++) {
         NSString *eventName = [NSString stringWithFormat:@"Test Event %d", i];
-        [self.eventDatabase insertData:eventName deviceID:kDeviceID];
+        NSString *normalizedName = [CTUtils getNormalizedName:eventName];
+        [self.eventDatabase insertEvent:eventName
+                    normalizedEventName:normalizedName
+                               deviceID:kDeviceID];
     }
     NSArray<CleverTapEventDetail *>*  allEvents = [self.eventDatabase getAllEventsForDeviceID:kDeviceID];
     XCTAssertEqual(allEvents.count, totalRowCount);


### PR DESCRIPTION
- Normalize the event name in database.
- Added `normalizedEventName` column to the `CTUserEventLogs` table.
- While inserting into table add the original event name along with normalized name.
- Query the table based on normalized name only.
- Added `normalizedEventName` and `deviceID` to `CleverTapEventDetail` class to include while event details are fetched.
- Added `upsertEvent` method to insert if event not exists and update when exists.
- Fixed the unit test cases.