### PR TITLE
Adds Notification Clicked event for inApps when dismissed with swipe

### DIFF
--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -179,6 +179,7 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_PROP_VARIANT @"Variant"
 #define CLTAP_PROP_WZRK_PIVOT @"wzrk_pivot"
 #define CLTAP_PROP_WZRK_CTA @"wzrk_c2a"
+#define CLTAP_CTA_SWIPE_DISMISS @"swipe-dismiss"
 
 #define CLTAP_INAPP_ID @"ti"
 #define CLTAP_INAPP_TTL @"wzrk_ttl"

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -460,7 +460,8 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
         [self.delegate respondsToSelector:@selector(handleNotificationAction:forNotification:withExtras:)]) {
         [self.delegate handleNotificationAction:action forNotification:self.notification withExtras:extras];
     }
-    [self hide:YES];
+    BOOL shouldAnimate = ![callToAction isEqualToString: CLTAP_CTA_SWIPE_DISMISS];
+    [self hide: shouldAnimate];
 }
 
 - (void)handleImageTapGesture {

--- a/CleverTapSDK/CTNotificationAction.h
+++ b/CleverTapSDK/CTNotificationAction.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if !CLEVERTAP_NO_INAPP_SUPPORT
 - (instancetype)initWithJSON:(NSDictionary *)json;
 - (instancetype)initWithOpenURL:(NSURL *)url;
+- (instancetype)initWithCloseAction;
 #endif
 
 @end

--- a/CleverTapSDK/CTNotificationAction.m
+++ b/CleverTapSDK/CTNotificationAction.m
@@ -55,4 +55,11 @@
     return self;
 }
 
+- (nonnull instancetype)initWithCloseAction {
+    if (self = [super init]) {
+        self.type = CTInAppActionTypeClose;
+    }
+    return self;
+}
+
 @end

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -490,7 +490,6 @@ typedef enum {
                 self->webView.frame = CGRectOffset(self->webView.frame, bounceDistance, 0);
             }
                              completion:^(BOOL finished) {
-                //add record event
                 CTNotificationAction *action = [[CTNotificationAction alloc] initWithCloseAction];
                 [self triggerInAppAction:action callToAction: CLTAP_CTA_SWIPE_DISMISS buttonId:nil];
             }];

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -490,7 +490,9 @@ typedef enum {
                 self->webView.frame = CGRectOffset(self->webView.frame, bounceDistance, 0);
             }
                              completion:^(BOOL finished) {
-                [self hide:NO];
+                //add record event
+                CTNotificationAction *action = [[CTNotificationAction alloc] initWithCloseAction];
+                [self triggerInAppAction:action callToAction: CLTAP_CTA_SWIPE_DISMISS buttonId:nil];
             }];
         }];
     }];


### PR DESCRIPTION
Adds cta: swipe-dismiss for Notification clicked event
InApps affected: Custom HTML inApps and Header / Footer InApps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced in-app messaging behavior: swipe-to-dismiss interactions now trigger an immediate, non-animated close, ensuring a more responsive dismissal.
  - Added dedicated handling for notification close actions, providing an improved and intuitive user experience during interactive messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->