### PR TITLE
[SDK-4819] Cleanup webview when dismissing HTML ViewController

### DIFF
--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -386,6 +386,26 @@ typedef enum {
     }
 }
 
+- (void)cleanupWebViewResources {
+    if (webView) {
+        webView.navigationDelegate = nil;
+        [webView.configuration.userContentController removeScriptMessageHandlerForName:@"clevertap"];
+        
+        if (_panGesture) {
+            [webView removeGestureRecognizer:_panGesture];
+            _panGesture.delegate = nil;
+            _panGesture = nil;
+        }
+        
+        [webView removeFromSuperview];
+        webView = nil;
+    }
+    _jsInterface = nil;
+}
+
+- (void)dealloc {
+    [self cleanupWebViewResources];
+}
 
 #pragma mark - Revealing Setter
 
@@ -549,14 +569,8 @@ typedef enum {
 }
 
 - (void)hide:(BOOL)animated {
-    __weak typeof(self) weakSelf = self;
-    [self hideFromWindow:animated withCompletion:^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) {
-            return;
-        }
-        [strongSelf->webView.configuration.userContentController removeScriptMessageHandlerForName:@"clevertap"];
-    }];
+    [self cleanupWebViewResources];
+    [super hideFromWindow:animated];
 }
 
 @end


### PR DESCRIPTION
## Overview
Cleanup web view resources when dismissing the `CTInAppHTMLViewController`.
Ensure to remove the `webView` from the `super view`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource cleanup for in-app message views, ensuring smoother performance and stability when closing or hiding these messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->