### PR TITLE
TemplateContext debugDescription: fallback to action type name

### DIFF
--- a/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTTemplateContext.m
@@ -261,13 +261,24 @@
     return nil;
 }
 
+- (NSString *)actionName:(CTNotificationAction *)action {
+    NSString *name = action.customTemplateInAppData.templateName;
+    if (!name) {
+        name = [CTInAppUtils inAppActionTypeString:action.type];
+    }
+    if (!name) {
+        name = @"";
+    }
+    return name;
+}
+
 - (NSString *)debugDescription {
     NSMutableArray<NSString *> *argsDescription = [NSMutableArray array];
     for (NSString *key in self.argumentValues) {
         NSString *value;
         if ([self.argumentValues[key] isKindOfClass:[CTNotificationAction class]]) {
             CTNotificationAction *action = self.argumentValues[key];
-            NSString *name = action.customTemplateInAppData.templateName ? action.customTemplateInAppData.templateName : @"";
+            NSString *name = [self actionName:action];
             value = [NSString stringWithFormat:@"Action: %@", name];
         } else {
             value = [self.argumentValues[key] debugDescription];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to retrieve action names for in-app notifications with improved logic for name resolution.

- **Refactor**
	- Enhanced the way action names are determined and displayed in the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->