### PR TITLE
[SDK-5250] Fixes multiple profiles created when using custom instance with onUserLogin

### DIFF
--- a/CleverTapSDK/CleverTapInstanceConfig.m
+++ b/CleverTapSDK/CleverTapInstanceConfig.m
@@ -235,7 +235,7 @@
     _handshakeDomain = isDefault ? plist.handshakeDomain : nil;
     _encryptionInTransitEnabled = isDefault ? plist.encryptionInTransitEnabled : NO;
     
-    // Initialise cryptManager with 0 encrytpion level for custom instance also.
+    // Initialise cryptManager with 0 encryption level for custom instance also.
     _cryptManager = [[CTEncryptionManager alloc] initWithAccountID:_accountId encryptionLevel:_encryptionLevel isDefaultInstance:isDefault];
 }
 


### PR DESCRIPTION
- When we are using custom instance without setting encryption level and doing onUserLogin, multiple profile were created as cryptManager was not initialised in this case.
- Improved the encryption flow to initialise cryptManager with encryption level 0 even when it is not set for custom instance, which will fixes the above problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed encryption initialization for custom instance configurations to ensure consistent behavior across all instance types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->