### PR TITLE
SDK-5375: App Launched checks Gate app lifecycle operations by actual foreground state

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1128,16 +1128,24 @@ static BOOL sharedInstanceErrorLogged;
 
 - (void)_appEnteredForeground {
     if ([CTUIUtils runningInsideAppExtension]) return;
+    
+    // Check application state
+    UIApplication *application = [CTUIUtils getSharedApplication];
+    BOOL isActuallyInForeground = (application.applicationState == UIApplicationStateActive);
     [self.sessionManager updateSessionStateOnLaunch];
-    if (!self.isAppForeground) {
+    
+    // Only record app launched if app is transitioning to foreground and app is active
+    if (!self.isAppForeground && isActuallyInForeground) {
         [self recordAppLaunched:@"appEnteredForeground"];
         [self scheduleQueueFlush];
         CleverTapLogInternal(self.config.logLevel, @"%@: app is in foreground", self);
     }
-    self.isAppForeground = YES;
+    
+    // Set flag based on actual state
+    self.isAppForeground = isActuallyInForeground;
     
 #if !CLEVERTAP_NO_INAPP_SUPPORT
-    if (!_config.analyticsOnly && ![CTUIUtils runningInsideAppExtension]) {
+    if (isActuallyInForeground && !_config.analyticsOnly && ![CTUIUtils runningInsideAppExtension]) {
         [self.inAppFCManager checkUpdateDailyLimits];
     }
 #endif


### PR DESCRIPTION
- Prevented App Launched events from being raised when the app is woken up via a silent push @coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of foreground state detection for more reliable session tracking.
  * Fixed app-launch recording to only occur when the app truly transitions to foreground.
  * Corrected session handling and limit checks to reflect actual app state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->