### PR TITLE
[SDK-5083] Fixes crash in CTInAppHTMLViewController

### DIFF
--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -70,6 +70,12 @@ typedef enum {
 }
 
 - (void)layoutNotification {
+    if (_jsInterface == nil) {
+        // When device is rotated and inapp is closed at same time, cleanupWebViewResources can be called
+        // first which makes _jsInterface nil and then layoutNotification is again called.
+        // Added this safety check to avoid crash in this race condition as inapp is already dismissed.
+        return;
+    }
     _currentStatus = kWRSlideStatusNormal;
     
     // control the initial scale of the WKWebView


### PR DESCRIPTION
## Overview
- When device is rotated and HTML inApp is closed at same time, `cleanupWebViewResources` can be called first which makes `_jsInterface` nil and then layoutNotification is again called, which leads to crash.
- Added safety check to avoid crash in this race condition as HTML inApp is already dismissed.