### PR TITLE
Move and refactor handshake logic to CTDomainFactory

### DIFF
--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -10,6 +10,9 @@ extern NSString *const ACCOUNT_TOKEN_HEADER;
 extern NSString *const REDIRECT_DOMAIN_KEY;
 extern NSString *const REDIRECT_NOTIF_VIEWED_DOMAIN_KEY;
 
+extern NSString *const LAST_TS_KEY;
+extern NSString *const FIRST_TS_KEY;
+
 extern NSString *const kLastSessionPing;
 extern NSString *const kLastSessionTime;
 extern NSString *const kSessionId;

--- a/CleverTapSDK/CTConstants.m
+++ b/CleverTapSDK/CTConstants.m
@@ -10,6 +10,9 @@ NSString *const ACCOUNT_TOKEN_HEADER = @"X-CleverTap-Token";
 NSString *const REDIRECT_DOMAIN_KEY = @"CLTAP_REDIRECT_DOMAIN_KEY";
 NSString *const REDIRECT_NOTIF_VIEWED_DOMAIN_KEY = @"CLTAP_REDIRECT_NOTIF_VIEWED_DOMAIN_KEY";
 
+NSString *const LAST_TS_KEY = @"CLTAP_LAST_TS_KEY";
+NSString *const FIRST_TS_KEY = @"CLTAP_FIRST_TS_KEY";
+
 NSString *const kLastSessionPing = @"last_session_ping";
 NSString *const kLastSessionTime = @"lastSessionTime";
 NSString *const kSessionId = @"sessionId";

--- a/CleverTapSDK/CTDomainFactory.h
+++ b/CleverTapSDK/CTDomainFactory.h
@@ -3,29 +3,55 @@
 //  CleverTapSDK
 //
 //  Created by Akash Malhotra on 19/01/23.
-//  Copyright © 2023 CleverTap. All rights reserved.
+//  Copyright © 2025 CleverTap. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import "CleverTapInstanceConfig.h"
+#import "CTRequestSender.h"
+#import "CTDispatchQueueManager.h"
 #if CLEVERTAP_SSL_PINNING
 #import "CTPinnedNSURLSessionDelegate.h"
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol CTDomainResolverDelegate <NSObject>
+
+- (void)onHandshakeSuccess;
+- (void)onMute;
+
+@end
 
 @interface CTDomainFactory : NSObject
+
 @property (nonatomic, strong, nullable) NSString *redirectDomain;
 @property (nonatomic, strong, nullable) NSString *explictEndpointDomain;
 @property (nonatomic, strong, nullable) NSString *redirectNotifViewedDomain;
 @property (nonatomic, strong, nullable) NSString *explictNotifViewedEndpointDomain;
+@property (nonatomic, strong, nullable) NSString *signedCallDomain;
 
-- (instancetype _Nonnull)initWithConfig:(CleverTapInstanceConfig* _Nonnull)config;
+@property (nonatomic, strong) CTDispatchQueueManager *dispatchQueueManager;
+@property (nonatomic, weak) id <CleverTapDomainDelegate> domainDelegate;
+@property (nonatomic, weak) id <CTDomainResolverDelegate> domainResolverDelegate;
+
+- (instancetype _Nonnull)initWithConfig:(CleverTapInstanceConfig *)config;
 - (void)persistRedirectDomain;
 - (void)persistRedirectNotifViewedDomain;
 - (void)clearRedirectDomain;
 
 #if CLEVERTAP_SSL_PINNING
-- (instancetype _Nonnull)initWithConfig:(CleverTapInstanceConfig* _Nonnull)config pinnedNSURLSessionDelegate: (CTPinnedNSURLSessionDelegate* _Nonnull)pinnedNSURLSessionDelegate sslCertNames:(NSArray* _Nonnull)sslCertNames;
+- (instancetype)initWithConfig:(CleverTapInstanceConfig *)config pinnedNSURLSessionDelegate:(CTPinnedNSURLSessionDelegate *)pinnedNSURLSessionDelegate sslCertNames:(NSArray *)sslCertNames;
 #endif
