### PR TITLE
Fix increment/decrement value persistence when no cached value

### DIFF
--- a/CleverTapSDK/CTProfileBuilder.m
+++ b/CleverTapSDK/CTProfileBuilder.m
@@ -385,7 +385,8 @@
 }
 
 + (NSNumber *_Nullable)_getUpdatedValue:(NSNumber *_Nonnull)value forKey:(NSString *_Nonnull)key withCommand:(NSString *_Nonnull)command cachedValue:(id)cachedValue {
-    NSNumber *newValue;
+    // Set the new value to be the increment/decrement value in case there is no cached value
+    NSNumber *newValue = value;
     if ([cachedValue isKindOfClass: [NSNumber class]]) {
         NSNumber *cachedNumber = (NSNumber*)cachedValue;
         CFNumberType numberType = CFNumberGetType((CFNumberRef)cachedNumber);


### PR DESCRIPTION
## Overview
If there is no cached value, ie this is the first time increment/decrement is called for a user property, the value will not be persisted since the cached value is nil.
Set the `newValue` to equal the current `value`. If there is a cached value, the new value will be calculated, otherwise it will be the current value.