### PR TITLE
[MC-2429] Add new public apis - Multi triggers

### DIFF
--- a/CleverTapSDK/CTLocalDataStore.h
+++ b/CleverTapSDK/CTLocalDataStore.h
@@ -46,4 +46,14 @@
 
 - (BOOL)isEventLoggedFirstTime:(NSString*)eventName;
 
+- (int)readUserEventLogCount:(NSString *)eventName;
+
+- (CleverTapEventDetail *)readUserEventLog:(NSString *)eventName;
+
+- (NSTimeInterval)readUserEventLogFirstTs:(NSString *)eventName;
+
+- (NSTimeInterval)readUserEventLogLastTs:(NSString *)eventName;
+
+- (NSDictionary *)readUserEventLogs;
+
 @end

--- a/CleverTapSDK/CTLocalDataStore.m
+++ b/CleverTapSDK/CTLocalDataStore.m
@@ -637,6 +637,37 @@ NSString *const CT_ENCRYPTION_KEY = @"CLTAP_ENCRYPTION_KEY";
     return count == 1;
 }
 
+#pragma mark - Public APIs for Event log
+
+- (int)readUserEventLogCount:(NSString *)eventName {
+    NSString *normalizedEventName = [CTUtils getNormalizedName:eventName];
+    return (int) [self.dbHelper getEventCount:normalizedEventName deviceID:self.deviceInfo.deviceId];
+}
+
+- (CleverTapEventDetail *)readUserEventLog:(NSString *)eventName {
+    NSString *normalizedEventName = [CTUtils getNormalizedName:eventName];
+    return [self.dbHelper getEventDetail:normalizedEventName deviceID:self.deviceInfo.deviceId];
+}
+
+- (NSTimeInterval)readUserEventLogFirstTs:(NSString *)eventName {
+    NSString *normalizedEventName = [CTUtils getNormalizedName:eventName];
+    return (int) [self.dbHelper getFirstTimestamp:normalizedEventName deviceID:self.deviceInfo.deviceId];
+}
+
+- (NSTimeInterval)readUserEventLogLastTs:(NSString *)eventName {
+    NSString *normalizedEventName = [CTUtils getNormalizedName:eventName];
+    return (int) [self.dbHelper getLastTimestamp:normalizedEventName deviceID:self.deviceInfo.deviceId];
+}
+
+- (NSDictionary *)readUserEventLogs {
+    NSArray<CleverTapEventDetail *> *allEvents = [self.dbHelper getAllEventsForDeviceID:self.deviceInfo.deviceId];
+    NSMutableDictionary *history = [[NSMutableDictionary alloc] init];
+    for (CleverTapEventDetail *event in allEvents) {
+        history[event.eventName] = event;
+    }
+    return history;
+}
+
 
 #pragma mark - Private Local Profile Getters and Setters and disk persistence handling
 

--- a/CleverTapSDK/CleverTap.h
+++ b/CleverTapSDK/CleverTap.h
@@ -801,7 +801,7 @@ extern NSString * _Nonnull const CleverTapGeofencesDidUpdateNotification;
  
  @param event           event name
  */
-- (NSTimeInterval)eventGetFirstTime:(NSString *_Nonnull)event;
+- (NSTimeInterval)eventGetFirstTime:(NSString *_Nonnull)event __attribute__((deprecated("Deprecated as of version 7.1.0, use getUserEventLogFirstTs instead")));
 
 /*!
  @method
@@ -813,7 +813,7 @@ extern NSString * _Nonnull const CleverTapGeofencesDidUpdateNotification;
  @param event           event name
  */
 
-- (NSTimeInterval)eventGetLastTime:(NSString *_Nonnull)event;
+- (NSTimeInterval)eventGetLastTime:(NSString *_Nonnull)event __attribute__((deprecated("Deprecated as of version 7.1.0, use getUserEventLogLastTs instead")));
 
 /*!
  @method
@@ -824,7 +824,7 @@ extern NSString * _Nonnull const CleverTapGeofencesDidUpdateNotification;
  
  @param event           event name
  */
