### PR TITLE
App Inbox: add default media fallback when orientation is missing

### DIFF
--- a/CleverTapSDK/Inbox/cells/CTCarouselImageMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTCarouselImageMessageCell.m
@@ -17,7 +17,7 @@
         NSString *imageDescription = content.mediaDescription ? content.mediaDescription : [NSString stringWithFormat:@"Message Image %d", imageNumber];
         imageNumber = imageNumber + 1;
         
-        if (imageUrl == nil) {
+        if (imageUrl == nil || imageUrl.length == 0) {
             continue;
         }
         CTCarouselImageView *itemView;
@@ -27,7 +27,8 @@
             frame.size.width = frame.size.width;
             itemView = [[CTCarouselImageView alloc] initWithFrame:frame
                                                          imageUrl:imageUrl actionUrl:actionUrl
-                                              orientationPortrait: [self orientationIsPortrait]
+                                                 orientationKnown:![self shouldUseDefaultMediaLayout]
+                                              orientationPortrait:[self orientationIsPortrait]
                                                  imageDescription:imageDescription];
         }
         
@@ -50,12 +51,19 @@
         CGFloat viewWidth = (CGFloat)[[UIScreen mainScreen] bounds].size.width - margins*2;
         CGFloat viewHeight = viewWidth / 3.5;
         self.carouselViewHeight.constant  = viewHeight;
-        self.carouselLandRatioConstraint.priority = [self orientationIsPortrait] ? 750 : 999;
-        self.carouselPortRatioConstraint.priority = [self orientationIsPortrait] ? 999 : 750;
+        if ([self shouldUseDefaultMediaLayout]) {
+            self.carouselLandRatioConstraint.priority = 250;
+            self.carouselPortRatioConstraint.priority = 250;
+        } else {
+            self.carouselLandRatioConstraint.priority = [self orientationIsPortrait] ? 750 : 999;
+            self.carouselPortRatioConstraint.priority = [self orientationIsPortrait] ? 999 : 750;
+        }
     } else {
         CGFloat viewWidth = (CGFloat)  [[UIScreen mainScreen] bounds].size.width;
         CGFloat viewHeight = viewWidth;
-        if (![self orientationIsPortrait]) {
+        if ([self shouldUseDefaultMediaLayout]) {
+            viewHeight = (viewWidth * [self getLandscapeMultiplier]);
+        } else if (![self orientationIsPortrait]) {
             viewHeight = (viewWidth*[self getLandscapeMultiplier]);
         }
         CGRect frame = CGRectMake(0, 0, viewWidth, viewHeight);

--- a/CleverTapSDK/Inbox/cells/CTCarouselMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTCarouselMessageCell.m
@@ -36,10 +36,11 @@ static const float kPageControlViewHeight = 30.f;
 
 - (void)populateLandscapeViews {
     self.itemViews = [NSMutableArray new];
-    NSUInteger index = 0;
+    NSUInteger originalIndex = 0;
     int imageNumber = 1;
     for (CleverTapInboxMessageContent *content in (self.message.content)) {
         if (content.mediaUrl.length == 0) {
+            originalIndex++;
             continue;
         }
         CTCarouselImageView *carouselItemView;
@@ -67,16 +68,16 @@ static const float kPageControlViewHeight = 30.f;
         
         UITapGestureRecognizer *carouselViewTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleItemViewTapGesture:)];
         carouselItemView.userInteractionEnabled = YES;
-        carouselItemView.tag = index;
+        carouselItemView.tag = originalIndex;
         [carouselItemView addGestureRecognizer:carouselViewTapGesture];
         [self.itemViews addObject:carouselItemView];
-        index++;
+        originalIndex++;
     }
 }
 
 - (void)populateItemViews {
     self.itemViews = [NSMutableArray new];
-    NSUInteger index = 0;
+    NSUInteger originalIndex = 0;
     int imageNumber = 1;
     for (CleverTapInboxMessageContent *content in (self.message.content)) {
         NSString *caption = content.title;
@@ -89,6 +90,7 @@ static const float kPageControlViewHeight = 30.f;
         imageNumber = imageNumber + 1;
         
         if (imageUrl == nil || imageUrl.length == 0) {
+            originalIndex++;
             continue;
         }
         CTCarouselImageView *itemView;
@@ -109,10 +111,10 @@ static const float kPageControlViewHeight = 30.f;
         
         UITapGestureRecognizer *itemViewTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleItemViewTapGesture:)];
         itemView.userInteractionEnabled = YES;
-        itemView.tag = index;
+        itemView.tag = originalIndex;
         [itemView addGestureRecognizer:itemViewTapGesture];
         [self.itemViews addObject:itemView];
-        index++;
+        originalIndex++;
     }
 }
 

