### PR TITLE
[SDK-4917] Fixes push primer callback crash if completion is nil

### DIFF
--- a/CleverTapSDK/CTPushPrimerManager.m
+++ b/CleverTapSDK/CTPushPrimerManager.m
@@ -138,12 +138,17 @@
                 } else {
                     CleverTapLogDebug(self.config.logLevel, @"%@: Push Notification permission is already granted.", self);
                 }
-                completion(pushPermissionPresented);
+                
+                if (completion) {
+                    completion(pushPermissionPresented);
+                }
             }];
         }];
     } else {
         CleverTapLogDebug(self.config.logLevel, @"%@: Push Notification is avaliable from iOS v10.0 or later", self);
-        completion(NO);
+        if (completion) {
+            completion(NO);
+        }
     }
 }
 


### PR DESCRIPTION
## Overview
when `promptForPushPermission:` method is called from client side, the completion block is executed while it is passed as nil internally which leads to crash. To fix this, added a condition to execute completion block only when it is not nil inside `promptForOSPushNotificationWithFallbackToSettings:` method.