### PR TITLE
[User Attributes] Remove unnecessary calls and parameters

### DIFF
--- a/CleverTapSDK/CTLocalDataStore.h
+++ b/CleverTapSDK/CTLocalDataStore.h
@@ -38,7 +38,7 @@
 
 - (id)getProfileFieldForKey:(NSString *)key;
 
-- (NSDictionary<NSString *, NSDictionary<NSString *, id> *> *)getUserAttributeChangeProperties:(NSDictionary *)event;
+- (NSDictionary<NSString *, NSDictionary<NSString *, id> *> *)userAttributeChangeProperties:(NSDictionary *)event;
 
 - (void)persistLocalProfileIfRequired;
 

--- a/CleverTapSDK/CTLocalDataStore.m
+++ b/CleverTapSDK/CTLocalDataStore.m
@@ -516,7 +516,7 @@ NSString *const CT_ENCRYPTION_KEY = @"CLTAP_ENCRYPTION_KEY";
     }
 }
 
-- (NSDictionary<NSString *, NSDictionary<NSString *, id> *> *)getUserAttributeChangeProperties:(NSDictionary *)event {
+- (NSDictionary<NSString *, NSDictionary<NSString *, id> *> *)userAttributeChangeProperties:(NSDictionary *)event {
     NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, id> *> *userAttributesChangeProperties = [NSMutableDictionary dictionary];
     NSMutableDictionary<NSString *, id> *fieldsToPersistLocally = [NSMutableDictionary dictionary];
     NSDictionary *profile = event[CLTAP_PROFILE];
@@ -544,7 +544,8 @@ NSString *const CT_ENCRYPTION_KEY = @"CLTAP_ENCRYPTION_KEY";
             else if ([commandIdentifier isEqualToString:kCLTAP_COMMAND_SET] ||
                      [commandIdentifier isEqualToString:kCLTAP_COMMAND_ADD] ||
                      [commandIdentifier isEqualToString:kCLTAP_COMMAND_REMOVE]) {
-                newValue = [CTProfileBuilder _constructLocalMultiValueWithOriginalValues:value forKey:key usingCommand:commandIdentifier localDataStore:self];
+                // Multi values are not supported as user property triggers
+                // The multi values changes are already persisted locally when building the event
             }
         } else if ([newValue isKindOfClass:[NSString class]]) {
             // Remove the date prefix before evaluation and persisting
@@ -569,6 +570,7 @@ NSString *const CT_ENCRYPTION_KEY = @"CLTAP_ENCRYPTION_KEY";
             [fieldsToPersistLocally setObject:newValue forKey:key];
         }
     }
+    // Persist the changes
     [self updateProfileFieldsLocally:fieldsToPersistLocally];
     return userAttributesChangeProperties;
 }

--- a/CleverTapSDK/CTProfileBuilder.h
+++ b/CleverTapSDK/CTProfileBuilder.h
@@ -19,9 +19,9 @@
 
 + (void)buildRemoveMultiValues:(NSArray<NSString *> *_Nonnull)values forKey:(NSString *_Nullable)key localDataStore:(CTLocalDataStore*_Nullable)dataStore completionHandler:(void(^ _Nonnull )(NSDictionary *_Nullable customFields,  NSArray* _Nullable updatedMultiValue, NSArray<CTValidationResult*> *_Nullable errors))completion;
 
-+ (void)buildIncrementValueBy:(NSNumber *_Nonnull)value forKey: (NSString *_Nonnull)key localDataStore:(CTLocalDataStore* _Nonnull)dataStore completionHandler:(void(^ _Nonnull )(NSDictionary *_Nullable operatorDict, NSNumber *_Nullable updatedValue, NSArray<CTValidationResult*> *_Nullable errors))completion;
++ (void)buildIncrementValueBy:(NSNumber* _Nonnull)value forKey:(NSString* _Nonnull)key localDataStore:(CTLocalDataStore* _Nonnull)dataStore completionHandler: (void(^ _Nonnull )(NSDictionary* _Nullable operatorDict, NSArray<CTValidationResult*>* _Nullable errors))completion;
 