+
+- (BOOL)isMuted;
+- (BOOL)needsHandshake;
+- (void)runSerialAsyncEnsureHandshake:(void(^)(BOOL success))block;
+- (BOOL)updateStateFromResponseHeaders:(NSDictionary *)headers;
+- (BOOL)updateStateForNotificationsFromResponseHeaders:(NSDictionary *)headers;
+- (void)setRequestSender:(CTRequestSender *)requestSender;
+- (NSString *)domainString;
+
 @end
 
+NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/CTDomainFactory.m
+++ b/CleverTapSDK/CTDomainFactory.m
@@ -3,16 +3,27 @@
 //  CleverTapSDK
 //
 //  Created by Akash Malhotra on 19/01/23.
-//  Copyright © 2023 CleverTap. All rights reserved.
+//  Copyright © 2025 CleverTap. All rights reserved.
 //
 
 #import "CTDomainFactory.h"
 #import "CTPreferences.h"
 #import "CTConstants.h"
 #import "CleverTapInstanceConfigPrivate.h"
+#import "CTRequestFactory.h"
+#import "CleverTap+SCDomain.h"
+
+NSString *const kREDIRECT_HEADER = @"X-WZRK-RD";
+NSString *const kREDIRECT_NOTIF_VIEWED_HEADER = @"X-WZRK-SPIKY-RD";
+NSString *const kMUTE_HEADER = @"X-WZRK-MUTE";
+
+NSString *const kMUTED_TS_KEY = @"CLTAP_MUTED_TS_KEY";
 
 @interface CTDomainFactory ()
 @property (nonatomic, strong) CleverTapInstanceConfig *config;
+@property (nonatomic, strong) CTRequestSender *requestSender;
+
+@property (nonatomic, assign) NSTimeInterval lastMutedTs;
 
 #if CLEVERTAP_SSL_PINNING
 @property(nonatomic, strong) CTPinnedNSURLSessionDelegate *urlSessionDelegate;
@@ -28,6 +39,7 @@
         self.config = config;
         self.redirectDomain = [self loadRedirectDomain];
         self.redirectNotifViewedDomain = [self loadRedirectNotifViewedDomain];
+        [self loadMutedTs];
     }
     return self;
 }
@@ -41,10 +53,27 @@
         self.sslCertNames = sslCertNames;
         self.redirectDomain = [self loadRedirectDomain];
         self.redirectNotifViewedDomain = [self loadRedirectNotifViewedDomain];
+        [self loadMutedTs];
     }
     return self;
 }
 #endif
