### PR TITLE
[SDK-5187] Fixes SDWebImage conflict via SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     dependencies: [],
     targets: [
         .binaryTarget(
-            name: "SDWebImage",
+            name: "SDWebImageCT",
             url: "https://github.com/SDWebImage/SDWebImage/releases/download/5.21.0/SDWebImage-dynamic.xcframework.zip",
             checksum: "e034ea04f5e86866bc3081d009941bd5b2a2ed705b3a06336656484514116638"
         ),
@@ -51,12 +51,11 @@ let package = Package(
             name: "CleverTapSDKWrapper",
             dependencies: [
                 "CleverTapSDK",
-                "SDWebImage"
+                "SDWebImageCT"
             ],
             path: "CleverTapSDKWrapper",
             linkerSettings: [
-                .linkedLibrary("sqlite3"),
-                .linkedFramework("SDWebImage", .when(platforms: [.iOS]))
+                .linkedLibrary("sqlite3")
             ]
         ),
         .target(


### PR DESCRIPTION
- When we add other library using SDWebImage like SDWebImageSwiftUI and SDWebImageWebPCoder, we get conflict while adding our SDK via SPM - `multiple packages declare targets with a conflicting name: 'SDWebImage'; target names need to be unique across the package graph`.
- To fix this added SDWebImage library with a different name `SDWebImageCT` as binary target and do not linked the framework.