-- (int)eventGetOccurrences:(NSString *_Nonnull)event;
+- (int)eventGetOccurrences:(NSString *_Nonnull)event __attribute__((deprecated("Deprecated as of version 7.1.0, use getUserEventLogCount instead")));
 
 /*!
  @method
@@ -838,7 +838,7 @@ extern NSString * _Nonnull const CleverTapGeofencesDidUpdateNotification;
  Be sure to call enablePersonalization (typically once at app launch) prior to using this method.
  
  */
-- (NSDictionary *_Nullable)userGetEventHistory;
+- (NSDictionary *_Nullable)userGetEventHistory __attribute__((deprecated("Deprecated as of version 7.1.0, use getUserEventLogHistory instead")));
 
 /*!
  @method
@@ -853,7 +853,72 @@ extern NSString * _Nonnull const CleverTapGeofencesDidUpdateNotification;
  
  @param event           event name
  */
-- (CleverTapEventDetail *_Nullable)eventGetDetail:(NSString *_Nullable)event;
+- (CleverTapEventDetail *_Nullable)eventGetDetail:(NSString *_Nullable)event __attribute__((deprecated("Deprecated as of version 7.1.0, use getUserEventLog instead")));
+
+/*!
+ @method
+ 
+ @abstract
+ Get the the count of logged events for a specific event name associated with the current user.
+ This operation involves a database query and should be called from a background thread.
+ Be sure to call enablePersonalization prior to invoking this method.
+ 
+ @param eventName           event name
+ */
+- (int)getUserEventLogCount:(NSString *_Nonnull)eventName;
+
+/*!
+ @method
+ 
+ @abstract
+ Get the details for the event.
+ 
+ @discussion
+ Returns a CleverTapEventDetail object (eventName, normalizedEventName, firstTime, lastTime, count, deviceID)
+ This operation involves a database query and should be called from a background thread.
+ Be sure to call enablePersonalization (typically once at app launch) prior to using this method.
+ 
+ @param eventName           event name
+ */
+- (CleverTapEventDetail *_Nullable)getUserEventLog:(NSString *_Nullable)eventName;
+
+/*!
+ @method
+ 
+ @abstract
+ Get the time of the first recording of the event.
+ This operation involves a database query and should be called from a background thread.
+ Be sure to call enablePersonalization prior to invoking this method.
+ 
+ @param eventName           event name
+ */
+- (NSTimeInterval)getUserEventLogFirstTs:(NSString *_Nonnull)eventName;
+
+/*!
+ @method
+ 
+ @abstract
+ Get the time of the last recording of the event.
+ This operation involves a database query and should be called from a background thread.
+ Be sure to call enablePersonalization prior to invoking this method.
+ 
+ @param eventName           event name
+ */
+- (NSTimeInterval)getUserEventLogLastTs:(NSString *_Nonnull)eventName;
+
+/*!
+ @method
+ 
+ @abstract
+ Get the user's event history.
+ 
+ @discussion
+ Returns a dictionary of CleverTapEventDetail objects (eventName, normalizedEventName, firstTime, lastTime, count, deviceID), keyed by eventName.
+ This operation involves a database query and should be called from a background thread.
+ Be sure to call enablePersonalization (typically once at app launch) prior to using this method.
+ 
+ */
+- (NSDictionary *_Nullable)getUserEventLogHistory;
 
 
 #pragma mark Session API
@@ -889,7 +954,17 @@ extern NSString * _Nonnull const CleverTapGeofencesDidUpdateNotification;
  
  Be sure to call enablePersonalization (typically once at app launch) prior to using this method.
  */
-- (int)userGetTotalVisits;
+- (int)userGetTotalVisits __attribute__((deprecated("Deprecated as of version 7.1.0, use getUserAppLaunchCount instead")));
+
+/*!
+ @method
+ 
+ @abstract
+ Get the total number of visits by this user.
+ This operation involves a database query and should be called from a background thread.
+ Be sure to call enablePersonalization (typically once at app launch) prior to using this method.
+ */
+- (int)getUserAppLaunchCount;
 
 /*!
  @method
@@ -909,7 +984,17 @@ extern NSString * _Nonnull const CleverTapGeofencesDidUpdateNotification;
  Be sure to call enablePersonalization (typically once at app launch) prior to using this method.
  
  */
