### PR TITLE
SDK-5705: Fixed crash when numeric values are sent as event names

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2058,7 +2058,13 @@ static BOOL sharedInstanceErrorLogged;
 - (void)evaluateOnEvent:(NSDictionary *)event withType:(CleverTapEventType)eventType flattenedEventData:(CTFlattenedEventData *)flattenedEventData {
     [self logFlattenedData:flattenedEventData];
 #if !CLEVERTAP_NO_INAPP_SUPPORT
-    NSString *eventName = event[CLTAP_EVENT_NAME];
+    id rawEventName = event[CLTAP_EVENT_NAME];
+    NSString *eventName;
+    if ([rawEventName isKindOfClass:[NSNumber class]]) {
+        eventName = [(NSNumber *)rawEventName stringValue];
+    } else if ([rawEventName isKindOfClass:[NSString class]]) {
+        eventName = rawEventName;
+    }
     // Add the system properties for evaluation
     NSMutableDictionary *eventData = [[NSMutableDictionary alloc] initWithDictionary:[self generateAppFields]];
     // Add the event properties last, so custom properties are not overriden

--- a/CleverTapSDK/Validation/Validators/CTEventNameValidator.h
+++ b/CleverTapSDK/Validation/Validators/CTEventNameValidator.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Validates and normalizes an event name.
  * Returns CTValidationResult with cleaned name and outcome.
  */
-- (CTValidationResult *)validateEventName:(nullable NSString *)eventName;
+- (CTValidationResult *)validateEventName:(nullable id)eventName;
 
 @end
 

--- a/CleverTapSDK/Validation/Validators/CTEventNameValidator.m
+++ b/CleverTapSDK/Validation/Validators/CTEventNameValidator.m
@@ -21,17 +21,25 @@
     return self;
 }
 
-- (CTValidationResult *)validateEventName:(NSString *)eventName {
+- (CTValidationResult *)validateEventName:(id)eventName {
+    if ([eventName isKindOfClass:[NSNumber class]]) {
+        eventName = [(NSNumber *)eventName stringValue];
+    }
+    if (eventName && ![eventName isKindOfClass:[NSString class]]) {
+        return [CTValidationResult dropWithCode:CTValidationErrorEventNameNull
+                                        message:@"Event name must be a String or numeric value"
+                                         reason:CTDropReasonNullEventName];
+    }
     //Check for null/empty
-    if (!eventName || eventName.length == 0) {
+    if (!eventName || [(NSString *)eventName length] == 0) {
         return [CTValidationResult dropWithCode:CTValidationErrorEventNameNull
                                         message:@"Event name is null or empty"
                                          reason:CTDropReasonNullEventName];
     }
     
     //Normalize the event name
-    NSString *originalName = eventName;
-    NSString *cleaned = [self normalizeEventName:eventName];
+    NSString *originalName = (NSString *)eventName;
+    NSString *cleaned = [self normalizeEventName:(NSString *)eventName];
     //Check if became empty after normalization
     if (!cleaned || cleaned.length == 0) {
         return [CTValidationResult dropWithCode:CTValidationErrorEventNameNull


### PR DESCRIPTION
Problem: The SDK crashes during event processing when a numeric value (e.g., NSNumber) is passed as an event name instead of the expected NSString.

Changes:  
Validation: Added type checking in CTEventNameValidator to handle non-string inputs.

Stability: Hardened CTInAppEvaluationManager and CleverTap.m to prevent "unrecognized selector" exceptions during event processing.

@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved event name handling to accept numeric values that are automatically converted to strings. Enhanced validation ensures both string and numeric event names are properly processed with appropriate error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->