--- a/CleverTapSDK/Inbox/cells/CTCarouselMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTCarouselMessageCell.m
@@ -26,7 +26,9 @@ static const float kPageControlViewHeight = 30.f;
 
 - (CGFloat)calculateHeight:(CGFloat)viewWidth {
     CGFloat viewHeight = viewWidth + captionHeight;
-    if (![self orientationIsPortrait]) {
+    if ([self shouldUseDefaultMediaLayout]) {
+        viewHeight = (viewWidth * kLandscapeMultiplier) + captionHeight;
+    } else if (![self orientationIsPortrait]) {
         viewHeight = (viewWidth*kLandscapeMultiplier) + captionHeight;
     }
     return viewHeight;
@@ -37,15 +39,22 @@ static const float kPageControlViewHeight = 30.f;
     NSUInteger index = 0;
     int imageNumber = 1;
     for (CleverTapInboxMessageContent *content in (self.message.content)) {
+        if (content.mediaUrl.length == 0) {
+            continue;
+        }
         CTCarouselImageView *carouselItemView;
         if (carouselItemView == nil){
             carouselItemView  = [[[CTUIUtils bundle] loadNibNamed: NSStringFromClass([CTCarouselImageView class]) owner:nil options:nil] lastObject];
             carouselItemView.backgroundColor = [UIColor clearColor];
-            [carouselItemView.cellImageView sd_setImageWithURL:[NSURL URLWithString:content.mediaUrl]
-                                              placeholderImage:[self orientationIsPortrait] ? [self getPortraitPlaceHolderImage] : [self getLandscapePlaceHolderImage]
-                                                       options:self.sdWebImageOptions context:self.sdWebImageContext];
-            carouselItemView.imageViewLandRatioConstraint.priority = [self orientationIsPortrait] ? 750 : 999;
-            carouselItemView.imageViewPortRatioConstraint.priority = [self orientationIsPortrait] ? 999 : 750;
+            BOOL useDefaultLayout = [self shouldUseDefaultMediaLayout];
+            if (content.mediaUrl.length > 0) {
+                [carouselItemView.cellImageView sd_setImageWithURL:[NSURL URLWithString:content.mediaUrl]
+                                                  placeholderImage:useDefaultLayout ? [self getLandscapePlaceHolderImage] : ([self orientationIsPortrait] ? [self getPortraitPlaceHolderImage] : [self getLandscapePlaceHolderImage])
+                                                           options:self.sdWebImageOptions context:self.sdWebImageContext];
+            }
+            carouselItemView.cellImageView.contentMode = useDefaultLayout ? UIViewContentModeScaleAspectFit : UIViewContentModeScaleAspectFill;
+            carouselItemView.imageViewLandRatioConstraint.priority = useDefaultLayout ? 250 : ([self orientationIsPortrait] ? 750 : 999);
+            carouselItemView.imageViewPortRatioConstraint.priority = useDefaultLayout ? 250 : ([self orientationIsPortrait] ? 999 : 750);
             carouselItemView.titleLabel.text = content.title;
             carouselItemView.titleLabel.textColor = content.titleColor ? [CTUIUtils ct_colorWithHexString:content.titleColor] : [CTUIUtils ct_colorWithHexString:@"#000000"];
             carouselItemView.bodyLabel.text = content.message;
@@ -79,14 +88,23 @@ static const float kPageControlViewHeight = 30.f;
         NSString *imageDescription = content.mediaDescription ? content.mediaDescription : [NSString stringWithFormat:@"Message Image %d", imageNumber];
         imageNumber = imageNumber + 1;
         
-        if (imageUrl == nil) {
+        if (imageUrl == nil || imageUrl.length == 0) {
             continue;
         }
         CTCarouselImageView *itemView;
         if (itemView == nil){
             CGRect frame = self.carouselView.bounds;
             frame.size.height =  frame.size.height;
-            itemView = [[CTCarouselImageView alloc] initWithFrame:self.carouselView.bounds caption:caption subcaption:subcaption captionColor:captionColor subcaptionColor:subcaptionColor imageUrl:imageUrl actionUrl:actionUrl orientationPortrait: [self orientationIsPortrait] imageDescription:imageDescription];
+            itemView = [[CTCarouselImageView alloc] initWithFrame:self.carouselView.bounds
+                                                          caption:caption
+                                                       subcaption:subcaption
+                                                     captionColor:captionColor
+                                                  subcaptionColor:subcaptionColor
+                                                         imageUrl:imageUrl
+                                                        actionUrl:actionUrl
+                                                 orientationKnown:![self shouldUseDefaultMediaLayout]
+                                              orientationPortrait:[self orientationIsPortrait]
+                                                 imageDescription:imageDescription];
         }
         
         UITapGestureRecognizer *itemViewTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleItemViewTapGesture:)];

--- a/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.h
+++ b/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.h
@@ -65,6 +65,9 @@ typedef NS_OPTIONS(NSUInteger , CTMediaPlayerCellType) {
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView *activityIndicator;
 @property (nonatomic, strong) SDAnimatedImageView *defaultCellImageView;
 @property (nonatomic, strong) NSLayoutConstraint *defaultMediaHeightConstraint;
+@property (nonatomic, assign) CGFloat originalImageViewHeightConstant;
+@property (nonatomic, assign) UILayoutPriority originalImageViewHeightPriority;
+@property (nonatomic, assign) BOOL didCaptureImageViewHeightDefaults;
 
 
 @property (nonatomic, assign) SDWebImageOptions sdWebImageOptions;

--- a/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.h
+++ b/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.h
@@ -17,10 +17,13 @@ typedef NS_OPTIONS(NSUInteger , CTMediaPlayerCellType) {
     CTMediaPlayerCellTypeNone,
     CTMediaPlayerCellTypeTopLandscape,
     CTMediaPlayerCellTypeTopPortrait,
+    CTMediaPlayerCellTypeTopDefault,
     CTMediaPlayerCellTypeMiddleLandscape,
     CTMediaPlayerCellTypeMiddlePortrait,
+    CTMediaPlayerCellTypeMiddleDefault,
     CTMediaPlayerCellTypeBottomLandscape,
-    CTMediaPlayerCellTypeBottomPortrait
+    CTMediaPlayerCellTypeBottomPortrait,
+    CTMediaPlayerCellTypeBottomDefault
 };
 
 @interface CTInboxBaseMessageCell : UITableViewCell <CTInboxActionViewDelegate>
@@ -60,6 +63,8 @@ typedef NS_OPTIONS(NSUInteger , CTMediaPlayerCellType) {
 @property (atomic, assign) CTMediaPlayerCellType mediaPlayerCellType;
 @property (atomic, assign) CTInboxMessageType messageType;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView *activityIndicator;
+@property (nonatomic, strong) SDAnimatedImageView *defaultCellImageView;
+@property (nonatomic, strong) NSLayoutConstraint *defaultMediaHeightConstraint;
 
 
 @property (nonatomic, assign) SDWebImageOptions sdWebImageOptions;
@@ -71,9 +76,15 @@ typedef NS_OPTIONS(NSUInteger , CTMediaPlayerCellType) {
 - (void)configureActionView:(BOOL)hide;
 - (BOOL)mediaIsEmpty;
 - (BOOL)orientationIsPortrait;
+- (BOOL)shouldUseDefaultMediaLayout;
 - (BOOL)deviceOrientationIsLandscape;
 - (UIImage *)getPortraitPlaceHolderImage;
 - (UIImage *)getLandscapePlaceHolderImage;
+- (SDAnimatedImageView *)activeMediaImageView;
+- (void)configureDefaultMediaViewIfNeeded;
+- (void)resetDefaultMediaView;
+- (void)configureDefaultMediaLayoutWithFallbackRatio:(CGFloat)fallbackRatio;
+- (void)updateDefaultMediaLayoutForImage:(UIImage *)image fallbackRatio:(CGFloat)fallbackRatio;
 
 - (BOOL)hasAudio;
 - (BOOL)hasVideo;

--- a/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
@@ -103,6 +103,7 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
 
 - (void)configureForMessage:(CleverTapInboxMessage *)message {
     self.message = message;
+    [self resetDefaultMediaView];
     if (message.backgroundColor && ![message.backgroundColor isEqual:@""]) {
         self.containerView.backgroundColor = [CTUIUtils ct_colorWithHexString:message.backgroundColor];
     } else {
@@ -637,6 +638,10 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
         self.defaultMediaHeightConstraint.constant = 0;
         self.defaultMediaHeightConstraint.active = NO;
     }
+    if (self.imageViewHeightConstraint && self.didCaptureImageViewHeightDefaults) {
+        self.imageViewHeightConstraint.constant = self.originalImageViewHeightConstant;
+        self.imageViewHeightConstraint.priority = self.originalImageViewHeightPriority;
+    }
 }
 
 - (void)configureDefaultMediaLayoutWithFallbackRatio:(CGFloat)fallbackRatio {
@@ -651,7 +656,12 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
         self.imageViewPRatioConstraint.priority = 250;
     }
     if (self.imageViewHeightConstraint) {
-        self.imageViewHeightConstraint.priority = 999;
+        if (!self.didCaptureImageViewHeightDefaults) {
+            self.originalImageViewHeightConstant = self.imageViewHeightConstraint.constant;
+            self.originalImageViewHeightPriority = self.imageViewHeightConstraint.priority;
+            self.didCaptureImageViewHeightDefaults = YES;
+        }
+        self.imageViewHeightConstraint.priority = 250;
     }
     [self updateDefaultMediaLayoutForImage:nil fallbackRatio:fallbackRatio];
 }
@@ -670,16 +680,12 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
         width = CGRectGetWidth([UIScreen mainScreen].bounds);
     }
     CGFloat height = MAX(1.0, width * ratio);
-    if (self.imageViewHeightConstraint) {
-        self.imageViewHeightConstraint.constant = height;
-    } else {
-        if (!self.defaultMediaHeightConstraint) {
-            self.defaultMediaHeightConstraint = [self.mediaContainerView.heightAnchor constraintEqualToConstant:height];
-            self.defaultMediaHeightConstraint.priority = 999;
-        }
-        self.defaultMediaHeightConstraint.constant = height;
-        self.defaultMediaHeightConstraint.active = YES;
+    if (!self.defaultMediaHeightConstraint) {
+        self.defaultMediaHeightConstraint = [self.mediaContainerView.heightAnchor constraintEqualToConstant:height];
+        self.defaultMediaHeightConstraint.priority = 999;
     }
+    self.defaultMediaHeightConstraint.constant = height;
+    self.defaultMediaHeightConstraint.active = YES;
 }
 
 @end

--- a/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
@@ -10,6 +10,13 @@ static UIImage *videoPlaceholderImage;
 static UIImage *portraitPlaceholderImage;
 static UIImage *landscapePlaceholderImage;
 static NSString * const kOrientationPortrait = @"p";
+static NSString * const kOrientationLandscape = @"l";
+static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
+
+@interface CTInboxBaseMessageCell ()
+- (NSString *)normalizedOrientation;
+- (BOOL)orientationIsLandscape;
+@end
 
 @implementation CTInboxBaseMessageCell
 
@@ -63,6 +70,7 @@ static NSString * const kOrientationPortrait = @"p";
 - (void)layoutSubviews {
     [super layoutSubviews];
     self.cellImageView.backgroundColor = [UIColor clearColor];
+    self.defaultCellImageView.backgroundColor = [UIColor clearColor];
     if (self.avPlayerContainerView) {
         dispatch_async(dispatch_get_main_queue(), ^{
             self.avPlayerLayer.frame = self.avPlayerContainerView.bounds;
@@ -82,6 +90,7 @@ static NSString * const kOrientationPortrait = @"p";
         [self.avPlayerLayer removeObserver:self forKeyPath:@"readyForDisplay"];
         self.avPlayerLayer = nil;
     }
+    [self resetDefaultMediaView];
 }
 
 - (void)setup {
@@ -102,10 +111,15 @@ static NSString * const kOrientationPortrait = @"p";
     
     self.messageType = [CTInboxUtils inboxMessageTypeFromString:message.type];
     if ([self hasAudio] || [self hasVideo]) {
-        Boolean isPortrait = [message.orientation.uppercaseString isEqualToString:@"P"];
+        BOOL isPortrait = [self orientationIsPortrait];
+        BOOL useDefaultMediaLayout = [self shouldUseDefaultMediaLayout];
         switch (self.messageType) {
             case CTInboxMessageTypeSimple:
-                self.mediaPlayerCellType = isPortrait ? CTMediaPlayerCellTypeTopPortrait : CTMediaPlayerCellTypeTopLandscape;
+                if (useDefaultMediaLayout) {
+                    self.mediaPlayerCellType = CTMediaPlayerCellTypeTopDefault;
+                } else {
+                    self.mediaPlayerCellType = isPortrait ? CTMediaPlayerCellTypeTopPortrait : CTMediaPlayerCellTypeTopLandscape;
+                }
                 break;
             case CTInboxMessageTypeCarousel:
                 self.mediaPlayerCellType = CTMediaPlayerCellTypeNone;
@@ -115,9 +129,17 @@ static NSString * const kOrientationPortrait = @"p";
                 break;
             case CTInboxMessageTypeMessageIcon:
                 if (message.content[0].actionHasLinks) {
-                    self.mediaPlayerCellType = isPortrait ? CTMediaPlayerCellTypeMiddlePortrait : CTMediaPlayerCellTypeMiddleLandscape;
+                    if (useDefaultMediaLayout) {
+                        self.mediaPlayerCellType = CTMediaPlayerCellTypeMiddleDefault;
+                    } else {
+                        self.mediaPlayerCellType = isPortrait ? CTMediaPlayerCellTypeMiddlePortrait : CTMediaPlayerCellTypeMiddleLandscape;
+                    }
                 } else {
-                    self.mediaPlayerCellType = isPortrait ? CTMediaPlayerCellTypeBottomPortrait : CTMediaPlayerCellTypeBottomLandscape;
+                    if (useDefaultMediaLayout) {
+                        self.mediaPlayerCellType = CTMediaPlayerCellTypeBottomDefault;
+                    } else {
+                        self.mediaPlayerCellType = isPortrait ? CTMediaPlayerCellTypeBottomPortrait : CTMediaPlayerCellTypeBottomLandscape;
+                    }
                 }
                 break;
             default:
@@ -162,12 +184,25 @@ static NSString * const kOrientationPortrait = @"p";
 }
 
 - (BOOL)orientationIsPortrait {
-    return [self.message.orientation.uppercaseString isEqualToString:kOrientationPortrait.uppercaseString];
+    NSString *orientation = [self normalizedOrientation];
+    return [orientation isEqualToString:kOrientationPortrait.uppercaseString];
+}
+
+- (BOOL)orientationIsLandscape {
+    NSString *orientation = [self normalizedOrientation];
+    return [orientation isEqualToString:kOrientationLandscape.uppercaseString];
+}
+
+- (BOOL)shouldUseDefaultMediaLayout {
+    if (!self.message) {
+        return YES;
+    }
+    return ![self orientationIsPortrait] && ![self orientationIsLandscape];
 }
 
 - (BOOL)mediaIsEmpty {
     CleverTapInboxMessageContent *content = [self.message.content firstObject];
-    return (content.mediaUrl == nil || [content.mediaUrl isEqual: @""]);
+    return (content.mediaUrl == nil || content.mediaUrl.length == 0);
 }
 
 - (BOOL)deviceOrientationIsLandscape {
@@ -229,6 +264,11 @@ static NSString * const kOrientationPortrait = @"p";
     }
     
     CleverTapInboxMessageContent *content = self.message.content[0];
+    if (content.mediaUrl == nil || content.mediaUrl.length == 0) {
+        return;
+    }
+    [self configureDefaultMediaViewIfNeeded];
+    SDAnimatedImageView *activeImageView = [self activeMediaImageView];
     
     self.hasVideoPoster = NO;
     self.controllersTimeoutPeriod = 1.0;
@@ -237,7 +277,9 @@ static NSString * const kOrientationPortrait = @"p";
     self.avPlayerControlsView.alpha = 1.0;
     self.activityIndicator.hidden = NO;
     self.cellImageView.hidden = YES;
-    self.cellImageView.contentMode = UIViewContentModeScaleAspectFit;
+    self.defaultCellImageView.hidden = YES;
+    activeImageView.hidden = YES;
+    activeImageView.contentMode = UIViewContentModeScaleAspectFit;
     self.volumeButton.hidden = YES;
     self.playButton.hidden = NO;
     self.isAVMuted = content.mediaIsVideo;
@@ -280,24 +322,36 @@ static NSString * const kOrientationPortrait = @"p";
     }
     
     if (content.mediaIsAudio) {
-        self.cellImageView.contentMode = UIViewContentModeScaleAspectFit;
-        self.cellImageView.image = [self getAudioPlaceholderImage];
-        self.cellImageView.hidden = NO;
-        self.cellImageView.alpha = 1.0;
+        activeImageView.contentMode = UIViewContentModeScaleAspectFit;
+        activeImageView.image = [self getAudioPlaceholderImage];
+        activeImageView.hidden = NO;
+        activeImageView.alpha = 1.0;
         self.volumeButton.hidden = YES;
         [self.activityIndicator startAnimating];
+        if ([self shouldUseDefaultMediaLayout]) {
+            [self configureDefaultMediaLayoutWithFallbackRatio:kDefaultFallbackAspectRatio];
+            [self updateDefaultMediaLayoutForImage:activeImageView.image fallbackRatio:kDefaultFallbackAspectRatio];
+        }
     }
     
     if (content.mediaIsVideo) {
-        self.cellImageView.hidden = NO;
-        self.cellImageView.alpha = 1.0;
+        activeImageView.hidden = NO;
+        activeImageView.alpha = 1.0;
         self.hasVideoPoster = YES;
         if (content.videoPosterUrl != nil && content.videoPosterUrl.length > 0) {
-            [self.cellImageView sd_setImageWithURL:[NSURL URLWithString:content.videoPosterUrl]
-                                  placeholderImage: [self getVideoPlaceHolderImage]
-                                           options:self.sdWebImageOptions context:self.sdWebImageContext];
+            [activeImageView sd_setImageWithURL:[NSURL URLWithString:content.videoPosterUrl]
+                               placeholderImage:[self getVideoPlaceHolderImage]
+                                        options:self.sdWebImageOptions
+                                        context:self.sdWebImageContext
+                                       progress:nil
+                                      completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+                if ([self shouldUseDefaultMediaLayout]) {
+                    [self configureDefaultMediaLayoutWithFallbackRatio:kDefaultFallbackAspectRatio];
+                    [self updateDefaultMediaLayoutForImage:image fallbackRatio:kDefaultFallbackAspectRatio];
+                }
+            }];
         } else {
-            self.cellImageView.image = [self getVideoPlaceHolderImage];
+            activeImageView.image = [self getVideoPlaceHolderImage];
             if (!self.thumbnailGenerator) {
                 self.thumbnailGenerator = [[CTVideoThumbnailGenerator alloc] init];
             }
@@ -305,7 +359,11 @@ static NSString * const kOrientationPortrait = @"p";
                 dispatch_async(dispatch_get_main_queue(), ^ {
                     CleverTapInboxMessageContent *content = self.message.content[0];
                     if (image && [sourceUrl isEqualToString:content.mediaUrl]) {
-                        self.cellImageView.image = image;
+                        activeImageView.image = image;
+                        if ([self shouldUseDefaultMediaLayout]) {
+                            [self configureDefaultMediaLayoutWithFallbackRatio:kDefaultFallbackAspectRatio];
+                            [self updateDefaultMediaLayoutForImage:image fallbackRatio:kDefaultFallbackAspectRatio];
+                        }
                     }
                 });
             }];
@@ -464,12 +522,13 @@ static NSString * const kOrientationPortrait = @"p";
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
     if ([keyPath isEqualToString:@"readyForDisplay"]) {
-        if ([self hasVideo] && !self.cellImageView.isHidden) {
+        SDAnimatedImageView *activeImageView = [self activeMediaImageView];
+        if ([self hasVideo] && !activeImageView.isHidden) {
             [UIView animateWithDuration:0.5f animations:^{
-                self ->_cellImageView.alpha = 0.0;
+                activeImageView.alpha = 0.0;
             } completion:^(BOOL finished) {
-                self->_cellImageView.hidden = YES;
-                self->_cellImageView.alpha = 1.0;
+                activeImageView.hidden = YES;
+                activeImageView.alpha = 1.0;
             }];
         }
     }
@@ -484,6 +543,9 @@ static NSString * const kOrientationPortrait = @"p";
         }
         if (self.volumeButton.isHidden && [self hasVideo]) {
             CGRect videoRect = [self videoRect];
+            if (CGRectIsEmpty(videoRect)) {
+                videoRect = self.avPlayerContainerView.bounds;
+            }
             self.volumeButton.frame = CGRectMake(videoRect.origin.x+30.f,(videoRect.origin.y+videoRect.size.height)-60.f, 30.f, 30.f);
             self.volumeButton.hidden = NO;
         }
@@ -531,6 +593,93 @@ static NSString * const kOrientationPortrait = @"p";
     [userInfo setObject:[NSNumber numberWithInt:0] forKey:@"index"];
     [userInfo setObject:[NSNumber numberWithInt:-1] forKey:@"buttonIndex"];
     [[NSNotificationCenter defaultCenter] postNotificationName:CLTAP_INBOX_MESSAGE_TAPPED_NOTIFICATION object:self.message userInfo:userInfo];
+}
+
+- (NSString *)normalizedOrientation {
+    if (!self.message.orientation || ![self.message.orientation isKindOfClass:[NSString class]]) {
+        return @"";
+    }
+    return [[self.message.orientation stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] uppercaseString];
+}
+
+- (SDAnimatedImageView *)activeMediaImageView {
+    return [self shouldUseDefaultMediaLayout] ? self.defaultCellImageView : self.cellImageView;
+}
+
+- (void)configureDefaultMediaViewIfNeeded {
+    if (!self.mediaContainerView || self.defaultCellImageView) {
+        return;
+    }
+    SDAnimatedImageView *defaultImageView = [[SDAnimatedImageView alloc] initWithFrame:CGRectZero];
+    defaultImageView.translatesAutoresizingMaskIntoConstraints = NO;
+    defaultImageView.contentMode = UIViewContentModeScaleAspectFit;
+    defaultImageView.clipsToBounds = YES;
+    defaultImageView.hidden = YES;
+    if ([defaultImageView respondsToSelector:@selector(setAdjustsImageSizeForAccessibilityContentSizeCategory:)]) {
+        defaultImageView.adjustsImageSizeForAccessibilityContentSizeCategory = YES;
+    }
+    [self.mediaContainerView addSubview:defaultImageView];
+    [self.mediaContainerView bringSubviewToFront:defaultImageView];
+    [NSLayoutConstraint activateConstraints:@[
+        [defaultImageView.topAnchor constraintEqualToAnchor:self.mediaContainerView.topAnchor],
+        [defaultImageView.leadingAnchor constraintEqualToAnchor:self.mediaContainerView.leadingAnchor],
+        [defaultImageView.trailingAnchor constraintEqualToAnchor:self.mediaContainerView.trailingAnchor],
+        [defaultImageView.bottomAnchor constraintEqualToAnchor:self.mediaContainerView.bottomAnchor]
+    ]];
+    self.defaultCellImageView = defaultImageView;
+}
+
+- (void)resetDefaultMediaView {
+    [self.defaultCellImageView sd_cancelCurrentImageLoad];
+    self.defaultCellImageView.image = nil;
+    self.defaultCellImageView.hidden = YES;
+    if (self.defaultMediaHeightConstraint) {
+        self.defaultMediaHeightConstraint.constant = 0;
+        self.defaultMediaHeightConstraint.active = NO;
+    }
+}
+
+- (void)configureDefaultMediaLayoutWithFallbackRatio:(CGFloat)fallbackRatio {
+    if (![self shouldUseDefaultMediaLayout]) {
+        return;
+    }
+    [self configureDefaultMediaViewIfNeeded];
+    if (self.imageViewLRatioConstraint) {
+        self.imageViewLRatioConstraint.priority = 250;
+    }
+    if (self.imageViewPRatioConstraint) {
+        self.imageViewPRatioConstraint.priority = 250;
+    }
+    if (self.imageViewHeightConstraint) {
+        self.imageViewHeightConstraint.priority = 999;
+    }
+    [self updateDefaultMediaLayoutForImage:nil fallbackRatio:fallbackRatio];
+}
+
+- (void)updateDefaultMediaLayoutForImage:(UIImage *)image fallbackRatio:(CGFloat)fallbackRatio {
+    if (![self shouldUseDefaultMediaLayout] || !self.mediaContainerView) {
+        return;
+    }
+    CGFloat ratio = fallbackRatio > 0.0 ? fallbackRatio : kDefaultFallbackAspectRatio;
+    if (image && image.size.width > 0.0) {
+        ratio = image.size.height / image.size.width;
+    }
+    [self layoutIfNeeded];
+    CGFloat width = CGRectGetWidth(self.mediaContainerView.bounds);
+    if (width <= 0.0) {
+        width = CGRectGetWidth([UIScreen mainScreen].bounds);
+    }
+    CGFloat height = MAX(1.0, width * ratio);
+    if (self.imageViewHeightConstraint) {
+        self.imageViewHeightConstraint.constant = height;
+    } else {
+        if (!self.defaultMediaHeightConstraint) {
+            self.defaultMediaHeightConstraint = [self.mediaContainerView.heightAnchor constraintEqualToConstant:height];
+            self.defaultMediaHeightConstraint.priority = 999;
+        }
+        self.defaultMediaHeightConstraint.constant = height;
+        self.defaultMediaHeightConstraint.active = YES;
+    }
 }
 
 @end

--- a/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
@@ -635,8 +635,8 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
     self.defaultCellImageView.image = nil;
     self.defaultCellImageView.hidden = YES;
     if (self.defaultMediaHeightConstraint) {
-        self.defaultMediaHeightConstraint.constant = 0;
         self.defaultMediaHeightConstraint.active = NO;
+        self.defaultMediaHeightConstraint = nil;
     }
     if (self.imageViewHeightConstraint && self.didCaptureImageViewHeightDefaults) {
         self.imageViewHeightConstraint.constant = self.originalImageViewHeightConstant;
@@ -666,6 +666,14 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
     [self updateDefaultMediaLayoutForImage:nil fallbackRatio:fallbackRatio];
 }
 
+- (UITableView *)containingTableView {
+    UIView *view = self.superview;
+    while (view && ![view isKindOfClass:[UITableView class]]) {
+        view = view.superview;
+    }
+    return (UITableView *)view;
+}
+
 - (void)updateDefaultMediaLayoutForImage:(UIImage *)image fallbackRatio:(CGFloat)fallbackRatio {
     if (![self shouldUseDefaultMediaLayout] || !self.mediaContainerView) {
         return;
@@ -674,18 +682,31 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
     if (image && image.size.width > 0.0) {
         ratio = image.size.height / image.size.width;
     }
-    [self layoutIfNeeded];
-    CGFloat width = CGRectGetWidth(self.mediaContainerView.bounds);
-    if (width <= 0.0) {
-        width = CGRectGetWidth([UIScreen mainScreen].bounds);
+    CGFloat previousMultiplier = self.defaultMediaHeightConstraint ? self.defaultMediaHeightConstraint.multiplier : 0;
+    if (self.defaultMediaHeightConstraint) {
+        self.defaultMediaHeightConstraint.active = NO;
     }
-    CGFloat height = MAX(1.0, width * ratio);
-    if (!self.defaultMediaHeightConstraint) {
-        self.defaultMediaHeightConstraint = [self.mediaContainerView.heightAnchor constraintEqualToConstant:height];
-        self.defaultMediaHeightConstraint.priority = 999;
-    }
-    self.defaultMediaHeightConstraint.constant = height;
+    self.defaultMediaHeightConstraint = [NSLayoutConstraint constraintWithItem:self.mediaContainerView
+                                                                      attribute:NSLayoutAttributeHeight
+                                                                      relatedBy:NSLayoutRelationEqual
+                                                                         toItem:self.mediaContainerView
+                                                                      attribute:NSLayoutAttributeWidth
+                                                                     multiplier:ratio
+                                                                       constant:0];
+    self.defaultMediaHeightConstraint.priority = 999;
     self.defaultMediaHeightConstraint.active = YES;
+    if (image && fabs(ratio - previousMultiplier) > 0.01) {
+        __weak typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UITableView *tableView = [weakSelf containingTableView];
+            if (tableView) {
+                [UIView performWithoutAnimation:^{
+                    [tableView beginUpdates];
+                    [tableView endUpdates];
+                }];
+            }
+        });
+    }
 }
 
 @end

--- a/CleverTapSDK/Inbox/cells/CTInboxIconMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTInboxIconMessageCell.m
@@ -13,7 +13,10 @@
     [super prepareForReuse];
     [self.cellIcon sd_cancelCurrentImageLoad];
     [self.imageView sd_cancelCurrentImageLoad];
+    [self.defaultCellImageView sd_cancelCurrentImageLoad];
     self.cellImageView.image = nil;
+    self.defaultCellImageView.image = nil;
+    self.defaultCellImageView.hidden = YES;
     self.cellIcon.image = nil;
 }
 
@@ -27,6 +30,8 @@
         self.imageViewHeightConstraint.priority = 999;
         self.imageViewLRatioConstraint.priority = 750;
         self.imageViewPRatioConstraint.priority = 750;
+    } else if ([self shouldUseDefaultMediaLayout]) {
+        [self configureDefaultMediaLayoutWithFallbackRatio:0.5625f];
     } else if ([self orientationIsPortrait]) {
         self.imageViewPRatioConstraint.priority = 999;
         self.imageViewLRatioConstraint.priority = 750;
@@ -77,18 +82,33 @@
     self.readView.hidden = message.isRead;
     self.readViewWidthConstraint.constant = message.isRead ? 0 : 16;
     [self setupInboxMessageActions:content];
-    self.cellImageView.contentMode = content.mediaIsGif ? UIViewContentModeScaleAspectFit : UIViewContentModeScaleAspectFill;
-    if (content.mediaUrl && !content.mediaIsVideo && !content.mediaIsAudio) {
-        self.cellImageView.hidden = NO;
-        self.cellImageView.alpha = 1.0;
-        [self.cellImageView sd_setImageWithURL:[NSURL URLWithString:content.mediaUrl]
-                              placeholderImage:[self orientationIsPortrait] ? [self getPortraitPlaceHolderImage] : [self getLandscapePlaceHolderImage]
-                                       options:self.sdWebImageOptions context:self.sdWebImageContext];
-        
-        self.cellImageView.accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Image";
+    [self configureDefaultMediaViewIfNeeded];
+    self.cellImageView.hidden = YES;
+    self.defaultCellImageView.hidden = YES;
+    SDAnimatedImageView *activeImageView = [self activeMediaImageView];
+    BOOL useDefaultLayout = [self shouldUseDefaultMediaLayout];
+    activeImageView.contentMode = useDefaultLayout || content.mediaIsGif ? UIViewContentModeScaleAspectFit : UIViewContentModeScaleAspectFill;
+    if (content.mediaUrl.length > 0 && !content.mediaIsVideo && !content.mediaIsAudio) {
+        activeImageView.hidden = NO;
+        activeImageView.alpha = 1.0;
+        UIImage *placeholder = useDefaultLayout ? [self getLandscapePlaceHolderImage] : ([self orientationIsPortrait] ? [self getPortraitPlaceHolderImage] : [self getLandscapePlaceHolderImage]);
+        [activeImageView sd_setImageWithURL:[NSURL URLWithString:content.mediaUrl]
+                           placeholderImage:placeholder
+                                    options:self.sdWebImageOptions
+                                    context:self.sdWebImageContext
+                                   progress:nil
+                                  completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+            if (useDefaultLayout) {
+                [self updateDefaultMediaLayoutForImage:image fallbackRatio:0.5625f];
+            }
+        }];
+        activeImageView.accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Image";
     } else if (content.mediaIsVideo || content.mediaIsAudio) {
+        if (content.mediaUrl.length == 0) {
+            return;
+        }
         [self setupMediaPlayer];
-        self.cellImageView.accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Media";
+        [self activeMediaImageView].accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Media";
         self.avPlayerContainerView.accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Media";
     }
     

--- a/CleverTapSDK/Inbox/cells/CTInboxSimpleMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTInboxSimpleMessageCell.m
@@ -22,7 +22,10 @@
 - (void)prepareForReuse {
     [super prepareForReuse];
     [self.cellImageView sd_cancelCurrentImageLoad];
+    [self.defaultCellImageView sd_cancelCurrentImageLoad];
     self.cellImageView.image = nil;
+    self.defaultCellImageView.image = nil;
+    self.defaultCellImageView.hidden = YES;
 }
 
 - (void)doLayoutForMessage:(CleverTapInboxMessage *)message {
@@ -38,6 +41,8 @@
         self.imageViewHeightConstraint.priority = 999;
         self.imageViewLRatioConstraint.priority = 750;
         self.imageViewPRatioConstraint.priority = 750;
+    } else if ([self shouldUseDefaultMediaLayout]) {
+        [self configureDefaultMediaLayoutWithFallbackRatio:0.5625f];
     } else {
         self.imageViewHeightConstraint.priority = 750;
         self.imageViewLRatioConstraint.priority = [self orientationIsPortrait] ? 750 : 999;
@@ -78,17 +83,33 @@
     self.readView.hidden = message.isRead;
     self.readViewWidthConstraint.constant = message.isRead ? 0 : 16;
     [self setupInboxMessageActions:content];
-    self.cellImageView.contentMode = content.mediaIsGif ? UIViewContentModeScaleAspectFit : UIViewContentModeScaleAspectFill;
-    if (content.mediaUrl && !content.mediaIsVideo && !content.mediaIsAudio) {
-        self.cellImageView.hidden = NO;
-        self.cellImageView.alpha = 1.0;
-        [self.cellImageView sd_setImageWithURL:[NSURL URLWithString:content.mediaUrl]
-                              placeholderImage:[self orientationIsPortrait] ? [self getPortraitPlaceHolderImage] : [self getLandscapePlaceHolderImage]
-                                       options:self.sdWebImageOptions context:self.sdWebImageContext];
-        self.cellImageView.accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Image";
+    [self configureDefaultMediaViewIfNeeded];
+    self.cellImageView.hidden = YES;
+    self.defaultCellImageView.hidden = YES;
+    SDAnimatedImageView *activeImageView = [self activeMediaImageView];
+    BOOL useDefaultLayout = [self shouldUseDefaultMediaLayout];
+    activeImageView.contentMode = useDefaultLayout || content.mediaIsGif ? UIViewContentModeScaleAspectFit : UIViewContentModeScaleAspectFill;
+    if (content.mediaUrl.length > 0 && !content.mediaIsVideo && !content.mediaIsAudio) {
+        activeImageView.hidden = NO;
+        activeImageView.alpha = 1.0;
+        UIImage *placeholder = useDefaultLayout ? [self getLandscapePlaceHolderImage] : ([self orientationIsPortrait] ? [self getPortraitPlaceHolderImage] : [self getLandscapePlaceHolderImage]);
+        [activeImageView sd_setImageWithURL:[NSURL URLWithString:content.mediaUrl]
+                           placeholderImage:placeholder
+                                    options:self.sdWebImageOptions
+                                    context:self.sdWebImageContext
+                                   progress:nil
+                                  completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+            if (useDefaultLayout) {
+                [self updateDefaultMediaLayoutForImage:image fallbackRatio:0.5625f];
+            }
+        }];
+        activeImageView.accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Image";
     } else if (content.mediaIsVideo || content.mediaIsAudio) {
+        if (content.mediaUrl.length == 0) {
+            return;
+        }
         [self setupMediaPlayer];
-        self.cellImageView.accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Media";
+        [self activeMediaImageView].accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Media";
         self.avPlayerContainerView.accessibilityLabel = content.mediaDescription ? content.mediaDescription : @"Message Media";
     }
 }

--- a/CleverTapSDK/Inbox/controllers/CleverTapInboxViewController.m
+++ b/CleverTapSDK/Inbox/controllers/CleverTapInboxViewController.m
@@ -550,6 +550,10 @@ static const int kMaxTags = 3;
             topOffset = 80.0 * multiplier;
             bottomOffset = 150.0 * multiplier;
             break;
+        case CTMediaPlayerCellTypeTopDefault:
+            topOffset = 60.0 * multiplier;
+            bottomOffset = 120.0 * multiplier;
+            break;
         case CTMediaPlayerCellTypeMiddleLandscape:
             topOffset = 75.0 * multiplier;
             bottomOffset = 100.0 * multiplier;
@@ -558,6 +562,10 @@ static const int kMaxTags = 3;
             topOffset = 125.0 * multiplier;
             bottomOffset = 150.0 * multiplier;
             break;
+        case CTMediaPlayerCellTypeMiddleDefault:
+            topOffset = 100.0 * multiplier;
+            bottomOffset = 130.0 * multiplier;
+            break;
         case CTMediaPlayerCellTypeBottomLandscape:
             topOffset = 100.0 * multiplier;
             bottomOffset = 50.0 * multiplier;
@@ -565,6 +573,10 @@ static const int kMaxTags = 3;
         case CTMediaPlayerCellTypeBottomPortrait:
             topOffset = 150.0 * multiplier;
             bottomOffset = 100.0 * multiplier;
+            break;
+        case CTMediaPlayerCellTypeBottomDefault:
+            topOffset = 120.0 * multiplier;
+            bottomOffset = 80.0 * multiplier;
             break;
         default:
             return NO;

--- a/CleverTapSDK/Inbox/views/CTCarouselImageView.h
+++ b/CleverTapSDK/Inbox/views/CTCarouselImageView.h
@@ -19,12 +19,14 @@
                        subcaptionColor:(NSString * _Nullable)subcaptionColor
                               imageUrl:(NSString * _Nonnull)imageUrl
                              actionUrl:(NSString * _Nullable)actionUrl
+                      orientationKnown:(BOOL)orientationKnown
                    orientationPortrait:(BOOL)orientationPortrait
                       imageDescription:(NSString * _Nonnull)imageDescription;
 
 - (instancetype _Nonnull)initWithFrame:(CGRect)frame
                               imageUrl:(NSString * _Nonnull)imageUrl
                              actionUrl:(NSString * _Nullable)actionUrl
+                      orientationKnown:(BOOL)orientationKnown
                    orientationPortrait:(BOOL)orientationPortrait
                       imageDescription:(NSString * _Nonnull)imageDescription;
 

--- a/CleverTapSDK/Inbox/views/CTCarouselImageView.m
+++ b/CleverTapSDK/Inbox/views/CTCarouselImageView.m
@@ -23,6 +23,7 @@ static float captionHeight = 0.f;
 @property (nonatomic, strong) NSString *subcaptionColor;
 @property (nonatomic, strong) NSString *imageUrl;
 @property (nonatomic, assign) BOOL orientationPortrait;
+@property (nonatomic, assign) BOOL orientationKnown;
 
 @property (nonatomic, strong) UIImageView *imageView;
 @property (nonatomic, strong) UILabel *captionLabel;
@@ -47,6 +48,7 @@ static float captionHeight = 0.f;
                        subcaptionColor:(NSString * _Nullable)subcaptionColor
                               imageUrl:(NSString * _Nonnull)imageUrl
                              actionUrl:(NSString * _Nullable)actionUrl
+                      orientationKnown:(BOOL)orientationKnown
                    orientationPortrait:(BOOL)orientationPortrait
                       imageDescription:(NSString * _Nonnull)imageDescription {
     
@@ -58,6 +60,7 @@ static float captionHeight = 0.f;
         self.captionColor = captionColor;
         self.subcaptionColor = subcaptionColor;
         self.actionUrl = actionUrl;
+        self.orientationKnown = orientationKnown;
         self.orientationPortrait = orientationPortrait;
         self.imageDescription = imageDescription;
         [self setup];
@@ -68,6 +71,7 @@ static float captionHeight = 0.f;
 - (instancetype _Nonnull)initWithFrame:(CGRect)frame
                               imageUrl:(NSString * _Nonnull)imageUrl
                              actionUrl:(NSString * _Nullable)actionUrl
+                      orientationKnown:(BOOL)orientationKnown
                    orientationPortrait:(BOOL)orientationPortrait
                       imageDescription:(NSString * _Nonnull)imageDescription {
     
@@ -75,6 +79,7 @@ static float captionHeight = 0.f;
     if (self) {
         self.imageUrl = imageUrl;
         self.actionUrl = actionUrl;
+        self.orientationKnown = orientationKnown;
         self.orientationPortrait = orientationPortrait;
         self.imageDescription = imageDescription;
         [self setupImageOnly];
@@ -90,7 +95,7 @@ static float captionHeight = 0.f;
     
     // gyrations to draw a corresponding gray border below the image
     self.imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0.f-kImageBorderWidth, 0.f-kImageBorderWidth, imageViewSize.width + (kImageBorderWidth*2), imageViewSize.height)];
-    self.imageView.contentMode = UIViewContentModeScaleAspectFill;
+    self.imageView.contentMode = self.orientationKnown ? UIViewContentModeScaleAspectFill : UIViewContentModeScaleAspectFit;
     self.imageView.layer.borderColor = [[UIColor lightGrayColor] CGColor];
     self.imageView.layer.borderWidth = kImageLayerBorderWidth;
     self.imageView.layer.masksToBounds = YES;
@@ -106,7 +111,7 @@ static float captionHeight = 0.f;
     
     // gyrations to draw a corresponding gray border below the image
     self.imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0.f-kImageBorderWidth, 0.f-kImageBorderWidth, imageViewSize.width + (kImageBorderWidth*2), imageViewSize.height)];
-    self.imageView.contentMode = UIViewContentModeScaleAspectFill;
+    self.imageView.contentMode = self.orientationKnown ? UIViewContentModeScaleAspectFill : UIViewContentModeScaleAspectFit;
     self.imageView.layer.borderColor = [[UIColor lightGrayColor] CGColor];
     self.imageView.layer.borderWidth = kImageLayerBorderWidth;
     self.imageView.layer.masksToBounds = YES;
@@ -141,6 +146,10 @@ static float captionHeight = 0.f;
 
 - (void)loadImage {
     if (!self.imageUrl) return;
+    if (!self.orientationKnown) {
+        self.imageViewLandRatioConstraint.priority = 250;
+        self.imageViewPortRatioConstraint.priority = 250;
+    }
     [self.imageView sd_setImageWithURL:[NSURL URLWithString:self.imageUrl]
                       placeholderImage: self.orientationPortrait ?  [self getPortraitPlaceHolderImage] : [self getLandscapePlaceHolderImage]
                                options:(SDWebImageRetryFailed) context:@{SDWebImageContextStoreCacheType : @(SDImageCacheTypeMemory)}];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip empty or missing media so carousels and messages no longer render blank items
  * More robust height/aspect calculations for portrait/landscape and ambiguous orientations
  * Improved placeholder selection and image loading behavior for consistent presentation

* **New Features**
  * Added "default" media layout variants for better formatting when orientation is indeterminate
  * Refined media visibility detection so in-app media playback/visibility is more accurate
<!-- end of auto-generated comment: release notes by coderabbit.ai -->