### PR TITLE
[SDK-4540] Notification Viewed Event for App rating

### DIFF
--- a/CleverTapSDK/InApps/CustomTemplates/SystemAppFunction/CTSystemAppFunctionPresenter.m
+++ b/CleverTapSDK/InApps/CustomTemplates/SystemAppFunction/CTSystemAppFunctionPresenter.m
@@ -49,8 +49,13 @@
         }
         [context dismissed];
     } else if ([context.templateName isEqual:CLTAP_APP_RATING_TEMPLATE_NAME]) {
-        [self.systemTemplateActionHandler promptAppRating];
-        [context dismissed];
+        [self.systemTemplateActionHandler promptAppRatingWithCompletionBlock:^(BOOL presented) {
+            if (presented) {
+                // Added this to record Notification Viewed event for OS App Rating.
+                [context presented];
+            }
+            [context dismissed];
+        }];
     }
 }
 

--- a/CleverTapSDK/InApps/CustomTemplates/SystemAppFunction/CTSystemTemplateActionHandler.h
+++ b/CleverTapSDK/InApps/CustomTemplates/SystemAppFunction/CTSystemTemplateActionHandler.h
@@ -21,7 +21,7 @@
 
 - (BOOL)handleOpenURL:(NSString *_Nullable)action;
 
-- (void)promptAppRating;
+- (void)promptAppRatingWithCompletionBlock:(void (^_Nonnull)(BOOL presented))completion;
 
 @end
 

--- a/CleverTapSDK/InApps/CustomTemplates/SystemAppFunction/CTSystemTemplateActionHandler.m
+++ b/CleverTapSDK/InApps/CustomTemplates/SystemAppFunction/CTSystemTemplateActionHandler.m
@@ -57,8 +57,8 @@
 
 #pragma mark App Rating System App Function
 
-- (void)promptAppRating {
-    [CTAppRatingHelper requestRating];
+- (void)promptAppRatingWithCompletionBlock:(void (^_Nonnull)(BOOL presented))completion; {
+    [CTAppRatingHelper requestRatingWithCompletion:completion];
 }
 
 @end


### PR DESCRIPTION
- Adds Notification Viewed Event for Standalone App Rating prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- App rating prompt now provides immediate feedback on whether the prompt was shown.
- **Bug Fixes**
	- Improved reliability in detecting when the app rating prompt is actually presented to users.
- **Refactor**
	- App rating prompt logic updated to use asynchronous handling and completion callbacks for more accurate event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->