### PR TITLE
BaseTestCase fixes

### DIFF
--- a/CleverTapSDKTests/BaseTestCase.h
+++ b/CleverTapSDKTests/BaseTestCase.h
@@ -15,5 +15,4 @@
 - (void)getLastBatchHeader:(void (^)(NSDictionary*))handler;
 - (void)stubRequestsWithName:(NSString*)name;
 - (void)getLastEventWithStubName: (NSString*)stubName eventName: (NSString*)eventName eventType:(NSString*)eventType handler:(void (^)(NSDictionary *))handler;
-- (NSString*)randomString;
 @end


### PR DESCRIPTION
## Overview
Fix an exception in `BaseTestCase`: `data is nil`. The exception is caused by the code in `BaseTestCase onStubActivation`. Make the call use weak self reference and add nil checks in it.

Remove `BaseTestCase` unused methods.
