### PR TITLE
SDK-4496 - Fix notification clicked getting registered while dismissing HTML in-App

### DIFF
--- a/CleverTapSDK/CleverTapJSInterface.m
+++ b/CleverTapSDK/CleverTapJSInterface.m
@@ -88,6 +88,8 @@
         [cleverTap profileDecrementValueBy: message[@"value"] forKey: message[@"key"]];
     } else if ([action isEqual: @"triggerInAppAction"]) {
         [self triggerInAppAction:message[@"actionJson"] callToAction:message[@"callToAction"] buttonId:message[@"buttonId"]];
+    } else if ([action isEqual: @"dismissInAppNotification"]) {
+        [self.controller hide:YES];
     } else if ([action isEqual: @"promptForPushPermission"]) {
         if (self.controller) {
             [self.controller hide:NO];

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -638,9 +638,7 @@ static NSMutableArray<NSArray *> *pendingNotifications;
 - (void)handleNotificationAction:(CTNotificationAction *)action forNotification:(CTInAppNotification *)notification withExtras:(NSDictionary *)extras {
     CleverTapLogInternal(self.config.logLevel, @"%@: handle InApp action type:%@ with cta: %@ button custom extras: %@ with options:%@", self, [CTInAppUtils inAppActionTypeString:action.type], action.actionURL.absoluteString, action.keyValues, extras);
     // record the notification clicked event
-    if (!action.keyValues[@"shouldEmitNotificationClickedEvent"]) {
         [self.instance recordInAppNotificationStateEvent:YES forNotification:notification andQueryParameters:extras];
-    }
     
     // add the action extras so they can be passed to the dismissedWithExtras delegate
     if (extras) {

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -638,7 +638,7 @@ static NSMutableArray<NSArray *> *pendingNotifications;
 - (void)handleNotificationAction:(CTNotificationAction *)action forNotification:(CTInAppNotification *)notification withExtras:(NSDictionary *)extras {
     CleverTapLogInternal(self.config.logLevel, @"%@: handle InApp action type:%@ with cta: %@ button custom extras: %@ with options:%@", self, [CTInAppUtils inAppActionTypeString:action.type], action.actionURL.absoluteString, action.keyValues, extras);
     // record the notification clicked event
-        [self.instance recordInAppNotificationStateEvent:YES forNotification:notification andQueryParameters:extras];
+    [self.instance recordInAppNotificationStateEvent:YES forNotification:notification andQueryParameters:extras];
     
     // add the action extras so they can be passed to the dismissedWithExtras delegate
     if (extras) {

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -638,7 +638,9 @@ static NSMutableArray<NSArray *> *pendingNotifications;
 - (void)handleNotificationAction:(CTNotificationAction *)action forNotification:(CTInAppNotification *)notification withExtras:(NSDictionary *)extras {
     CleverTapLogInternal(self.config.logLevel, @"%@: handle InApp action type:%@ with cta: %@ button custom extras: %@ with options:%@", self, [CTInAppUtils inAppActionTypeString:action.type], action.actionURL.absoluteString, action.keyValues, extras);
     // record the notification clicked event
-    [self.instance recordInAppNotificationStateEvent:YES forNotification:notification andQueryParameters:extras];
+    if (!action.keyValues[@"shouldEmitNotificationClickedEvent"]) {
+        [self.instance recordInAppNotificationStateEvent:YES forNotification:notification andQueryParameters:extras];
+    }
     
     // add the action extras so they can be passed to the dismissedWithExtras delegate
     if (extras) {


### PR DESCRIPTION
Fix for notification clicked getting registered while dismissing HTML in-App. For Javascript support in In-App Notifications by calling the JS method if we add the action as 'dismissInAppNotification' in the dashboard, the inapp will get closed without registering notification clicked  event:

```
if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.clevertap) { 
var message = { action:'dismissInAppNotification'};
window.webkit.messageHandlers.clevertap.postMessage(message);
}
}
```