### PR TITLE
[SDK-4954] User Switch responses

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2334,7 +2334,7 @@ static BOOL sharedInstanceErrorLogged;
 #if !defined(CLEVERTAP_TVOS)
                 if (!self.isUserSwitching) {
                     [self.contentFetchManager handleContentFetch:jsonResp];
-                } else {
+                } else if (jsonResp[CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY]) {
                     CleverTapLogDebug(self.config.logLevel, @"%@: Content fetch response will not be handled due to user switch", self);
                 }
 #endif

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -269,7 +269,7 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 
 @property (nonatomic, strong) NSLocale *locale;
 
-@property (nonatomic, assign) BOOL isUserSwitching;
+@property (atomic, assign) BOOL isUserSwitching;
 
 - (instancetype)init __unavailable;
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2354,12 +2354,14 @@ static BOOL sharedInstanceErrorLogged;
                 [self handleGeofencesResponse:jsonResp];
 #endif
                 
-                // Handle and Cache PE Variables
+                // Handle PE Variables
                 NSDictionary *varsResponse = jsonResp[CLTAP_PE_VARS_RESPONSE_KEY];
                 if (varsResponse) {
+                    // Do not handle variables if the user is switching. Do not trigger fetch variables callback.
                     if (!self.isUserSwitching) {
                         [[self variables] handleVariablesResponse: jsonResp[CLTAP_PE_VARS_RESPONSE_KEY]];
                     } else {
+                        // Log only if variables are received in the response and will not be handled.
                         CleverTapLogDebug(self.config.logLevel, @"%@: PE Variables will not be handled due to user switch", self);
                     }
                 }

--- a/CleverTapSDK/CleverTapInternal.h
+++ b/CleverTapSDK/CleverTapInternal.h
@@ -39,6 +39,8 @@ typedef NS_ENUM(NSInteger, CleverTapEventType) {
 
 @property (nonatomic, strong, readonly) CTFileDownloader * _Nullable fileDownloader;
 
+@property (nonatomic, assign, readonly) BOOL isUserSwitching;
+
 + (NSMutableDictionary<NSString *, CleverTap *> * _Nullable)getInstances;
 
 - (void)recordInAppNotificationStateEvent:(BOOL)clicked

--- a/CleverTapSDK/CleverTapInternal.h
+++ b/CleverTapSDK/CleverTapInternal.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, CleverTapEventType) {
 
 @property (nonatomic, strong, readonly) CTFileDownloader * _Nullable fileDownloader;
 
-@property (nonatomic, assign, readonly) BOOL isUserSwitching;
+@property (atomic, assign, readonly) BOOL isUserSwitching;
 
 + (NSMutableDictionary<NSString *, CleverTap *> * _Nullable)getInstances;
 

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -69,10 +69,10 @@
         return;
     }
     
-    if (self.isUserSwitching && (jsonResp[CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY] || jsonResp[CLTAP_INAPP_JSON_RESPONSE_KEY])) {
-        CleverTapLogDebug(self.config.logLevel, @"%@: InApp Notifications will not be handled due to user switch", self);
-        return;
-    } else if (self.isUserSwitching) {
+    if (self.isUserSwitching) {
+        if (jsonResp[CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY] || jsonResp[CLTAP_INAPP_JSON_RESPONSE_KEY]) {
+            CleverTapLogDebug(self.config.logLevel, @"%@: InApp Notifications will not be handled due to user switch", self);
+        }
         return;
     }
     

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -71,8 +71,10 @@
     
     if (self.isUserSwitching) {
         if (jsonResp[CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY] || jsonResp[CLTAP_INAPP_JSON_RESPONSE_KEY]) {
+            // Log only if in-apps are received in the response and will not be handled.
             CleverTapLogDebug(self.config.logLevel, @"%@: InApp Notifications will not be handled due to user switch", self);
         }
+        // Do not show any in-apps if the user is switching. Do not trigger the fetch in-apps callback.
         return;
     }
     

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -69,6 +69,11 @@
         return;
     }
     
+    if (self.isUserSwitching) {
+        CleverTapLogDebug(self.config.logLevel, @"%@: InApp Notifications will not be handled due to user switch", self);
+        return;
+    }
+    
     // Parse SS App Launched notifications
     NSArray *inAppNotifsAppLaunched = jsonResp[CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY];
     if (inAppNotifsAppLaunched) {

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -69,8 +69,10 @@
         return;
     }
     
-    if (self.isUserSwitching) {
+    if (self.isUserSwitching && (jsonResp[CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY] || jsonResp[CLTAP_INAPP_JSON_RESPONSE_KEY])) {
         CleverTapLogDebug(self.config.logLevel, @"%@: InApp Notifications will not be handled due to user switch", self);
+        return;
+    } else if (self.isUserSwitching) {
         return;
     }
     


### PR DESCRIPTION
## Overview
Introduces a change to the user switching and processing responses.

When `onUserLogin` is called, checks are made to determine if the `deviceId` should be changed. If so, an asynchronous user switch is performed. Before the `deviceId` is changed, the current user (`deviceId`) information is sent to the API. 

When the events are flushed, the responses are parsed and processed. This data is for the user (`deviceId`) that is about to be changed. When processing those responses, do _not_ handle any data that could lead to displaying or updating campaigns.

## Implementation
Sets a `isUserSwitching` flag to determine if the SDK is in the process of switching the user and changing the `deviceId`.
Refactors response handling for different features into separate methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced improved handling for user switching, ensuring certain notifications and content are not processed during a user switch to prevent inconsistencies.

- **Refactor**
	- Streamlined response processing by separating response handling into dedicated methods for better maintainability.

- **Bug Fixes**
	- Prevented in-app notifications and content updates from being processed during user switch operations, reducing the risk of conflicting updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->