+
+- (void)setRequestSender:(CTRequestSender *)requestSender {
+    _requestSender = requestSender;
+}
+
+- (void)loadMutedTs {
+    if (self.config.isDefaultInstance) {
+        self.lastMutedTs = [CTPreferences getIntForKey:[CTPreferences storageKeyWithSuffix:LAST_TS_KEY config: self.config] withResetValue:[CTPreferences getIntForKey:kMUTED_TS_KEY withResetValue:0]];
+    } else {
+        self.lastMutedTs = [CTPreferences getIntForKey:[CTPreferences storageKeyWithSuffix:LAST_TS_KEY config: self.config] withResetValue:0];
+    }
+}
+
+- (BOOL)isMuted {
+    return [NSDate new].timeIntervalSince1970 - self.lastMutedTs < 24 * 60 * 60;
+}
 
 - (void)clearRedirectDomain {
     self.redirectDomain = nil;
@@ -128,6 +157,197 @@
     } else {
         [CTPreferences removeObjectForKey:REDIRECT_NOTIF_VIEWED_DOMAIN_KEY];
         [CTPreferences removeObjectForKey:[CTPreferences storageKeyWithSuffix:REDIRECT_NOTIF_VIEWED_DOMAIN_KEY config: self.config]];
+    }
+}
+
+- (void)persistMutedTs {
+    self.lastMutedTs = [NSDate new].timeIntervalSince1970;
+    [CTPreferences putInt:self.lastMutedTs forKey:[CTPreferences storageKeyWithSuffix:kMUTED_TS_KEY config: self.config]];
+}
+
+#pragma mark - Handshake Handling
+
+- (BOOL)needsHandshake {
+    if ([self isMuted] || self.explictEndpointDomain) {
+        return NO;
+    }
+    return self.redirectDomain == nil;
+}
+
+- (void)performHandshakeWithCompletion:(void (^)(BOOL success))completion {
+    if (!self.requestSender) {
+        CleverTapLogInternal(self.config.logLevel, @"%@: Cannot perform handshake: requestSender is nil", self);
+        if (completion) {
+            completion(NO);
+        }
+        return;
+    }
+    
+    if (![self needsHandshake]) {
+        [self onDomainAvailable];
+        if (completion) {
+            completion(YES);
+        }
+        return;
+    }
+    
+    CleverTapLogInternal(self.config.logLevel, @"%@: Starting handshake with %@", self, kHANDSHAKE_URL);
+    
+    CTRequest *ctRequest = [CTRequestFactory helloRequestWithConfig:self.config];
+    
+    [ctRequest onResponse:^(NSData * _Nullable data, NSURLResponse * _Nullable response) {
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+            if (httpResponse.statusCode == 200) {
+                NSDictionary *headers = httpResponse.allHeaderFields;
+                BOOL redirectUpdated = [self updateStateFromResponseHeaders:headers];
+                BOOL notifViewedRedirectUpdated = [self updateStateForNotificationsFromResponseHeaders:headers];
+                [self updateMutedFromResponseHeaders:headers];
+                [self handleHandshakeSuccess];
+                
+                if (completion) {
+                    completion(redirectUpdated || notifViewedRedirectUpdated);
+                }
+            } else {
+                [self onDomainUnavailable];
+                CleverTapLogInternal(self.config.logLevel, @"%@: Handshake failed with status code %ld", self, (long)httpResponse.statusCode);
+                if (completion) {
+                    completion(NO);
+                }
+            }
+        } else {
+            [self onDomainUnavailable];
+            CleverTapLogInternal(self.config.logLevel, @"%@: Handshake failed", self);
+            if (completion) {
+                completion(NO);
+            }
+        }
+    }];
+    
+    [ctRequest onError:^(NSError * _Nullable error) {
+        CleverTapLogInternal(self.config.logLevel, @"%@: Handshake error: %@", self, error.localizedDescription);
+        if (completion) {
+            completion(NO);
+        }
+    }];
+    
+    [self.requestSender send:ctRequest];
+}
+
+- (void)updateMutedFromResponseHeaders:(NSDictionary *)headers {
+    NSString *mutedString = headers[kMUTE_HEADER];
+    BOOL muted = (mutedString == nil ? NO : [mutedString boolValue]);
+    if (muted) {
+        [self persistMutedTs];
+        if (self.domainResolverDelegate && [self.domainResolverDelegate respondsToSelector:@selector(onMute)]) {
+            [self.domainResolverDelegate onMute];
+        }
+    }
+}
+
+- (BOOL)updateStateFromResponseHeaders:(NSDictionary *)headers {
+    CleverTapLogInternal(self.config.logLevel, @"%@: Processing response with headers:%@", self, headers);
+    BOOL shouldRedirect = NO;
+    
+    @try {
+        NSString *redirectDomain = headers[kREDIRECT_HEADER];
+        if (redirectDomain != nil) {
+            NSString *currentDomain = self.redirectDomain;
+            self.redirectDomain = redirectDomain;
+            if (![self.redirectDomain isEqualToString:currentDomain]) {
+                shouldRedirect = YES;
+                [self persistRedirectDomain];
+                CleverTapLogInternal(self.config.logLevel, @"%@: Redirect domain updated to: %@", self, redirectDomain);
+                [self onDomainAvailable];
+            }
+        }
+    } @catch(NSException *e) {
+        CleverTapLogInternal(self.config.logLevel, @"%@: Error processing response headers: %@", self, e.debugDescription);
+    }
+    
+    return shouldRedirect;
+}
+
+- (BOOL)updateStateForNotificationsFromResponseHeaders:(NSDictionary *)headers {
+    CleverTapLogInternal(self.config.logLevel, @"%@: Processing response with headers:%@", self, headers);
+    BOOL shouldRedirect = NO;
+    
+    @try {
+        NSString *redirectNotifViewedDomain = headers[kREDIRECT_NOTIF_VIEWED_HEADER];
+        if (redirectNotifViewedDomain != nil) {
+            NSString *currentDomain = self.redirectNotifViewedDomain;
+            self.redirectNotifViewedDomain = redirectNotifViewedDomain;
+            if (![self.redirectNotifViewedDomain isEqualToString:currentDomain]) {
+                shouldRedirect = YES;
+                [self persistRedirectNotifViewedDomain];
+                CleverTapLogInternal(self.config.logLevel, @"%@: Notification viewed redirect domain updated to: %@", self, redirectNotifViewedDomain);
+            }
+        }
+    } @catch(NSException *e) {
+        CleverTapLogInternal(self.config.logLevel, @"%@: Error processing Notification Viewed response headers: %@", self, e.debugDescription);
+    }
+    
+    return shouldRedirect;
+}
+
+- (void)handleHandshakeSuccess {
+    CleverTapLogInternal(self.config.logLevel, @"%@: handshake success", self);
+    
+    if (self.domainResolverDelegate && [self.domainResolverDelegate respondsToSelector:@selector(onHandshakeSuccess)]) {
+        [self.domainResolverDelegate onHandshakeSuccess];
+    }
+}
+
+- (void)runSerialAsyncEnsureHandshake:(void(^)(BOOL success))block {
+    [self.dispatchQueueManager runSerialAsync:^{
+        if (![self needsHandshake]) {
+            if (block) {
+                block(YES);
+            }
+            return;
+        }
+        
+        // Need to simulate a synchronous request
+        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+        [self performHandshakeWithCompletion:^(BOOL success) {
+            if (block) {
+                block(success);
+            }
+            dispatch_semaphore_signal(semaphore);
+        }];
+        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    }];
+}
+
+- (void)onDomainAvailable {
+    NSString *dcDomain = [self domainString];
+    if (self.domainDelegate && [self.domainDelegate respondsToSelector:@selector(onSCDomainAvailable:)]) {
+        [self.domainDelegate onSCDomainAvailable: dcDomain];
+    } else if (dcDomain == nil) {
+        [self onDomainUnavailable];
+    }
+}
+
+- (void)onDomainUnavailable {
+    if (self.domainDelegate && [self.domainDelegate respondsToSelector:@selector(onSCDomainUnavailable)]) {
+        [self.domainDelegate onSCDomainUnavailable];
+    }
+}
+
+// Updates the format of the domain.
+// From `in1.clevertap-prod.com` to region.auth.domain (i.e. in1.auth.clevertap-prod.com)
+- (NSString *)domainString {
+    if (self.redirectDomain != nil) {
+        NSArray *listItems = [self.redirectDomain componentsSeparatedByString:@"."];
+        NSString *domainItem = [listItems[0] stringByAppendingString:@".auth"];
+        for (int i = 1; i < listItems.count; i++ ) {
+            NSString *dotString = [@"." stringByAppendingString: listItems[i]];
+            domainItem = [domainItem stringByAppendingString: dotString];
+        }
+        self.signedCallDomain = domainItem;
+        return domainItem;
+    } else {
+        return nil;
     }
 }
 


### PR DESCRIPTION
## Overview
Moves and refactors the handshake logic from `CleverTap` to `CTDomainFactory`.
Centralizes domain-related functionality in a more appropriate location.
Simplify sending requests that require a handshake.

### Remarks
Added the "do not merge" label since this should ultimately be merged to `develop`. However, the base branch is `v7.2.0` to ease the merge after that release.