### PR TITLE
SDK-5299 : Potential Inbox fixes

### DIFF
--- a/CleverTapSDK/Inbox/controllers/CTInboxController.m
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.m
@@ -151,7 +151,7 @@ static dispatch_once_t coordinatorOnceToken;
         
         if (haveUpdates) {
             [strongSelf _save];
-            [strongSelf _notifyUpdateOnMainThread];
+            [strongSelf _notifyUpdate];
         }
     }];
 }
@@ -212,7 +212,7 @@ static dispatch_once_t coordinatorOnceToken;
         if (message) {
             message.isRead = YES;
             [strongSelf _save];
-            [strongSelf _notifyUpdateOnMainThread];
+            [strongSelf _notifyUpdate];
         }
     }];
 }
@@ -243,7 +243,7 @@ static dispatch_once_t coordinatorOnceToken;
         
         if (hasChanges) {
             [strongSelf _save];
-            [strongSelf _notifyUpdateOnMainThread];
+            [strongSelf _notifyUpdate];
         }
     }];
 }
@@ -326,7 +326,7 @@ static dispatch_once_t coordinatorOnceToken;
     }
     
     [self _save];
-    [self _notifyUpdateOnMainThread];
+    [self _notifyUpdate];
 }
 
 // Always call from inside context performBlock/performBlockAndWait
@@ -360,10 +360,7 @@ static dispatch_once_t coordinatorOnceToken;
     
     // Delete expired messages
     if (toDelete.count > 0) {
-        for (CTMessageMO *msg in toDelete) {
-            [self.context deleteObject:msg];
-        }
-        [self _save];
+        [self _deleteMessages:toDelete];
     }
     
     return messages;
@@ -388,12 +385,10 @@ static dispatch_once_t coordinatorOnceToken;
 
 #pragma mark - Delegate Notification
 
-- (void)_notifyUpdateOnMainThread {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.delegate && [self.delegate respondsToSelector:@selector(inboxMessagesDidUpdate)]) {
-            [self.delegate inboxMessagesDidUpdate];
-        }
-    });
+- (void)_notifyUpdate {
+    if (self.delegate && [self.delegate respondsToSelector:@selector(inboxMessagesDidUpdate)]) {
+        [self.delegate inboxMessagesDidUpdate];
+    }
 }
 
 @end


### PR DESCRIPTION
Potential/Theoretical fixes non-reproducible inbox crashes:

 ### Background:
- This PR has potential/theoretical fixes to rare inbox crashes that are concurrency related.
- Replacing the old parent-child context strategy to a singular one.
- Added certain threading and null checks.

### Testing:
- Use multiple CT instances plus the shared one. Initialize the inbox with all of them and call multiple public inbox methods before and after initialization.
- Initialize inbox at app launch itself to test edge cases.
- Open inbox with a custom inbox config object.
- Add a debug flag called `-com.apple.CoreData.ConcurrencyDebug 1` to the sample app scheme's arguments. Its should not crash.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced inbox message storage infrastructure with improved data management and synchronization, resulting in better reliability and stability for message handling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->