-+ (void)buildDecrementValueBy:(NSNumber *_Nonnull)value forKey: (NSString *_Nonnull)key localDataStore:(CTLocalDataStore* _Nonnull)dataStore completionHandler:(void(^ _Nonnull )(NSDictionary *_Nullable operatorDict, NSNumber *_Nullable updatedValue, NSArray<CTValidationResult*> *_Nullable errors))completion;
++ (void)buildDecrementValueBy:(NSNumber* _Nonnull)value forKey:(NSString* _Nonnull)key localDataStore:(CTLocalDataStore* _Nonnull)dataStore completionHandler: (void(^ _Nonnull )(NSDictionary* _Nullable operatorDict, NSArray<CTValidationResult*>* _Nullable errors))completion;
 
 + (NSNumber *_Nullable)_getUpdatedValue:(NSNumber *_Nonnull)value forKey:(NSString *_Nonnull)key withCommand:(NSString *_Nonnull)command cachedValue:(id _Nullable)cachedValue;
 

--- a/CleverTapSDK/CTProfileBuilder.m
+++ b/CleverTapSDK/CTProfileBuilder.m
@@ -345,28 +345,26 @@
 
 #pragma mark - Increment and Decrement Operator Handling
 
-+ (void)buildIncrementValueBy:(NSNumber* _Nonnull)value forKey:(NSString* _Nonnull)key localDataStore:(CTLocalDataStore* _Nonnull)dataStore completionHandler: (void(^ _Nonnull )(NSDictionary* _Nullable operatorDict, NSNumber* _Nullable updatedValue, NSArray<CTValidationResult*>* _Nullable errors))completion {
-    
++ (void)buildIncrementValueBy:(NSNumber* _Nonnull)value forKey:(NSString* _Nonnull)key localDataStore:(CTLocalDataStore* _Nonnull)dataStore completionHandler: (void(^ _Nonnull )(NSDictionary* _Nullable operatorDict, NSArray<CTValidationResult*>* _Nullable errors))completion {
     [self _handleIncrementDecrementValue:value forKey:key
                              withCommand:kCLTAP_COMMAND_INCREMENT
                           localDataStore:dataStore completionHandler:completion];
 }
 
-+ (void)buildDecrementValueBy:(NSNumber* _Nonnull)value forKey:(NSString* _Nonnull)key localDataStore:(CTLocalDataStore* _Nonnull)dataStore completionHandler: (void(^ _Nonnull )(NSDictionary* _Nullable operatorDict, NSNumber* _Nullable updatedValue, NSArray<CTValidationResult*>* _Nullable errors))completion {
-    
++ (void)buildDecrementValueBy:(NSNumber* _Nonnull)value forKey:(NSString* _Nonnull)key localDataStore:(CTLocalDataStore* _Nonnull)dataStore completionHandler: (void(^ _Nonnull )(NSDictionary* _Nullable operatorDict, NSArray<CTValidationResult*>* _Nullable errors))completion {
     [self _handleIncrementDecrementValue:value forKey:key
                              withCommand:kCLTAP_COMMAND_DECREMENT
                           localDataStore:dataStore completionHandler:completion];
 }
 
-+ (void)_handleIncrementDecrementValue:(NSNumber *_Nonnull)value forKey:(NSString *_Nonnull)key withCommand:(NSString *_Nonnull)command localDataStore:(CTLocalDataStore *_Nonnull)dataStore completionHandler: (void(^ _Nonnull )(NSDictionary *_Nullable operatorDict, NSNumber *_Nullable updatedValue, NSArray<CTValidationResult *> *_Nullable errors))completion {
++ (void)_handleIncrementDecrementValue:(NSNumber *_Nonnull)value forKey:(NSString *_Nonnull)key withCommand:(NSString *_Nonnull)command localDataStore:(CTLocalDataStore *_Nonnull)dataStore completionHandler:(void(^ _Nonnull )(NSDictionary *_Nullable operatorDict, NSArray<CTValidationResult *> *_Nullable errors))completion {
     
     if ([key length] == 0) {
         NSMutableArray<CTValidationResult*> *errors = [NSMutableArray new];
         CTValidationResult* error =  [self _generateInvalidMultiValueError: @"Profile key cannot be empty while incrementing/decrementing a property value"];
         
         [errors addObject: error];
-        completion(nil, nil, errors);
+        completion(nil, errors);
         return;
     }
     
@@ -375,18 +373,15 @@
         CTValidationResult* error =  [self _generateInvalidMultiValueError: [NSString stringWithFormat:@"Increment/Decrement value for profile key %@ cannot be zero or negative", key]];
         
         [errors addObject: error];
-        completion(nil, nil, errors);
+        completion(nil, errors);
         return;
     }
     
     NSDictionary* operatorDict = @{
         key: @{command: value}
     };
-    id cachedValue = [dataStore getProfileFieldForKey: key];
-    NSNumber *newValue;
-    newValue = [self _getUpdatedValue:value forKey:key withCommand:command cachedValue:cachedValue];
     
-    completion(operatorDict, newValue, nil);
+    completion(operatorDict, nil);
 }
 
 + (NSNumber *_Nullable)_getUpdatedValue:(NSNumber *_Nonnull)value forKey:(NSString *_Nonnull)key withCommand:(NSString *_Nonnull)command cachedValue:(id)cachedValue {

--- a/CleverTapSDKTests/CTLocalDataStoreTests.m
+++ b/CleverTapSDKTests/CTLocalDataStoreTests.m
@@ -36,13 +36,13 @@
 
 - (void)testGetUserAttributeChangePropertiesWithEmptyEvent {
     NSDictionary *event = @{};
-    NSDictionary *result = [self.dataStore getUserAttributeChangeProperties:event];
+    NSDictionary *result = [self.dataStore userAttributeChangeProperties:event];
     XCTAssertEqual(result.count, 0);
 }
 
 - (void)testGetUserAttributeChangePropertiesWithNoProfile {
     NSDictionary *event = @{@"someKey": @"someValue"};
-    NSDictionary *result = [self.dataStore getUserAttributeChangeProperties:event];
+    NSDictionary *result = [self.dataStore userAttributeChangeProperties:event];
     XCTAssertEqual(result.count, 0);
 }
 
@@ -66,7 +66,7 @@
     id mockGetProfileFieldForKeyAge = OCMStub([dataStoreMock getProfileFieldForKey:@"age"]).andReturn(mockOldValueForAge);
     
     // Call the method and get the result
-    NSDictionary *result = [dataStoreMock getUserAttributeChangeProperties:event];
+    NSDictionary *result = [dataStoreMock userAttributeChangeProperties:event];
     
     // Verify the result dictionary
     XCTAssertEqual(result.count, 2);
@@ -100,7 +100,7 @@
     id mockGetProfileFieldForKey = OCMStub([dataStoreMock getProfileFieldForKey:@"points"]).andReturn(mockOldValue);
     
     // Call the method and get the result
-    NSDictionary *result = [dataStoreMock getUserAttributeChangeProperties:event];
+    NSDictionary *result = [dataStoreMock userAttributeChangeProperties:event];
     
     // Verify the result dictionary
     XCTAssertEqual(result.count, 1);


### PR DESCRIPTION
## Overview
1. The updated value is not used in the completion callbacks for the user attributes methods. Remove it and remove the code that calculates it.

2. Persist the profile changes in `processEvent:withType:` even if in-apps are not supported.

3. Rename `getUserAttributeChangeProperties:` to `userAttributeChangeProperties:`.

4. In `userAttributeChangeProperties:` method, do not construct the multi value, since the multi value user attributes are not supported by the user attributes triggering. 
The multi value attributes are already persisted and calling the method `_constructLocalMultiValueWithOriginalValues:forKey:usingCommand:localDataStore:` produces an empty array.
The multi values are persisted in the method `_handleMultiValueProfilePush:updatedMultiValue:errors:`.