### PR TITLE
SDK-4474 TTL fix for InApps

### DIFF
--- a/CleverTapSDK/CTInAppNotification.h
+++ b/CleverTapSDK/CTInAppNotification.h
@@ -20,7 +20,7 @@
 @property (nonatomic, readonly) int maxPerSession;
 @property (nonatomic, readonly) int totalLifetimeCount;
 @property (nonatomic, readonly) int totalDailyCount;
-@property (nonatomic, readonly) NSInteger timeToLive;
+@property (nonatomic, readonly) NSTimeInterval timeToLive;
 @property (nonatomic, assign, readonly) char position;
 @property (nonatomic, assign, readonly) float height;
 @property (nonatomic, assign, readonly) float heightPercent;

--- a/CleverTapSDK/CTInAppNotification.m
+++ b/CleverTapSDK/CTInAppNotification.m
@@ -46,7 +46,7 @@
 @property (nonatomic, readwrite) int maxPerSession;
 @property (nonatomic, readwrite) int totalLifetimeCount;
 @property (nonatomic, readwrite) int totalDailyCount;
-@property (nonatomic, readwrite) NSInteger timeToLive;
+@property (nonatomic, readwrite) NSTimeInterval timeToLive;
 @property (nonatomic, assign, readwrite) char position;
 @property (nonatomic, assign, readwrite) float height;
 @property (nonatomic, assign, readwrite) float heightPercent;
@@ -113,9 +113,7 @@
             } else {
                 NSDate *now = [NSDate date];
                 NSDate *timeToLiveDate = [now dateByAddingTimeInterval:(48 * 60 * 60)];
-                NSTimeInterval timeToLiveEpoch = [timeToLiveDate timeIntervalSince1970];
-                NSInteger defaultTimeToLive = (long)timeToLiveEpoch;
-                _timeToLive = defaultTimeToLive;
+                _timeToLive = [timeToLiveDate timeIntervalSince1970];
             }
         } @catch (NSException *e) {
             self.error = e.debugDescription;

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -304,7 +304,7 @@ static NSMutableArray<NSArray *> *pendingNotifications;
             return;
         }
 
-        NSTimeInterval now = (int)[[NSDate date] timeIntervalSince1970];
+        NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
         if (now > notification.timeToLive) {
             CleverTapLogInternal(self.config.logLevel, @"%@: InApp has elapsed its time to live, not showing the InApp: %@ wzrk_ttl: %lu", self, jsonObj, (unsigned long)notification.timeToLive);
             return;


### PR DESCRIPTION
Typecasting [[NSDate date] timeIntervalSince1970] to an int resulted in the same value as notification.timeToLive, causing the elapsed condition to be bypassed.
 https://wizrocket.atlassian.net/browse/SDK-4474

Resolution: Implemented a fix to enable TTL validation by using NSTimeInterval instead of int.
