### PR TITLE
[SDK-4916] Filter out system templates in sync payload

### DIFF
--- a/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager.m
+++ b/CleverTapSDK/InApps/CustomTemplates/CTCustomTemplatesManager.m
@@ -188,6 +188,11 @@ static NSMutableArray<id<CTTemplateProducer>> *templateProducers;
     NSMutableDictionary *definitions = [NSMutableDictionary dictionary];
     NSDictionary *templates = [self templates];
     [templates enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull templateKey, CTCustomTemplate * _Nonnull template, BOOL * _Nonnull stop) {
+        if (template.isSystemDefined) {
+            // Don't add system defined templates in sync payload.
+            return;
+        }
+
         NSMutableDictionary *templateData = [NSMutableDictionary dictionary];
         templateData[@"type"] = template.templateType;
 


### PR DESCRIPTION
## Overview

Currently we are sending system defined templates in sync payload which leads to `No new templates are synced` error and not syncing new templates. We have filtered out the system defined templates as they are not needed during sync templates.