-- (NSTimeInterval)userGetPreviousVisitTime;
+- (NSTimeInterval)userGetPreviousVisitTime __attribute__((deprecated("Deprecated as of version 7.1.0, use getUserLastVisitTs instead")));
+
+/*!
+ @method
+ 
+ @abstract
+ Get the last prior visit time for this user.
+ Be sure to call enablePersonalization (typically once at app launch) prior to using this method.
+ 
+ */
+- (NSTimeInterval)getUserLastVisitTs;
 
 /* ------------------------------------------------------------------------------------------------------
  * Synchronization

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -195,6 +195,7 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 
 @property (nonatomic, strong, readwrite) CleverTapInstanceConfig *config;
 @property (nonatomic, assign) NSTimeInterval lastAppLaunchedTime;
+@property (nonatomic, assign) NSTimeInterval userLastVisitTs;
 @property (nonatomic, strong) CTDeviceInfo *deviceInfo;
 @property (nonatomic, strong) CTLocalDataStore *localDataStore;
 @property (nonatomic, strong) CTDispatchQueueManager *dispatchQueueManager;
@@ -473,6 +474,7 @@ static BOOL sharedInstanceErrorLogged;
         _localDataStore = [[CTLocalDataStore alloc] initWithConfig:_config profileValues:initialProfileValues andDeviceInfo: _deviceInfo dispatchQueueManager:_dispatchQueueManager];
         
         _lastAppLaunchedTime = [self eventGetLastTime:@"App Launched"];
+        _userLastVisitTs = [self getUserEventLogLastTs:@"App Launched"];
         self.validationResultStack = [[CTValidationResultStack alloc]initWithConfig: _config];
         self.userSetLocation = kCLLocationCoordinate2DInvalid;
         
@@ -3105,6 +3107,50 @@ static BOOL sharedInstanceErrorLogged;
     return [self.localDataStore getEventDetail:event];
 }
 
+#pragma mark - User Event Log Methods
+
+- (int)getUserEventLogCount:(NSString *)eventName {
+    if (!self.config.enablePersonalization) {
+        return -1;
+    }
+    return [self.localDataStore readUserEventLogCount:eventName];
+}
+
+- (CleverTapEventDetail *)getUserEventLog:(NSString *)eventName {
+    if (!self.config.enablePersonalization) {
+        return nil;
+    }
+    return [self.localDataStore readUserEventLog:eventName];
+}
+
+- (NSTimeInterval)getUserEventLogFirstTs:(NSString *)eventName {
+    if (!self.config.enablePersonalization) {
+        return -1;
+    }
+    return [self.localDataStore readUserEventLogFirstTs:eventName];
+}
+
+- (NSTimeInterval)getUserEventLogLastTs:(NSString *)eventName {
+    if (!self.config.enablePersonalization) {
+        return -1;
+    }
+    return [self.localDataStore readUserEventLogFirstTs:eventName];
+}
+
+- (NSDictionary *)getUserEventLogHistory {
+    if (!self.config.enablePersonalization) {
+        return nil;
+    }
+    return [self.localDataStore readUserEventLogs];
+}
+
+- (int)getUserAppLaunchCount {
+    return [self getUserEventLogCount:@"App Launched"];
+}
+
+- (NSTimeInterval)getUserLastVisitTs {
+    return self.userLastVisitTs;
+}
 
 #pragma mark - Session API
 


### PR DESCRIPTION
- Added following new public apis for accessing new event database methods.
`getUserEventLogCount:`
`getUserEventLog:`
`getUserEventLogFirstTs:`
`getUserEventLogLastTs:`
`getUserEventLogHistory`
`getUserAppLaunchCount`
`getUserLastVisitTs`

- Deprecated following old apis which read previous storage.
`eventGetOccurrences:`
`eventGetDetail:`
`eventGetFirstTime:`
`eventGetLastTime:`
`userGetEventHistory`
`userGetTotalVisits`
`userGetPreviousVisitTime`