### PR TITLE
Invalidate cloudfront cache after uploading a new xcframework

### DIFF
--- a/.github/workflows/update_package_swift.yml
+++ b/.github/workflows/update_package_swift.yml
@@ -96,6 +96,16 @@ jobs:
           echo "S3_FILENAME=$S3_FILENAME" >> $GITHUB_ENV
           echo "✅ Uploaded to S3 as $S3_FILENAME"
 
+      - name: Invalidate CloudFront Cache
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          CLOUDFRONT_DIST_ID: ${{ secrets.CLOUDFRONT_DIST_ID }}
+        run: |
+          aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DIST_ID" --paths '/*'
+          echo "✅ CloudFront invalidation triggered."
+
       - name: Pull Latest Changes
         run: |
           git pull origin develop --rebase || true


### PR DESCRIPTION
The cloudfront server does not point to the updated artifact after a new XCFramework is uploaded to s3. An additional command has been added to the workflow to make it invalidate its cache for this purpose.