### PR TITLE
[SDK-4476] Fix custom in-app device orientation check

### DIFF
--- a/CleverTapSDK/CTInAppNotification.m
+++ b/CleverTapSDK/CTInAppNotification.m
@@ -197,18 +197,6 @@
     }
     self.buttons = _buttons;
     
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.hasPortrait && !self.hasLandscape && [self deviceOrientationIsLandscape]) {
-            self.error = [NSString stringWithFormat:@"The in-app in %@, dismissing %@ InApp Notification.", @"portrait", @"landscape"];
-            return;
-        }
-        
-        if (self.hasLandscape && !self.hasPortrait && ![self deviceOrientationIsLandscape]) {
-            self.error = [NSString stringWithFormat:@"The in-app in %@, dismissing %@ InApp Notification.", @"landscape", @"portrait"];
-            return;
-        }
-    });
-    
     switch (self.inAppType) {
         case CTInAppTypeHeader:
         case CTInAppTypeFooter:
@@ -290,14 +278,6 @@
 
 - (BOOL)mediaIsVideo {
     return _mediaIsVideo;
-}
-
-- (BOOL)deviceOrientationIsLandscape {
-#if (TARGET_OS_TV)
-    return nil;
-#else
-    return [CTUIUtils isDeviceOrientationLandscape];
-#endif
 }
 
 - (void)setPreparedInAppImage:(UIImage *)inAppImage


### PR DESCRIPTION
## Overview
Fixes custom in-app device orientation check. 
The default value for the `CTInAppNotification` `hasPortrait` is `YES` and the default value for `hasLandscape` is `NO` which causes custom in-apps to not be presented if the device is in Landscape.
The customer's implementation handles the presentation of custom in-apps so it should handle if the device orientation is supported for the in-app.

## Implementation
The `deviceOrientationIsLandscape` check requires the main thread. The implementation in `CTInAppNotificaton` was making this check async. 
The orientation check is now performed in the `CTInAppDisplayManager prepareNotificationForDisplay:` method. The check is done in `runSyncMainQueue` block which ensures code executes on main thread.

The orientation check returns if the in-app type is Custom. 