### PR TITLE
SDWebImage Embed Settings Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-### [Version 7.2.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/7.2.0) (May 26, 2025)
+### [Version 7.2.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/7.2.0) (May 27, 2025)
 
 #### Added
 - Introduces System App Functions (Open Url, App Rating, Push Permission Request - as mentioned [here](/docs/SystemInAppFunctions.md)) which can be triggered either as a button action within an in-app message or as a standalone campaign action in CleverTap, enriching client workflows.

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .binaryTarget(
             name: "CleverTapSDK",
             url: "https://d1new0xr8otir0.cloudfront.net/CleverTapSDK-7.2.0.xcframework.zip",
-            checksum: "6f1608e38f1b9c822e56a6934203e29a9261f14ea4d1118d359fd733b26f018b"
+            checksum: "2f7935c89f099194c5fede42f39598d430ff7d5d219863a3e159c9e7f0e3ddf6"
         ),
         .target(
             name: "CleverTapLocation",

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .binaryTarget(
             name: "CleverTapSDK",
             url: "https://d1new0xr8otir0.cloudfront.net/CleverTapSDK-7.2.0.xcframework.zip",
-            checksum: "2f7935c89f099194c5fede42f39598d430ff7d5d219863a3e159c9e7f0e3ddf6"
+            checksum: "50c88d641327513a948937031874fc082b626fa401a55815600e0b49cacd1479"
         ),
         .target(
             name: "CleverTapLocation",


### PR DESCRIPTION
The embedded framework settings for SDWebImage inside CleverTapSDK's project settings is wrongly set to "Embed and Sign". This PR reverts it back to "Do Not Embed".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal build configuration for framework embedding.
  - Refreshed the checksum for the CleverTapSDK binary target to ensure package integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->