### PR TITLE
[SDK-5732] App Inbox v2

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -3041,13 +3041,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-shared-CleverTapSDKTests/Pods-shared-CleverTapSDKTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-shared-CleverTapSDKTests/Pods-shared-CleverTapSDKTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -131,9 +131,11 @@ extern NSString *const kSessionId;
 #define CLTAP_INBOX_MSG_JSON_RESPONSE_KEY @"inbox_notifs"
 #define CLTAP_INBOX_V2_RESPONSE_KEY @"inbox_notifs_v2"
 #define CLTAP_NOTIFICATION_DELETED_EVENT_NAME @"Notification Deleted"
-#define CLTAP_INBOX_PENDING_DELETES_KEY_PREFIX @"CLTAP_inbox_pending_deletes_"
 #define CLTAP_INBOX_PENDING_READS_KEY_PREFIX @"CLTAP_inbox_pending_reads_"
 #define CLTAP_INBOX_V2_IDS_KEY_PREFIX @"CLTAP_inbox_v2_ids_"
+#define CLTAP_INBOX_CONFIRMED_DELETES_KEY_PREFIX @"CLTAP_inbox_confirmed_deletes_"
+#define CLTAP_INBOX_RETRY_DELETES_KEY_PREFIX @"CLTAP_inbox_retry_deletes_"
+static const NSTimeInterval kCTInboxConfirmedDeleteFallbackTTL = 86400.0; // 24 hours
 static const NSInteger kCTInboxFetchTypeInboxV2 = 7;
 static const NSTimeInterval kCTInboxRefreshMinInterval = 300.0;
 #define CLTAP_DISPLAY_UNIT_JSON_RESPONSE_KEY @"adUnit_notifs"

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -133,6 +133,7 @@ extern NSString *const kSessionId;
 #define CLTAP_NOTIFICATION_DELETED_EVENT_NAME @"Notification Deleted"
 #define CLTAP_INBOX_PENDING_DELETES_KEY_PREFIX @"CLTAP_inbox_pending_deletes_"
 #define CLTAP_INBOX_PENDING_READS_KEY_PREFIX @"CLTAP_inbox_pending_reads_"
+#define CLTAP_INBOX_V2_IDS_KEY_PREFIX @"CLTAP_inbox_v2_ids_"
 static const NSInteger kCTInboxFetchTypeInboxV2 = 7;
 static const NSTimeInterval kCTInboxRefreshMinInterval = 300.0;
 #define CLTAP_DISPLAY_UNIT_JSON_RESPONSE_KEY @"adUnit_notifs"

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -129,6 +129,12 @@ extern NSString *const kSessionId;
 #define CLTAP_LOCATION_PING_INTERVAL_SECONDS 10
 #define CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY @"content_fetch"
 #define CLTAP_INBOX_MSG_JSON_RESPONSE_KEY @"inbox_notifs"
+#define CLTAP_INBOX_V2_RESPONSE_KEY @"inbox_notifs_v2"
+#define CLTAP_NOTIFICATION_DELETED_EVENT_NAME @"Notification Deleted"
+#define CLTAP_INBOX_PENDING_DELETES_KEY_PREFIX @"CLTAP_inbox_pending_deletes_"
+#define CLTAP_INBOX_PENDING_READS_KEY_PREFIX @"CLTAP_inbox_pending_reads_"
+static const NSInteger kCTInboxFetchTypeInboxV2 = 7;
+static const NSTimeInterval kCTInboxRefreshMinInterval = 300.0;
 #define CLTAP_DISPLAY_UNIT_JSON_RESPONSE_KEY @"adUnit_notifs"
 #define CLTAP_FEATURE_FLAGS_JSON_RESPONSE_KEY @"ff_notifs"
 #define CLTAP_PRODUCT_CONFIG_JSON_RESPONSE_KEY @"pc_notifs"

--- a/CleverTapSDK/CTEventBuilder.h
+++ b/CleverTapSDK/CTEventBuilder.h
@@ -32,10 +32,6 @@
                  andQueryParameters:(NSDictionary * _Nullable)params
                   completionHandler:(void(^ _Nonnull)(NSDictionary * _Nullable event, NSArray<CTValidationResult*> * _Nullable errors))completion;
 
-+ (void)buildInboxMessageDeletedEventForMessage:(CleverTapInboxMessage * _Nonnull)message
-                             andQueryParameters:(NSDictionary * _Nullable)params
-                              completionHandler:(void(^ _Nonnull)(NSDictionary * _Nullable event, NSArray<CTValidationResult*> * _Nullable errors))completion;
-
 + (void)buildDisplayViewStateEvent:(BOOL)clicked
                     forDisplayUnit:(CleverTapDisplayUnit * _Nonnull)displayUnit
                 andQueryParameters:(NSDictionary * _Nullable)params

--- a/CleverTapSDK/CTEventBuilder.h
+++ b/CleverTapSDK/CTEventBuilder.h
@@ -29,6 +29,7 @@
 
 + (void)buildInboxMessageStateEvent:(BOOL)clicked
                          forMessage:(CleverTapInboxMessage * _Nonnull)message
+                        isV2Message:(BOOL)isV2Message
                  andQueryParameters:(NSDictionary * _Nullable)params
                   completionHandler:(void(^ _Nonnull)(NSDictionary * _Nullable event, NSArray<CTValidationResult*> * _Nullable errors))completion;
 

--- a/CleverTapSDK/CTEventBuilder.h
+++ b/CleverTapSDK/CTEventBuilder.h
@@ -32,6 +32,10 @@
                  andQueryParameters:(NSDictionary * _Nullable)params
                   completionHandler:(void(^ _Nonnull)(NSDictionary * _Nullable event, NSArray<CTValidationResult*> * _Nullable errors))completion;
 
++ (void)buildInboxMessageDeletedEventForMessage:(CleverTapInboxMessage * _Nonnull)message
+                             andQueryParameters:(NSDictionary * _Nullable)params
+                              completionHandler:(void(^ _Nonnull)(NSDictionary * _Nullable event, NSArray<CTValidationResult*> * _Nullable errors))completion;
+
 + (void)buildDisplayViewStateEvent:(BOOL)clicked
                     forDisplayUnit:(CleverTapDisplayUnit * _Nonnull)displayUnit
                 andQueryParameters:(NSDictionary * _Nullable)params

--- a/CleverTapSDK/CTEventBuilder.m
+++ b/CleverTapSDK/CTEventBuilder.m
@@ -243,7 +243,7 @@ static CTDataValidator *_eventDataValidator;
             notif[x] = value;
         }
         if (message.messageId) {
-            notif[@"_id"] = message.messageId;
+            notif[@"wzrk_mid"] = message.messageId;
         }
         if (params) {
             [notif addEntriesFromDictionary:params];

--- a/CleverTapSDK/CTEventBuilder.m
+++ b/CleverTapSDK/CTEventBuilder.m
@@ -259,33 +259,6 @@ static CTDataValidator *_eventDataValidator;
     }
 }
 
-+ (void)buildInboxMessageDeletedEventForMessage:(CleverTapInboxMessage *)message
-                             andQueryParameters:(NSDictionary *)params
-                              completionHandler:(void(^)(NSDictionary *event, NSArray<CTValidationResult*> *errors))completion {
-    NSMutableDictionary *event = [[NSMutableDictionary alloc] init];
-    NSMutableDictionary *notif = [[NSMutableDictionary alloc] init];
-    @try {
-        NSDictionary *data = message.json;
-        for (NSString *x in [data allKeys]) {
-            if (![CTUtils doesString:x startWith:@"wzrk_"])
-                continue;
-            id value = data[x];
-            notif[x] = value;
-        }
-        if (message.messageId) {
-            notif[@"_id"] = message.messageId;
-        }
-        if (params) {
-            [notif addEntriesFromDictionary:params];
-        }
-        event[CLTAP_EVENT_NAME] = CLTAP_NOTIFICATION_DELETED_EVENT_NAME;
-        event[CLTAP_EVENT_DATA] = notif;
-        completion(event, nil);
-    } @catch (NSException *e) {
-        completion(nil, nil);
-    }
-}
-
 /**
  * Raises the Native Display Clicked event, if clicked is true,
  * otherwise the Native Display Viewed event, if clicked is false.

--- a/CleverTapSDK/CTEventBuilder.m
+++ b/CleverTapSDK/CTEventBuilder.m
@@ -230,6 +230,7 @@ static CTDataValidator *_eventDataValidator;
  */
 + (void)buildInboxMessageStateEvent:(BOOL)clicked
                          forMessage:(CleverTapInboxMessage *)message
+                        isV2Message:(BOOL)isV2Message
                  andQueryParameters:(NSDictionary *)params
                   completionHandler:(void(^)(NSDictionary* event, NSArray<CTValidationResult*> *errors))completion {
     NSMutableDictionary *event = [[NSMutableDictionary alloc] init];
@@ -242,7 +243,7 @@ static CTDataValidator *_eventDataValidator;
             id value = data[x];
             notif[x] = value;
         }
-        if (message.messageId) {
+        if (isV2Message && message.messageId) {
             notif[@"wzrk_mid"] = message.messageId;
         }
         if (params) {

--- a/CleverTapSDK/CTEventBuilder.m
+++ b/CleverTapSDK/CTEventBuilder.m
@@ -259,6 +259,33 @@ static CTDataValidator *_eventDataValidator;
     }
 }
 
++ (void)buildInboxMessageDeletedEventForMessage:(CleverTapInboxMessage *)message
+                             andQueryParameters:(NSDictionary *)params
+                              completionHandler:(void(^)(NSDictionary *event, NSArray<CTValidationResult*> *errors))completion {
+    NSMutableDictionary *event = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *notif = [[NSMutableDictionary alloc] init];
+    @try {
+        NSDictionary *data = message.json;
+        for (NSString *x in [data allKeys]) {
+            if (![CTUtils doesString:x startWith:@"wzrk_"])
+                continue;
+            id value = data[x];
+            notif[x] = value;
+        }
+        if (message.messageId) {
+            notif[@"_id"] = message.messageId;
+        }
+        if (params) {
+            [notif addEntriesFromDictionary:params];
+        }
+        event[CLTAP_EVENT_NAME] = CLTAP_NOTIFICATION_DELETED_EVENT_NAME;
+        event[CLTAP_EVENT_DATA] = notif;
+        completion(event, nil);
+    } @catch (NSException *e) {
+        completion(nil, nil);
+    }
+}
+
 /**
  * Raises the Native Display Clicked event, if clicked is true,
  * otherwise the Native Display Viewed event, if clicked is false.

--- a/CleverTapSDK/CTEventBuilder.m
+++ b/CleverTapSDK/CTEventBuilder.m
@@ -242,6 +242,9 @@ static CTDataValidator *_eventDataValidator;
             id value = data[x];
             notif[x] = value;
         }
+        if (message.messageId) {
+            notif[@"_id"] = message.messageId;
+        }
         if (params) {
             [notif addEntriesFromDictionary:params];
         }

--- a/CleverTapSDK/CTRequestFactory.h
+++ b/CleverTapSDK/CTRequestFactory.h
@@ -20,11 +20,11 @@
 + (CTRequest * _Nonnull)previewRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config url:(NSString * _Nonnull)url;
 + (CTRequest * _Nonnull)inboxV2FetchRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
                                                params:(id _Nullable)params
-                                               domain:(NSString * _Nonnull)domain;
+                                                  url:(NSString * _Nonnull)url;
 
-+ (CTRequest * _Nonnull)inboxV2NotificationEventRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
-                                                           params:(id _Nullable)params
-                                                           domain:(NSString * _Nonnull)domain;
++ (CTRequest * _Nonnull)inboxV2DeleteMessagesRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
+                                                        params:(id _Nullable)params
+                                                           url:(NSString * _Nonnull)url;
 @end
 
 

--- a/CleverTapSDK/CTRequestFactory.h
+++ b/CleverTapSDK/CTRequestFactory.h
@@ -18,6 +18,9 @@
 + (CTRequest * _Nonnull)syncVarsRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config params:(id _Nullable)params domain:(NSString * _Nonnull)domain;
 + (CTRequest * _Nonnull)syncTemplatesRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config params:(id _Nullable)params domain:(NSString * _Nonnull)domain;
 + (CTRequest * _Nonnull)previewRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config url:(NSString * _Nonnull)url;
++ (CTRequest * _Nonnull)inboxV2FetchRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
+                                               params:(id _Nullable)params
+                                               domain:(NSString * _Nonnull)domain;
 @end
 
 

--- a/CleverTapSDK/CTRequestFactory.h
+++ b/CleverTapSDK/CTRequestFactory.h
@@ -21,6 +21,10 @@
 + (CTRequest * _Nonnull)inboxV2FetchRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
                                                params:(id _Nullable)params
                                                domain:(NSString * _Nonnull)domain;
+
++ (CTRequest * _Nonnull)inboxV2NotificationEventRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
+                                                           params:(id _Nullable)params
+                                                           domain:(NSString * _Nonnull)domain;
 @end
 
 

--- a/CleverTapSDK/CTRequestFactory.m
+++ b/CleverTapSDK/CTRequestFactory.m
@@ -45,6 +45,13 @@
     return [self _createGetRequestWithConfig:config url:url];
 }
 
++ (CTRequest * _Nonnull)inboxV2FetchRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
+                                               params:(id _Nullable)params
+                                               domain:(NSString * _Nonnull)domain {
+    NSString *url = [self _urlWithDomain:domain andPath:@"inbox/v2/getMessages"];
+    return [self _createPostRequestWithConfig:config params:params url:url];
+}
+
 + (CTRequest * _Nonnull)_createPostRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config params:(id _Nullable)params url:(NSString * _Nonnull)url {
     return [self _createPostRequestWithConfig:config params:params url:url additionalHeaders:nil];
 }

--- a/CleverTapSDK/CTRequestFactory.m
+++ b/CleverTapSDK/CTRequestFactory.m
@@ -47,15 +47,13 @@
 
 + (CTRequest * _Nonnull)inboxV2FetchRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
                                                params:(id _Nullable)params
-                                               domain:(NSString * _Nonnull)domain {
-    NSString *url = [self _urlWithDomain:domain andPath:@"inbox/v2/getMessages"];
+                                                  url:(NSString * _Nonnull)url {
     return [self _createPostRequestWithConfig:config params:params url:url];
 }
 
-+ (CTRequest * _Nonnull)inboxV2NotificationEventRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
-                                                           params:(id _Nullable)params
-                                                           domain:(NSString * _Nonnull)domain {
-    NSString *url = [self _urlWithDomain:domain andPath:@"inbox/v2/events"];
++ (CTRequest * _Nonnull)inboxV2DeleteMessagesRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
+                                                        params:(id _Nullable)params
+                                                           url:(NSString * _Nonnull)url {
     return [self _createPostRequestWithConfig:config params:params url:url];
 }
 

--- a/CleverTapSDK/CTRequestFactory.m
+++ b/CleverTapSDK/CTRequestFactory.m
@@ -52,6 +52,13 @@
     return [self _createPostRequestWithConfig:config params:params url:url];
 }
 
++ (CTRequest * _Nonnull)inboxV2NotificationEventRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config
+                                                           params:(id _Nullable)params
+                                                           domain:(NSString * _Nonnull)domain {
+    NSString *url = [self _urlWithDomain:domain andPath:@"inbox/v2/events"];
+    return [self _createPostRequestWithConfig:config params:params url:url];
+}
+
 + (CTRequest * _Nonnull)_createPostRequestWithConfig:(CleverTapInstanceConfig * _Nonnull)config params:(id _Nullable)params url:(NSString * _Nonnull)url {
     return [self _createPostRequestWithConfig:config params:params url:url additionalHeaders:nil];
 }

--- a/CleverTapSDK/CleverTap+Inbox.h
+++ b/CleverTapSDK/CleverTap+Inbox.h
@@ -263,7 +263,7 @@ typedef void (^CleverTapInboxUpdatedBlock)(void);
  callback(NO)  — throttled (< 5 min since last fetch) or inbox not initialised.
  Pass nil if you do not need the completion signal.
  */
-- (void)refreshInboxWithCallback:(CleverTapInboxSuccessBlock _Nullable)callback;
+- (void)fetchInboxWithCallback:(CleverTapInboxSuccessBlock _Nullable)callback;
 
 /*!
  @method

--- a/CleverTapSDK/CleverTap+Inbox.h
+++ b/CleverTapSDK/CleverTap+Inbox.h
@@ -253,15 +253,6 @@ typedef void (^CleverTapInboxUpdatedBlock)(void);
  */
 - (void)recordInboxNotificationClickedEventForID:(NSString * _Nonnull)messageId;
 
-/*!
- @method
-
- @abstract
- Record Notification Deleted for App Inbox.
- Must be called before deleting the message so the message JSON is still available
- for event serialisation. No-ops silently if the message is not found.
- */
-- (void)recordInboxNotificationDeletedEventForID:(NSString *_Nonnull)messageId;
 
 /*!
  @method

--- a/CleverTapSDK/CleverTap+Inbox.h
+++ b/CleverTapSDK/CleverTap+Inbox.h
@@ -255,7 +255,28 @@ typedef void (^CleverTapInboxUpdatedBlock)(void);
 
 /*!
  @method
- 
+
+ @abstract
+ Record Notification Deleted for App Inbox.
+ Must be called before deleting the message so the message JSON is still available
+ for event serialisation. No-ops silently if the message is not found.
+ */
+- (void)recordInboxNotificationDeletedEventForID:(NSString *_Nonnull)messageId;
+
+/*!
+ @method
+
+ @abstract
+ Manually trigger an inbox refresh via /inbox/v2/getMessages.
+ callback(YES) — fetch was dispatched; new messages may arrive via registered update blocks.
+ callback(NO)  — throttled (< 5 min since last fetch) or inbox not initialised.
+ Pass nil if you do not need the completion signal.
+ */
+- (void)refreshInboxWithCallback:(CleverTapInboxSuccessBlock _Nullable)callback;
+
+/*!
+ @method
+
  @abstract
  This method dismisses the inbox controller
  */

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2605,7 +2605,7 @@ static BOOL sharedInstanceErrorLogged;
                 
 #if !CLEVERTAP_NO_INBOX_SUPPORT
                 if (jsonResp[CLTAP_INBOX_V2_RESPONSE_KEY]) {
-                    [self handleAppInboxV2Response:jsonResp];
+                    [self handleAppInboxV2Response:jsonResp isCompleteResponse:NO];
                 }
                 if (jsonResp[CLTAP_INBOX_MSG_JSON_RESPONSE_KEY]) {
                     [self handleAppInboxResponse:jsonResp];
@@ -4282,7 +4282,7 @@ static BOOL sharedInstanceErrorLogged;
 
 #pragma mark Inbox V2 private
 
-- (void)handleAppInboxV2Response:(NSDictionary *)jsonResp {
+- (void)handleAppInboxV2Response:(NSDictionary *)jsonResp isCompleteResponse:(BOOL)isCompleteResponse {
     NSArray *inboxV2JSON = jsonResp[CLTAP_INBOX_V2_RESPONSE_KEY];
     if (!inboxV2JSON) return;
     if (self.isUserSwitching) {
@@ -4338,7 +4338,9 @@ static BOOL sharedInstanceErrorLogged;
         [self.dispatchQueueManager runSerialAsync:^{
             [self.inboxController performExpiryPurge];
             [self.inboxController addV2MessageIds:[capturedResponseIds allObjects]];
-            [self.inboxController deleteAbsentPersistentV2MessagesFromResponseIds:capturedResponseIds];
+            if (isCompleteResponse) {
+                [self.inboxController deleteAbsentPersistentV2MessagesFromResponseIds:capturedResponseIds];
+            }
             if (capturedFiltered.count > 0) {
                 [self.inboxController updateMessages:capturedFiltered];
             }
@@ -4407,7 +4409,7 @@ static BOOL sharedInstanceErrorLogged;
                 CleverTapLogDebug(strongSelf.config.logLevel,
                     @"%@: InboxV2 fetch response received — response: %@", strongSelf, jsonResp);
                 [strongSelf.dispatchQueueManager runSerialAsync:^{
-                    [strongSelf handleAppInboxV2Response:jsonResp];
+                    [strongSelf handleAppInboxV2Response:jsonResp isCompleteResponse:YES];
                     if (completion) {
                         [CTUtils runSyncMainQueue:^{
                             completion(YES);

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4330,9 +4330,13 @@ static BOOL sharedInstanceErrorLogged;
     };
     NSArray *params = @[meta, fetchEvent];
 
+    NSString *fetchEndpoint = [NSString stringWithFormat:@"https://%@/inbox/v2/getMessages?os=iOS&t=%@&z=%@",
+                               domain, self.deviceInfo.sdkVersion, self.config.accountId];
+    fetchEndpoint = [fetchEndpoint stringByAppendingFormat:@"&ts=%d", (int)[[[NSDate alloc] init] timeIntervalSince1970]];
+
     CTRequest *request = [CTRequestFactory inboxV2FetchRequestWithConfig:self.config
                                                                   params:params
-                                                                  domain:domain];
+                                                                     url:fetchEndpoint];
     __weak typeof(self) weakSelf = self;
     [request onResponse:^(NSData * _Nullable data, NSURLResponse * _Nullable response) {
         typeof(self) strongSelf = weakSelf;
@@ -4376,7 +4380,6 @@ static BOOL sharedInstanceErrorLogged;
         if (completion) completion(NO);
     }];
     NSString *fetchJsonBody = [CTUtils jsonObjectToString:params];
-    NSString *fetchEndpoint = [NSString stringWithFormat:@"https://%@/inbox/v2/getMessages", domain];
     CleverTapLogDebug(self.config.logLevel, @"%@: Sending %@ to servers at %@", self, fetchJsonBody, fetchEndpoint);
     [self.requestSender send:request];
 }
@@ -4411,51 +4414,61 @@ static BOOL sharedInstanceErrorLogged;
         return;
     }
 
+    if (!message.messageId || !message.campaignId) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: deleteMessages skipped — missing messageId or campaignId", self);
+        return;
+    }
+
     NSString *domain = self.domainFactory.redirectDomain;
     NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
 
-    [CTEventBuilder buildInboxMessageDeletedEventForMessage:message
-                                         andQueryParameters:nil
-                                          completionHandler:^(NSDictionary *event, NSArray<CTValidationResult *> *errors) {
-        if (!event) return;
-        if (errors) [self.validationResultStack pushValidationResults:errors];
+    NSString *pivot = message.json[CLTAP_NOTIFICATION_PIVOT] ?: CLTAP_NOTIFICATION_PIVOT_DEFAULT;
+    NSDictionary *messageEntry = @{
+        @"wzrk_mid": message.messageId,
+        @"wzrk_id": message.campaignId,
+        CLTAP_NOTIFICATION_PIVOT: pivot
+    };
+    NSDictionary *deleteBody = @{
+        @"type": @"deleteMessages",
+        @"messages": @[messageEntry]
+    };
+    NSArray *params = @[meta, deleteBody];
 
-        NSMutableDictionary *eventWithType = [event mutableCopy];
-        eventWithType[@"type"] = @"event";
-        NSArray *params = @[meta, eventWithType];
+    NSString *deleteEndpoint = [NSString stringWithFormat:@"https://%@/inbox/v2/deleteMessages?os=iOS&t=%@&z=%@",
+                                domain, self.deviceInfo.sdkVersion, self.config.accountId];
+    deleteEndpoint = [deleteEndpoint stringByAppendingFormat:@"&ts=%d", (int)[[[NSDate alloc] init] timeIntervalSince1970]];
 
-        CTRequest *request = [CTRequestFactory inboxV2NotificationEventRequestWithConfig:self.config
-                                                                                  params:params
-                                                                                  domain:domain];
-        __weak typeof(self) weakSelf = self;
-        [request onResponse:^(NSData *data, NSURLResponse *response) {
-            typeof(self) strongSelf = weakSelf;
-            if (!strongSelf) return;
-            NSInteger statusCode = 0;
-            if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-                statusCode = ((NSHTTPURLResponse *)response).statusCode;
-            }
-            if (statusCode == 403) {
-                strongSelf.disableInboxV2 = YES;
-                CleverTapLogDebug(strongSelf.config.logLevel,
-                    @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
-                return;
-            }
-            [strongSelf.inboxController removeV2MessageId:message.messageId];
+    CTRequest *request = [CTRequestFactory inboxV2DeleteMessagesRequestWithConfig:self.config
+                                                                           params:params
+                                                                              url:deleteEndpoint];
+    __weak typeof(self) weakSelf = self;
+    [request onResponse:^(NSData *data, NSURLResponse *response) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        NSInteger statusCode = 0;
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            statusCode = ((NSHTTPURLResponse *)response).statusCode;
+        }
+        if (statusCode == 403) {
+            strongSelf.disableInboxV2 = YES;
             CleverTapLogDebug(strongSelf.config.logLevel,
-                @"%@: Inbox: Notification Deleted event sent — status: %ld", strongSelf, (long)statusCode);
-        }];
-        [request onError:^(NSError *error) {
-            typeof(self) strongSelf = weakSelf;
-            if (!strongSelf) return;
-            CleverTapLogDebug(strongSelf.config.logLevel,
-                @"%@: Inbox: Notification Deleted event failed — error: %@", strongSelf, error.localizedDescription);
-        }];
-        NSString *deleteJsonBody = [CTUtils jsonObjectToString:params];
-        NSString *deleteEndpoint = [NSString stringWithFormat:@"https://%@/inbox/v2/events", domain];
-        CleverTapLogDebug(self.config.logLevel, @"%@: Sending %@ to servers at %@", self, deleteJsonBody, deleteEndpoint);
-        [self.requestSender send:request];
+                @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
+            return;
+        }
+        [strongSelf.inboxController removeV2MessageId:message.messageId];
+        CleverTapLogDebug(strongSelf.config.logLevel,
+            @"%@: Inbox: deleteMessages sent — status: %ld", strongSelf, (long)statusCode);
     }];
+    [request onError:^(NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        CleverTapLogDebug(strongSelf.config.logLevel,
+            @"%@: Inbox: deleteMessages failed — error: %@", strongSelf, error.localizedDescription);
+    }];
+    NSString *deleteJsonBody = [CTUtils jsonObjectToString:params];
+    CleverTapLogDebug(self.config.logLevel, @"%@: Sending %@ to servers at %@", self, deleteJsonBody, deleteEndpoint);
+    [self.requestSender send:request];
 }
 
 #pragma mark Inbox Pending Actions (R-15)

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -3992,6 +3992,11 @@ static BOOL sharedInstanceErrorLogged;
             @"%@: Inbox: skipping Deleted event — message %@ not found", self, messageId);
         return;
     }
+    if (![self.inboxController isV2MessageId:messageId]) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Deleted event — message %@ is not a V2 message", self, messageId);
+        return;
+    }
     CleverTapInboxMessage *message = [[CleverTapInboxMessage alloc] initWithJSON:msgJSON];
     if (!message) return;
 
@@ -4286,6 +4291,10 @@ static BOOL sharedInstanceErrorLogged;
         }
     }
 
+    // Persist all V2 message IDs from this response; prune IDs no longer returned by server.
+    [self.inboxController addV2MessageIds:[responseIds allObjects]];
+    [self.inboxController pruneV2MessageIdsNotInSet:responseIds];
+
     if (filtered.count > 0) {
         [self.inboxController updateMessages:filtered];
     }
@@ -4429,6 +4438,7 @@ static BOOL sharedInstanceErrorLogged;
                     @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
                 return;
             }
+            [strongSelf.inboxController removeV2MessageId:message.messageId];
             CleverTapLogDebug(strongSelf.config.logLevel,
                 @"%@: Inbox: Notification Deleted event sent — status: %ld", strongSelf, (long)statusCode);
         }];

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4042,8 +4042,7 @@ static BOOL sharedInstanceErrorLogged;
         return;
     }
 
-    self.lastInboxRefreshTimestamp = now;
-    [self _fetchInboxV2WithCompletion:^(BOOL success) {
+    [self _fetchInboxV2WithThrottle:YES completion:^(BOOL success) {
         if (callback) callback(success);
     }];
 }
@@ -4150,7 +4149,7 @@ static BOOL sharedInstanceErrorLogged;
         if (!self.deviceInfo.deviceId) return;
         [self _purgeExpiredConfirmedDeletes];
         [self _flushPendingRetryDeletes];
-        [self _fetchInboxV2WithCompletion:nil];
+        [self _fetchInboxV2WithThrottle:NO completion:nil];
     }];
 }
 
@@ -4159,7 +4158,7 @@ static BOOL sharedInstanceErrorLogged;
         self.inboxController = [[CTInboxController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy] encryptionLevel:self.config.encryptionLevel previousEncryptionLevel:self.config.cryptManager.previousEncryptionLevel encryptionManager:self.config.cryptManager];
         self.inboxController.delegate = self;
         self.lastInboxRefreshTimestamp = 0;
-        [self _fetchInboxV2WithCompletion:nil];
+        [self _fetchInboxV2WithThrottle:NO completion:nil];
     }
 }
 
@@ -4339,7 +4338,7 @@ static BOOL sharedInstanceErrorLogged;
     }];
 }
 
-- (void)_fetchInboxV2WithCompletion:(CleverTapInboxSuccessBlock)completion {
+- (void)_fetchInboxV2WithThrottle:(BOOL)shouldThrottle completion:(CleverTapInboxSuccessBlock)completion {
     if (_config.analyticsOnly) {
         CleverTapLogDebug(self.config.logLevel,
             @"%@ is configured as analytics only, InboxV2 fetch skipped", self);
@@ -4391,6 +4390,9 @@ static BOOL sharedInstanceErrorLogged;
             if (completion) completion(NO);
             return;
         }
+        if (shouldThrottle) {
+            strongSelf.lastInboxRefreshTimestamp = [[NSDate date] timeIntervalSince1970];
+        }
         if (data) {
             id jsonResp = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
             if (jsonResp && [jsonResp isKindOfClass:[NSDictionary class]]) {
@@ -4418,6 +4420,9 @@ static BOOL sharedInstanceErrorLogged;
     [request onError:^(NSError * _Nullable error) {
         typeof(self) strongSelf = weakSelf;
         if (!strongSelf) return;
+        if (shouldThrottle) {
+            strongSelf.lastInboxRefreshTimestamp = [[NSDate date] timeIntervalSince1970];
+        }
         CleverTapLogDebug(strongSelf.config.logLevel,
             @"%@: InboxV2 fetch failed — error: %@", strongSelf, error.localizedDescription);
         if (completion) completion(NO);

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -553,6 +553,9 @@ static BOOL sharedInstanceErrorLogged;
         
         [self _initFeatureFlags];
         [self _initProductConfig];
+#if !CLEVERTAP_NO_INBOX_SUPPORT
+        [self _initInbox];
+#endif
         [self notifyUserProfileInitialized];
     }
     
@@ -3870,8 +3873,6 @@ static BOOL sharedInstanceErrorLogged;
             if (!self.inboxClickedDebounceMap) {
                 self.inboxClickedDebounceMap = [NSMutableDictionary new];
             }
-            [self.inboxController performExpiryPurge];
-            [self _fetchInboxV2WithCompletion:nil];
             [CTUtils runSyncMainQueue: ^{
                 callback(self.inboxController.isInitialized);
             }];
@@ -4096,6 +4097,33 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 #pragma mark Private
+
+- (void)_initInbox {
+    if ([CTUIUtils runningInsideAppExtension]) return;
+    if (_config.analyticsOnly) return;
+    if (sizeof(void*) == 4) return;
+
+    [self.dispatchQueueManager runSerialAsync:^{
+        if (self.inboxController) return;
+        if (!self.deviceInfo.deviceId) return;
+
+        self.inboxController = [[CTInboxController alloc]
+            initWithAccountId:[self.config.accountId copy]
+                         guid:[self.deviceInfo.deviceId copy]
+              encryptionLevel:self.config.encryptionLevel
+      previousEncryptionLevel:self.config.cryptManager.previousEncryptionLevel
+            encryptionManager:self.config.cryptManager];
+        self.inboxController.delegate = self;
+        if (!self.inboxViewedDebounceMap) {
+            self.inboxViewedDebounceMap = [NSMutableDictionary new];
+        }
+        if (!self.inboxClickedDebounceMap) {
+            self.inboxClickedDebounceMap = [NSMutableDictionary new];
+        }
+        [self.inboxController performExpiryPurge];
+        [self _fetchInboxV2WithCompletion:nil];
+    }];
+}
 
 - (void)_resetInbox {
     if (self.inboxController && self.inboxController.isInitialized && self.deviceInfo.deviceId) {

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -162,6 +162,7 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 @property(atomic, strong) CTInboxController *inboxController;
 @property(nonatomic, strong) NSMutableArray<CleverTapInboxUpdatedBlock> *inboxUpdateBlocks;
 @property(atomic, assign) NSTimeInterval lastInboxRefreshTimestamp;
+@property(atomic, assign) BOOL disableInboxV2;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *inboxViewedDebounceMap;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *inboxClickedDebounceMap;
 @end
@@ -4298,6 +4299,12 @@ static BOOL sharedInstanceErrorLogged;
         if (completion) completion(NO);
         return;
     }
+    if (self.disableInboxV2) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: InboxV2 fetch skipped — API not enabled for this account", self);
+        if (completion) completion(NO);
+        return;
+    }
     if (!self.domainFactory.redirectDomain) {
         CleverTapLogDebug(self.config.logLevel,
             @"%@: InboxV2 fetch skipped — redirect domain not available", self);
@@ -4325,6 +4332,13 @@ static BOOL sharedInstanceErrorLogged;
         NSInteger statusCode = 0;
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
             statusCode = ((NSHTTPURLResponse *)response).statusCode;
+        }
+        if (statusCode == 403) {
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
+            strongSelf.disableInboxV2 = YES;
+            if (completion) completion(NO);
+            return;
         }
         if (data) {
             id jsonResp = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -3981,42 +3981,38 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)recordInboxNotificationViewedEventForID:(NSString * _Nonnull)messageId {
-    [self.dispatchQueueManager runSerialAsync:^{
-        CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
-        if (!msg) {
-            CleverTapLogDebug(self.config.logLevel,
-                @"%@: Inbox: skipping Viewed — message %@ not found or expired", self, messageId);
-            return;
-        }
-        if (msg.isRead) {
-            CleverTapLogDebug(self.config.logLevel,
-                @"%@: Inbox: skipping Viewed — message %@ already read", self, messageId);
-            return;
-        }
-        if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME forMessageId:messageId]) {
-            CleverTapLogDebug(self.config.logLevel,
-                @"%@: Inbox: skipping Viewed — duplicate within debounce window for %@", self, messageId);
-            return;
-        }
-        [self recordInboxMessageStateEvent:NO forMessage:msg andQueryParameters:nil];
-    }];
+    CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
+    if (!msg) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Viewed — message %@ not found or expired", self, messageId);
+        return;
+    }
+    if ([self.inboxController isV2MessageId:messageId] && msg.isRead) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox V2: skipping Viewed — message %@ already read", self, messageId);
+        return;
+    }
+    if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME forMessageId:messageId]) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Viewed — duplicate within debounce window for %@", self, messageId);
+        return;
+    }
+    [self recordInboxMessageStateEvent:NO forMessage:msg andQueryParameters:nil];
 }
 
 - (void)recordInboxNotificationClickedEventForID:(NSString * _Nonnull)messageId {
-    [self.dispatchQueueManager runSerialAsync:^{
-        CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
-        if (!msg) {
-            CleverTapLogDebug(self.config.logLevel,
-                @"%@: Inbox: skipping Clicked — message %@ not found or expired", self, messageId);
-            return;
-        }
-        if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_CLICKED_EVENT_NAME forMessageId:messageId]) {
-            CleverTapLogDebug(self.config.logLevel,
-                @"%@: Inbox: skipping Clicked — duplicate within debounce window for %@", self, messageId);
-            return;
-        }
-        [self recordInboxMessageStateEvent:YES forMessage:msg andQueryParameters:nil];
-    }];
+    CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
+    if (!msg) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Clicked — message %@ not found or expired", self, messageId);
+        return;
+    }
+    if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_CLICKED_EVENT_NAME forMessageId:messageId]) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Clicked — duplicate within debounce window for %@", self, messageId);
+        return;
+    }
+    [self recordInboxMessageStateEvent:YES forMessage:msg andQueryParameters:nil];
 }
 
 
@@ -4447,16 +4443,18 @@ static BOOL sharedInstanceErrorLogged;
 
     NSTimeInterval nowMs = [[NSDate date] timeIntervalSince1970] * 1000.0;
     BOOL isViewed = [eventName isEqualToString:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME];
-    NSMutableDictionary *map = isViewed ? self.inboxViewedDebounceMap : self.inboxClickedDebounceMap;
     NSTimeInterval intervalMs = isViewed ? 2000.0 : 5000.0;
 
-    if (!map) return NO;
+    @synchronized(self) {
+        NSMutableDictionary *map = isViewed ? self.inboxViewedDebounceMap : self.inboxClickedDebounceMap;
+        if (!map) return NO;
 
-    NSNumber *lastFired = map[messageId];
-    if (lastFired && (nowMs - lastFired.doubleValue) < intervalMs) {
-        return YES;
+        NSNumber *lastFired = map[messageId];
+        if (lastFired && (nowMs - lastFired.doubleValue) < intervalMs) {
+            return YES;
+        }
+        map[messageId] = @(nowMs);
     }
-    map[messageId] = @(nowMs);
     return NO;
 }
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -3938,8 +3938,12 @@ static BOOL sharedInstanceErrorLogged;
     if (![self _isInboxInitialized]) {
         return;
     }
-    [self _addPendingDeleteForMessageId:message.messageId];
-    [self.inboxController deleteMessageWithId:message.messageId];
+    NSDictionary *msgJSON = [self.inboxController messageForId:message.messageId];
+    if (msgJSON && [self.inboxController isV2MessageId:message.messageId]) {
+        [self _sendInboxDeleteForMessage:message];
+    } else {
+        [self.inboxController deleteMessageWithId:message.messageId];
+    }
 }
 
 - (void)markReadInboxMessage:(CleverTapInboxMessage * _Nonnull) message {
@@ -3985,24 +3989,6 @@ static BOOL sharedInstanceErrorLogged;
     [self recordInboxMessageStateEvent:YES forMessage:msg andQueryParameters:nil];
 }
 
-- (void)recordInboxNotificationDeletedEventForID:(NSString *)messageId {
-    NSDictionary *msgJSON = [self.inboxController messageForId:messageId];
-    if (!msgJSON) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: skipping Deleted event — message %@ not found", self, messageId);
-        return;
-    }
-    if (![self.inboxController isV2MessageId:messageId]) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: skipping Deleted event — message %@ is not a V2 message", self, messageId);
-        return;
-    }
-    CleverTapInboxMessage *message = [[CleverTapInboxMessage alloc] initWithJSON:msgJSON];
-    if (!message) return;
-
-    [self _addPendingDeleteForMessageId:messageId];
-    [self _sendInboxDeleteForMessage:message];
-}
 
 - (void)refreshInboxWithCallback:(CleverTapInboxSuccessBlock)callback {
     if (!self.inboxController || !self.inboxController.isInitialized) {
@@ -4032,18 +4018,36 @@ static BOOL sharedInstanceErrorLogged;
     if (![self _isInboxInitialized]) {
         return;
     }
-    [self _addPendingDeleteForMessageId:messageId];
-    [self.inboxController deleteMessageWithId:messageId];
+    NSDictionary *msgJSON = [self.inboxController messageForId:messageId];
+    if (msgJSON && [self.inboxController isV2MessageId:messageId]) {
+        CleverTapInboxMessage *message = [[CleverTapInboxMessage alloc] initWithJSON:msgJSON];
+        if (message) [self _sendInboxDeleteForMessage:message];
+    } else {
+        [self.inboxController deleteMessageWithId:messageId];
+    }
 }
 
 - (void)deleteInboxMessagesForIDs:(NSArray<NSString *> *_Nonnull)messageIds {
     if (![self _isInboxInitialized]) {
         return;
     }
+    NSMutableArray<CleverTapInboxMessage *> *v2Messages = [NSMutableArray new];
+    NSMutableArray<NSString *> *legacyIds = [NSMutableArray new];
     for (NSString *msgId in messageIds) {
-        [self _addPendingDeleteForMessageId:msgId];
+        NSDictionary *msgJSON = [self.inboxController messageForId:msgId];
+        if (msgJSON && [self.inboxController isV2MessageId:msgId]) {
+            CleverTapInboxMessage *message = [[CleverTapInboxMessage alloc] initWithJSON:msgJSON];
+            if (message) [v2Messages addObject:message];
+        } else {
+            [legacyIds addObject:msgId];
+        }
     }
-    [self.inboxController deleteMessagesWithId:messageIds];
+    if (v2Messages.count > 0) {
+        [self _sendInboxDeleteForMessages:v2Messages];
+    }
+    if (legacyIds.count > 0) {
+        [self.inboxController deleteMessagesWithId:legacyIds];
+    }
 }
 
 - (void)markReadInboxMessageForID:(NSString *)messageId{
@@ -4126,6 +4130,8 @@ static BOOL sharedInstanceErrorLogged;
             self.inboxClickedDebounceMap = [NSMutableDictionary new];
         }
         [self.inboxController performExpiryPurge];
+        [self _purgeExpiredConfirmedDeletes];
+        [self _flushPendingRetryDeletes];
         [self _fetchInboxV2WithCompletion:nil];
     }];
 }
@@ -4260,8 +4266,11 @@ static BOOL sharedInstanceErrorLogged;
         return;
     }
 
-    NSSet *pendingDeletes = [self _pendingDeleteMessageIds];
-    NSSet *pendingReads   = [self _pendingReadMessageIds];
+    [self _purgeExpiredConfirmedDeletes];
+
+    NSSet *retryDeleteIds   = [NSSet setWithArray:[[self _retryDeleteEntries] valueForKey:@"wzrk_mid"]];
+    NSSet *confirmedDeletes = [self _confirmedDeleteMessageIds];
+    NSSet *pendingReads     = [self _pendingReadMessageIds];
 
     NSMutableSet *responseIds = [NSMutableSet setWithCapacity:inboxV2JSON.count];
     NSMutableArray *filtered = [NSMutableArray arrayWithCapacity:inboxV2JSON.count];
@@ -4269,7 +4278,8 @@ static BOOL sharedInstanceErrorLogged;
         NSString *msgId = msg[@"_id"];
         if (msgId) [responseIds addObject:msgId];
 
-        if ([pendingDeletes containsObject:msgId]) continue;
+        if ([retryDeleteIds containsObject:msgId]) continue;
+        if ([confirmedDeletes containsObject:msgId]) continue;
 
         if ([pendingReads containsObject:msgId]) {
             NSMutableDictionary *m = [msg mutableCopy];
@@ -4280,10 +4290,10 @@ static BOOL sharedInstanceErrorLogged;
         }
     }
 
-    // Cleanup pending deletes whose messages are now absent from server response.
-    for (NSString *deletedId in pendingDeletes) {
+    // Cleanup retry deletes whose messages are now absent from server response.
+    for (NSString *deletedId in retryDeleteIds) {
         if (![responseIds containsObject:deletedId]) {
-            [self _removePendingDeleteForMessageId:deletedId];
+            [self _removeRetryDeleteForMessageId:deletedId];
         }
     }
 
@@ -4407,37 +4417,54 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)_sendInboxDeleteForMessage:(CleverTapInboxMessage *)message {
+    [self _sendInboxDeleteForMessages:@[message]];
+}
+
+- (void)_sendInboxDeleteForMessages:(NSArray<CleverTapInboxMessage *> *)messages {
     if (self.disableInboxV2) {
         CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: Notification Deleted skipped — InboxV2 API not enabled for this account", self);
+            @"%@: Inbox: deleteMessages skipped — InboxV2 API not enabled for this account", self);
         return;
     }
     if (!self.domainFactory.redirectDomain) {
         CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: Notification Deleted skipped — redirect domain not available", self);
-        return;
-    }
-
-    if (!message.messageId || !message.campaignId) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: deleteMessages skipped — missing messageId or campaignId", self);
+            @"%@: Inbox: deleteMessages skipped — redirect domain not available", self);
         return;
     }
 
     NSString *domain = self.domainFactory.redirectDomain;
     NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
 
-    NSString *pivot = message.json[CLTAP_NOTIFICATION_PIVOT] ?: CLTAP_NOTIFICATION_PIVOT_DEFAULT;
-    NSDictionary *messageEntry = @{
-        @"wzrk_mid": message.messageId,
-        @"wzrk_id": message.campaignId,
-        CLTAP_NOTIFICATION_PIVOT: pivot
-    };
-    NSDictionary *deleteBody = @{
-        @"type": @"deleteMessages",
-        @"messages": @[messageEntry]
-    };
-    NSArray *params = @[meta, deleteBody];
+    NSMutableArray *messageEntries = [NSMutableArray arrayWithCapacity:messages.count];
+    NSMutableArray *retryEntries = [NSMutableArray arrayWithCapacity:messages.count];
+
+    for (CleverTapInboxMessage *message in messages) {
+        if (!message.messageId || !message.campaignId) {
+            CleverTapLogDebug(self.config.logLevel,
+                @"%@: Inbox: skipping message in batch — missing messageId or campaignId", self);
+            continue;
+        }
+        NSString *pivot = message.json[CLTAP_NOTIFICATION_PIVOT] ?: CLTAP_NOTIFICATION_PIVOT_DEFAULT;
+        NSTimeInterval ttl = (NSTimeInterval)message.expires;
+
+        [messageEntries addObject:@{
+            @"wzrk_mid": message.messageId,
+            @"wzrk_id": message.campaignId,
+            CLTAP_NOTIFICATION_PIVOT: pivot
+        }];
+        NSDictionary *retryEntry = @{
+            @"wzrk_mid": message.messageId,
+            @"wzrk_id": message.campaignId,
+            CLTAP_NOTIFICATION_PIVOT: pivot,
+            @"ttl": @(ttl)
+        };
+        [retryEntries addObject:retryEntry];
+        [self _addRetryDeleteEntry:retryEntry];
+    }
+
+    if (messageEntries.count == 0) return;
+
+    NSArray *params = @[meta, @{@"type": @"deleteMessages", @"messages": messageEntries}];
 
     NSString *deleteEndpoint = [NSString stringWithFormat:@"https://%@/inbox/v2/deleteMessages?os=iOS&t=%@&z=%@",
                                 domain, self.deviceInfo.sdkVersion, self.config.accountId];
@@ -4460,15 +4487,28 @@ static BOOL sharedInstanceErrorLogged;
                 @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
             return;
         }
-        [strongSelf.inboxController removeV2MessageId:message.messageId];
-        CleverTapLogDebug(strongSelf.config.logLevel,
-            @"%@: Inbox: deleteMessages sent — status: %ld", strongSelf, (long)statusCode);
+        if (statusCode == 200) {
+            for (NSDictionary *entry in retryEntries) {
+                NSString *messageId = entry[@"wzrk_mid"];
+                NSTimeInterval entryTtl = [entry[@"ttl"] doubleValue];
+                [strongSelf _removeRetryDeleteForMessageId:messageId];
+                [strongSelf _addConfirmedDeleteForMessageId:messageId ttl:entryTtl];
+                [strongSelf.inboxController removeV2MessageId:messageId];
+            }
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: Inbox: deleteMessages confirmed — %lu message(s)", strongSelf, (unsigned long)retryEntries.count);
+        } else {
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: Inbox: deleteMessages not confirmed — status: %ld, will retry on next launch",
+                strongSelf, (long)statusCode);
+        }
     }];
     [request onError:^(NSError *error) {
         typeof(self) strongSelf = weakSelf;
         if (!strongSelf) return;
         CleverTapLogDebug(strongSelf.config.logLevel,
-            @"%@: Inbox: deleteMessages failed — error: %@", strongSelf, error.localizedDescription);
+            @"%@: Inbox: deleteMessages failed — error: %@, will retry on next launch",
+            strongSelf, error.localizedDescription);
     }];
     NSString *deleteJsonBody = [CTUtils jsonObjectToString:params];
     CleverTapLogDebug(self.config.logLevel, @"%@: Sending %@ to servers at %@", self, deleteJsonBody, deleteEndpoint);
@@ -4477,13 +4517,6 @@ static BOOL sharedInstanceErrorLogged;
 
 #pragma mark Inbox Pending Actions (R-15)
 
-- (NSString *)_pendingDeletesKey {
-    return [NSString stringWithFormat:@"%@%@_%@",
-            CLTAP_INBOX_PENDING_DELETES_KEY_PREFIX,
-            self.config.accountId,
-            self.deviceInfo.deviceId ?: @""];
-}
-
 - (NSString *)_pendingReadsKey {
     return [NSString stringWithFormat:@"%@%@_%@",
             CLTAP_INBOX_PENDING_READS_KEY_PREFIX,
@@ -4491,25 +4524,9 @@ static BOOL sharedInstanceErrorLogged;
             self.deviceInfo.deviceId ?: @""];
 }
 
-- (NSSet<NSString *> *)_pendingDeleteMessageIds {
-    NSArray *stored = [CTPreferences getObjectForKey:[self _pendingDeletesKey]];
-    return stored ? [NSSet setWithArray:stored] : [NSSet set];
-}
-
 - (NSSet<NSString *> *)_pendingReadMessageIds {
     NSArray *stored = [CTPreferences getObjectForKey:[self _pendingReadsKey]];
     return stored ? [NSSet setWithArray:stored] : [NSSet set];
-}
-
-- (void)_addPendingDeleteForMessageId:(NSString *)messageId {
-    if (!messageId) return;
-    NSString *key = [self _pendingDeletesKey];
-    NSArray *existing = [CTPreferences getObjectForKey:key] ?: @[];
-    NSMutableArray *updated = [existing mutableCopy];
-    if (![updated containsObject:messageId]) {
-        [updated addObject:messageId];
-        [CTPreferences putObject:updated forKey:key];
-    }
 }
 
 - (void)_addPendingReadForMessageId:(NSString *)messageId {
@@ -4523,16 +4540,6 @@ static BOOL sharedInstanceErrorLogged;
     }
 }
 
-- (void)_removePendingDeleteForMessageId:(NSString *)messageId {
-    if (!messageId) return;
-    NSString *key = [self _pendingDeletesKey];
-    NSArray *existing = [CTPreferences getObjectForKey:key];
-    if (!existing) return;
-    NSMutableArray *updated = [existing mutableCopy];
-    [updated removeObject:messageId];
-    [CTPreferences putObject:updated forKey:key];
-}
-
 - (void)_removePendingReadForMessageId:(NSString *)messageId {
     if (!messageId) return;
     NSString *key = [self _pendingReadsKey];
@@ -4541,6 +4548,148 @@ static BOOL sharedInstanceErrorLogged;
     NSMutableArray *updated = [existing mutableCopy];
     [updated removeObject:messageId];
     [CTPreferences putObject:updated forKey:key];
+}
+
+// MARK: Confirmed deletes (got 200 from backend; filter until TTL passes)
+
+- (NSString *)_confirmedDeletesKey {
+    return [NSString stringWithFormat:@"%@%@_%@",
+            CLTAP_INBOX_CONFIRMED_DELETES_KEY_PREFIX,
+            self.config.accountId,
+            self.deviceInfo.deviceId ?: @""];
+}
+
+- (NSSet<NSString *> *)_confirmedDeleteMessageIds {
+    NSDictionary *stored = [CTPreferences getObjectForKey:[self _confirmedDeletesKey]];
+    return stored ? [NSSet setWithArray:stored.allKeys] : [NSSet set];
+}
+
+- (void)_addConfirmedDeleteForMessageId:(NSString *)messageId ttl:(NSTimeInterval)ttl {
+    if (!messageId) return;
+    NSString *key = [self _confirmedDeletesKey];
+    NSMutableDictionary *existing = [[CTPreferences getObjectForKey:key] mutableCopy] ?: [NSMutableDictionary new];
+    NSTimeInterval expiresAt = ttl > 0 ? ttl : ([[NSDate date] timeIntervalSince1970] + kCTInboxConfirmedDeleteFallbackTTL);
+    existing[messageId] = @(expiresAt);
+    [CTPreferences putObject:existing forKey:key];
+}
+
+- (void)_purgeExpiredConfirmedDeletes {
+    NSString *key = [self _confirmedDeletesKey];
+    NSDictionary *stored = [CTPreferences getObjectForKey:key];
+    if (!stored) return;
+    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+    NSMutableDictionary *pruned = [stored mutableCopy];
+    for (NSString *messageId in stored) {
+        NSTimeInterval expiresAt = [stored[messageId] doubleValue];
+        if (expiresAt > 0 && now >= expiresAt) {
+            [pruned removeObjectForKey:messageId];
+        }
+    }
+    [CTPreferences putObject:pruned forKey:key];
+}
+
+// MARK: Retry deletes (no 200 yet; retried on next app launch)
+
+- (NSString *)_retryDeletesKey {
+    return [NSString stringWithFormat:@"%@%@_%@",
+            CLTAP_INBOX_RETRY_DELETES_KEY_PREFIX,
+            self.config.accountId,
+            self.deviceInfo.deviceId ?: @""];
+}
+
+- (NSArray<NSDictionary *> *)_retryDeleteEntries {
+    return [CTPreferences getObjectForKey:[self _retryDeletesKey]] ?: @[];
+}
+
+- (void)_addRetryDeleteEntry:(NSDictionary *)entry {
+    if (!entry[@"wzrk_mid"]) return;
+    NSString *key = [self _retryDeletesKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key] ?: @[];
+    for (NSDictionary *e in existing) {
+        if ([e[@"wzrk_mid"] isEqualToString:entry[@"wzrk_mid"]]) return;
+    }
+    [CTPreferences putObject:[existing arrayByAddingObject:entry] forKey:key];
+}
+
+- (void)_removeRetryDeleteForMessageId:(NSString *)messageId {
+    if (!messageId) return;
+    NSString *key = [self _retryDeletesKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key];
+    if (!existing) return;
+    NSArray *updated = [existing filteredArrayUsingPredicate:
+        [NSPredicate predicateWithBlock:^BOOL(NSDictionary *e, NSDictionary *_) {
+            return ![e[@"wzrk_mid"] isEqualToString:messageId];
+        }]];
+    [CTPreferences putObject:updated forKey:key];
+}
+
+- (void)_flushPendingRetryDeletes {
+    if (self.disableInboxV2) return;
+    if (!self.domainFactory.redirectDomain) return;
+
+    NSArray<NSDictionary *> *entries = [self _retryDeleteEntries];
+    if (entries.count == 0) return;
+
+    CleverTapLogDebug(self.config.logLevel,
+        @"%@: Inbox: retrying %lu pending delete(s) in single request", self, (unsigned long)entries.count);
+
+    NSString *domain = self.domainFactory.redirectDomain;
+    NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
+
+    NSMutableArray *messageEntries = [NSMutableArray arrayWithCapacity:entries.count];
+    for (NSDictionary *entry in entries) {
+        [messageEntries addObject:@{
+            @"wzrk_mid": entry[@"wzrk_mid"],
+            @"wzrk_id": entry[@"wzrk_id"],
+            CLTAP_NOTIFICATION_PIVOT: entry[CLTAP_NOTIFICATION_PIVOT] ?: CLTAP_NOTIFICATION_PIVOT_DEFAULT
+        }];
+    }
+
+    NSArray *params = @[meta, @{@"type": @"deleteMessages", @"messages": messageEntries}];
+
+    NSString *endpoint = [NSString stringWithFormat:@"https://%@/inbox/v2/deleteMessages?os=iOS&t=%@&z=%@",
+                          domain, self.deviceInfo.sdkVersion, self.config.accountId];
+    endpoint = [endpoint stringByAppendingFormat:@"&ts=%d", (int)[[[NSDate alloc] init] timeIntervalSince1970]];
+
+    CTRequest *request = [CTRequestFactory inboxV2DeleteMessagesRequestWithConfig:self.config
+                                                                           params:params
+                                                                              url:endpoint];
+    __weak typeof(self) weakSelf = self;
+    [request onResponse:^(NSData *data, NSURLResponse *response) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        NSInteger statusCode = [response isKindOfClass:[NSHTTPURLResponse class]]
+            ? ((NSHTTPURLResponse *)response).statusCode : 0;
+        if (statusCode == 403) {
+            strongSelf.disableInboxV2 = YES;
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
+            return;
+        }
+        if (statusCode == 200) {
+            for (NSDictionary *entry in entries) {
+                NSString *messageId = entry[@"wzrk_mid"];
+                NSTimeInterval entryTtl = [entry[@"ttl"] doubleValue];
+                [strongSelf _removeRetryDeleteForMessageId:messageId];
+                [strongSelf _addConfirmedDeleteForMessageId:messageId ttl:entryTtl];
+                [strongSelf.inboxController removeV2MessageId:messageId];
+            }
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: Inbox: retry deleteMessages confirmed — %lu message(s)", strongSelf, (unsigned long)entries.count);
+        } else {
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: Inbox: retry deleteMessages not confirmed — status: %ld", strongSelf, (long)statusCode);
+        }
+    }];
+    [request onError:^(NSError *error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        CleverTapLogDebug(strongSelf.config.logLevel,
+            @"%@: Inbox: retry deleteMessages failed — error: %@", strongSelf, error.localizedDescription);
+    }];
+    NSString *retryJsonBody = [CTUtils jsonObjectToString:params];
+    CleverTapLogDebug(self.config.logLevel, @"%@: Sending %@ to servers at %@", self, retryJsonBody, endpoint);
+    [self.requestSender send:request];
 }
 
 #pragma mark Inbox Message private

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -3881,18 +3881,26 @@ static BOOL sharedInstanceErrorLogged;
     }];
 }
 
+- (NSSet<NSString *> *)_locallyDeletedV2MessageIds {
+    NSArray *retryIds = [[self _retryDeleteEntries] valueForKey:@"wzrk_mid"];
+    NSSet *confirmed = [self _confirmedDeleteMessageIds];
+    NSMutableSet *deleted = [NSMutableSet setWithArray:retryIds];
+    [deleted unionSet:confirmed];
+    return deleted;
+}
+
 - (NSInteger)getInboxMessageCount {
     if (![self _isInboxInitialized]) {
         return -1;
     }
-    return self.inboxController.count;
+    return (NSInteger)[self getAllInboxMessages].count;
 }
 
 - (NSInteger)getInboxMessageUnreadCount {
     if (![self _isInboxInitialized]) {
         return -1;
     }
-    return self.inboxController.unreadCount;
+    return (NSInteger)[self getUnreadInboxMessages].count;
 }
 
 - (NSArray<CleverTapInboxMessage *> * _Nonnull )getAllInboxMessages {
@@ -3900,14 +3908,16 @@ static BOOL sharedInstanceErrorLogged;
     if (![self _isInboxInitialized]) {
         return all;
     }
+    NSSet *deleted = [self _locallyDeletedV2MessageIds];
     for (NSDictionary *m in self.inboxController.messages) {
         @try {
-            [all addObject: [[CleverTapInboxMessage alloc] initWithJSON:m]];
+            NSString *msgId = m[@"_id"];
+            if (msgId && [deleted containsObject:msgId]) continue;
+            [all addObject:[[CleverTapInboxMessage alloc] initWithJSON:m]];
         } @catch (NSException *e) {
             CleverTapLogDebug(_config.logLevel, @"Error getting inbox message: %@", e.debugDescription);
         }
-    };
-    
+    }
     return all;
 }
 
@@ -3916,18 +3926,24 @@ static BOOL sharedInstanceErrorLogged;
     if (![self _isInboxInitialized]) {
         return all;
     }
+    NSSet *deleted = [self _locallyDeletedV2MessageIds];
     for (NSDictionary *m in self.inboxController.unreadMessages) {
         @try {
-            [all addObject: [[CleverTapInboxMessage alloc] initWithJSON:m]];
+            NSString *msgId = m[@"_id"];
+            if (msgId && [deleted containsObject:msgId]) continue;
+            [all addObject:[[CleverTapInboxMessage alloc] initWithJSON:m]];
         } @catch (NSException *e) {
             CleverTapLogDebug(_config.logLevel, @"Error getting inbox message: %@", e.debugDescription);
         }
-    };
+    }
     return all;
 }
 
-- (CleverTapInboxMessage * _Nullable )getInboxMessageForId:(NSString * _Nonnull)messageId {
+- (CleverTapInboxMessage * _Nullable)getInboxMessageForId:(NSString * _Nonnull)messageId {
     if (![self _isInboxInitialized]) {
+        return nil;
+    }
+    if ([[self _locallyDeletedV2MessageIds] containsObject:messageId]) {
         return nil;
     }
     NSDictionary *m = [self.inboxController messageForId:messageId];

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -161,6 +161,9 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 @interface CleverTap () <CTInboxDelegate, CleverTapInboxViewControllerAnalyticsDelegate> {}
 @property(atomic, strong) CTInboxController *inboxController;
 @property(nonatomic, strong) NSMutableArray<CleverTapInboxUpdatedBlock> *inboxUpdateBlocks;
+@property(atomic, assign) NSTimeInterval lastInboxRefreshTimestamp;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *inboxViewedDebounceMap;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *inboxClickedDebounceMap;
 @end
 #endif
 
@@ -2594,7 +2597,12 @@ static BOOL sharedInstanceErrorLogged;
 #endif
                 
 #if !CLEVERTAP_NO_INBOX_SUPPORT
-                [self handleAppInboxResponse:jsonResp];
+                if (jsonResp[CLTAP_INBOX_V2_RESPONSE_KEY]) {
+                    [self handleAppInboxV2Response:jsonResp];
+                }
+                if (jsonResp[CLTAP_INBOX_MSG_JSON_RESPONSE_KEY]) {
+                    [self handleAppInboxResponse:jsonResp];
+                }
 #endif
                 
 #if !CLEVERTAP_NO_DISPLAY_UNIT_SUPPORT
@@ -3856,6 +3864,14 @@ static BOOL sharedInstanceErrorLogged;
         if (self.deviceInfo.deviceId) {
             self.inboxController = [[CTInboxController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy] encryptionLevel:self.config.encryptionLevel previousEncryptionLevel:self.config.cryptManager.previousEncryptionLevel encryptionManager:self.config.cryptManager];
             self.inboxController.delegate = self;
+            if (!self.inboxViewedDebounceMap) {
+                self.inboxViewedDebounceMap = [NSMutableDictionary new];
+            }
+            if (!self.inboxClickedDebounceMap) {
+                self.inboxClickedDebounceMap = [NSMutableDictionary new];
+            }
+            [self.inboxController performExpiryPurge];
+            [self _fetchInboxV2WithCompletion:nil];
             [CTUtils runSyncMainQueue: ^{
                 callback(self.inboxController.isInitialized);
             }];
@@ -3920,6 +3936,7 @@ static BOOL sharedInstanceErrorLogged;
     if (![self _isInboxInitialized]) {
         return;
     }
+    [self _addPendingDeleteForMessageId:message.messageId];
     [self.inboxController deleteMessageWithId:message.messageId];
 }
 
@@ -3927,29 +3944,98 @@ static BOOL sharedInstanceErrorLogged;
     if (![self _isInboxInitialized]) {
         return;
     }
+    [self _addPendingReadForMessageId:message.messageId];
     [self.inboxController markReadMessageWithId:message.messageId];
 }
 
 - (void)recordInboxNotificationViewedEventForID:(NSString * _Nonnull)messageId {
-    CleverTapInboxMessage *message = [self getInboxMessageForId:messageId];
-    [self recordInboxMessageStateEvent:NO forMessage:message andQueryParameters:nil];
+    CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
+    if (!msg) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Viewed — message %@ not found or expired", self, messageId);
+        return;
+    }
+    if (msg.isRead) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Viewed — message %@ already read", self, messageId);
+        return;
+    }
+    if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME forMessageId:messageId]) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Viewed — duplicate within debounce window for %@", self, messageId);
+        return;
+    }
+    [self recordInboxMessageStateEvent:NO forMessage:msg andQueryParameters:nil];
 }
 
 - (void)recordInboxNotificationClickedEventForID:(NSString * _Nonnull)messageId {
-    CleverTapInboxMessage *message = [self getInboxMessageForId:messageId];
-    [self recordInboxMessageStateEvent:YES forMessage:message andQueryParameters:nil];
+    CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
+    if (!msg) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Clicked — message %@ not found or expired", self, messageId);
+        return;
+    }
+    if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_CLICKED_EVENT_NAME forMessageId:messageId]) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Clicked — duplicate within debounce window for %@", self, messageId);
+        return;
+    }
+    [self recordInboxMessageStateEvent:YES forMessage:msg andQueryParameters:nil];
+}
+
+- (void)recordInboxNotificationDeletedEventForID:(NSString *)messageId {
+    NSDictionary *msgJSON = [self.inboxController messageForId:messageId];
+    if (!msgJSON) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: skipping Deleted event — message %@ not found", self, messageId);
+        return;
+    }
+    CleverTapInboxMessage *message = [[CleverTapInboxMessage alloc] initWithJSON:msgJSON];
+    if (!message) return;
+
+    [self _addPendingDeleteForMessageId:messageId];
+    // V2 delete endpoint — blocked on Q-15 (backend contract TBD).
+    [self _sendInboxDeleteForMessage:message];
+}
+
+- (void)refreshInboxWithCallback:(CleverTapInboxSuccessBlock)callback {
+    if (!self.inboxController || !self.inboxController.isInitialized) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox refresh skipped — inbox not initialised", self);
+        if (callback) callback(NO);
+        return;
+    }
+
+    NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+    if (self.lastInboxRefreshTimestamp > 0 &&
+        (now - self.lastInboxRefreshTimestamp) < kCTInboxRefreshMinInterval) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox refresh throttled — %.0f s remaining",
+            self, kCTInboxRefreshMinInterval - (now - self.lastInboxRefreshTimestamp));
+        if (callback) callback(NO);
+        return;
+    }
+
+    self.lastInboxRefreshTimestamp = now;
+    [self _fetchInboxV2WithCompletion:^(BOOL success) {
+        if (callback) callback(success);
+    }];
 }
 
 - (void)deleteInboxMessageForID:(NSString *)messageId {
     if (![self _isInboxInitialized]) {
         return;
     }
+    [self _addPendingDeleteForMessageId:messageId];
     [self.inboxController deleteMessageWithId:messageId];
 }
 
 - (void)deleteInboxMessagesForIDs:(NSArray<NSString *> *_Nonnull)messageIds {
     if (![self _isInboxInitialized]) {
         return;
+    }
+    for (NSString *msgId in messageIds) {
+        [self _addPendingDeleteForMessageId:msgId];
     }
     [self.inboxController deleteMessagesWithId:messageIds];
 }
@@ -3958,6 +4044,7 @@ static BOOL sharedInstanceErrorLogged;
     if (![self _isInboxInitialized]) {
         return;
     }
+    [self _addPendingReadForMessageId:messageId];
     [self.inboxController markReadMessageWithId:messageId];
 }
 
@@ -3966,6 +4053,9 @@ static BOOL sharedInstanceErrorLogged;
         return;
     }
     if (messageIds != nil && [messageIds count] > 0) {
+        for (NSString *msgId in messageIds) {
+            [self _addPendingReadForMessageId:msgId];
+        }
         [self.inboxController markReadMessagesWithId:messageIds];
     }
     else {
@@ -4011,6 +4101,8 @@ static BOOL sharedInstanceErrorLogged;
     if (self.inboxController && self.inboxController.isInitialized && self.deviceInfo.deviceId) {
         self.inboxController = [[CTInboxController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy] encryptionLevel:self.config.encryptionLevel previousEncryptionLevel:self.config.cryptManager.previousEncryptionLevel encryptionManager:self.config.cryptManager];
         self.inboxController.delegate = self;
+        self.lastInboxRefreshTimestamp = 0;
+        [self _fetchInboxV2WithCompletion:nil];
     }
 }
 
@@ -4097,6 +4189,10 @@ static BOOL sharedInstanceErrorLogged;
 #endif
 }
 
+- (void)inboxViewControllerDidRequestRefreshWithCallback:(CleverTapInboxSuccessBlock)callback {
+    [self refreshInboxWithCallback:callback];
+}
+
 - (void)recordInboxMessageStateEvent:(BOOL)clicked
                           forMessage:(CleverTapInboxMessage *)message andQueryParameters:(NSDictionary *)params {
     
@@ -4115,6 +4211,214 @@ static BOOL sharedInstanceErrorLogged;
     }];
 }
 
+
+#pragma mark Inbox V2 private
+
+- (void)handleAppInboxV2Response:(NSDictionary *)jsonResp {
+    NSArray *inboxV2JSON = jsonResp[CLTAP_INBOX_V2_RESPONSE_KEY];
+    if (!inboxV2JSON) return;
+    if (self.isUserSwitching) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: InboxV2 response skipped — user switching in progress", self);
+        return;
+    }
+
+    NSSet *pendingDeletes = [self _pendingDeleteMessageIds];
+    NSSet *pendingReads   = [self _pendingReadMessageIds];
+
+    NSMutableSet *responseIds = [NSMutableSet setWithCapacity:inboxV2JSON.count];
+    NSMutableArray *filtered = [NSMutableArray arrayWithCapacity:inboxV2JSON.count];
+    for (NSDictionary *msg in inboxV2JSON) {
+        NSString *msgId = msg[@"_id"];
+        if (msgId) [responseIds addObject:msgId];
+
+        if ([pendingDeletes containsObject:msgId]) continue;
+
+        if ([pendingReads containsObject:msgId]) {
+            NSMutableDictionary *m = [msg mutableCopy];
+            m[@"isRead"] = @YES;
+            [filtered addObject:m];
+        } else {
+            [filtered addObject:msg];
+        }
+    }
+
+    // Cleanup pending deletes whose messages are now absent from server response.
+    for (NSString *deletedId in pendingDeletes) {
+        if (![responseIds containsObject:deletedId]) {
+            [self _removePendingDeleteForMessageId:deletedId];
+        }
+    }
+
+    // Cleanup pending reads confirmed by server (server returned isRead=true).
+    for (NSDictionary *msg in inboxV2JSON) {
+        NSString *msgId = msg[@"_id"];
+        if (msgId && [pendingReads containsObject:msgId] && [msg[@"isRead"] boolValue]) {
+            [self _removePendingReadForMessageId:msgId];
+        }
+    }
+
+    if (filtered.count > 0) {
+        [self.inboxController updateMessages:filtered];
+    }
+}
+
+- (void)_fetchInboxV2WithCompletion:(CleverTapInboxSuccessBlock)completion {
+    if (_config.analyticsOnly) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@ is configured as analytics only, InboxV2 fetch skipped", self);
+        if (completion) completion(NO);
+        return;
+    }
+    if (!self.domainFactory.redirectDomain) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: InboxV2 fetch skipped — redirect domain not available", self);
+        if (completion) completion(NO);
+        return;
+    }
+
+    NSString *domain = self.domainFactory.redirectDomain;
+
+    NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
+    NSDictionary *fetchEvent = @{
+        @"type": @"event",
+        @"evtName": CLTAP_WZRK_FETCH_EVENT,
+        @"evtData": @{@"t": @(kCTInboxFetchTypeInboxV2)}
+    };
+    NSArray *params = @[meta, fetchEvent];
+
+    CTRequest *request = [CTRequestFactory inboxV2FetchRequestWithConfig:self.config
+                                                                  params:params
+                                                                  domain:domain];
+    __weak typeof(self) weakSelf = self;
+    [request onResponse:^(NSData * _Nullable data, NSURLResponse * _Nullable response) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        NSInteger statusCode = 0;
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            statusCode = ((NSHTTPURLResponse *)response).statusCode;
+        }
+        if (data) {
+            id jsonResp = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
+            if (jsonResp && [jsonResp isKindOfClass:[NSDictionary class]]) {
+                CleverTapLogDebug(strongSelf.config.logLevel,
+                    @"%@: InboxV2 fetch response received — status: %ld", strongSelf, (long)statusCode);
+                [strongSelf.dispatchQueueManager runSerialAsync:^{
+                    [strongSelf handleAppInboxV2Response:jsonResp];
+                }];
+                if (completion) completion(YES);
+            } else {
+                CleverTapLogDebug(strongSelf.config.logLevel,
+                    @"%@: InboxV2 fetch failed — could not parse response, status: %ld", strongSelf, (long)statusCode);
+                if (completion) completion(NO);
+            }
+        } else {
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: InboxV2 fetch failed — no data, status: %ld", strongSelf, (long)statusCode);
+            if (completion) completion(NO);
+        }
+    }];
+    [request onError:^(NSError * _Nullable error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        CleverTapLogDebug(strongSelf.config.logLevel,
+            @"%@: InboxV2 fetch failed — error: %@", strongSelf, error.localizedDescription);
+        if (completion) completion(NO);
+    }];
+    [self.requestSender send:request];
+}
+
+- (BOOL)_isDuplicateInboxEvent:(NSString *)eventName forMessageId:(NSString *)messageId {
+    if (!messageId || !eventName) return NO;
+
+    NSTimeInterval nowMs = [[NSDate date] timeIntervalSince1970] * 1000.0;
+    BOOL isViewed = [eventName isEqualToString:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME];
+    NSMutableDictionary *map = isViewed ? self.inboxViewedDebounceMap : self.inboxClickedDebounceMap;
+    NSTimeInterval intervalMs = isViewed ? 2000.0 : 5000.0;
+
+    if (!map) return NO;
+
+    NSNumber *lastFired = map[messageId];
+    if (lastFired && (nowMs - lastFired.doubleValue) < intervalMs) {
+        return YES;
+    }
+    map[messageId] = @(nowMs);
+    return NO;
+}
+
+- (void)_sendInboxDeleteForMessage:(CleverTapInboxMessage *)message {
+    // V2 delete endpoint is blocked on Q-15 (backend contract TBD).
+    CleverTapLogDebug(self.config.logLevel,
+        @"%@: Inbox: Notification Deleted pending — V2 delete endpoint not yet defined (Q-15)", self);
+}
+
+#pragma mark Inbox Pending Actions (R-15)
+
+- (NSString *)_pendingDeletesKey {
+    return [NSString stringWithFormat:@"%@%@_%@",
+            CLTAP_INBOX_PENDING_DELETES_KEY_PREFIX,
+            self.config.accountId,
+            self.deviceInfo.deviceId ?: @""];
+}
+
+- (NSString *)_pendingReadsKey {
+    return [NSString stringWithFormat:@"%@%@_%@",
+            CLTAP_INBOX_PENDING_READS_KEY_PREFIX,
+            self.config.accountId,
+            self.deviceInfo.deviceId ?: @""];
+}
+
+- (NSSet<NSString *> *)_pendingDeleteMessageIds {
+    NSArray *stored = [CTPreferences getObjectForKey:[self _pendingDeletesKey]];
+    return stored ? [NSSet setWithArray:stored] : [NSSet set];
+}
+
+- (NSSet<NSString *> *)_pendingReadMessageIds {
+    NSArray *stored = [CTPreferences getObjectForKey:[self _pendingReadsKey]];
+    return stored ? [NSSet setWithArray:stored] : [NSSet set];
+}
+
+- (void)_addPendingDeleteForMessageId:(NSString *)messageId {
+    if (!messageId) return;
+    NSString *key = [self _pendingDeletesKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key] ?: @[];
+    NSMutableArray *updated = [existing mutableCopy];
+    if (![updated containsObject:messageId]) {
+        [updated addObject:messageId];
+        [CTPreferences putObject:updated forKey:key];
+    }
+}
+
+- (void)_addPendingReadForMessageId:(NSString *)messageId {
+    if (!messageId) return;
+    NSString *key = [self _pendingReadsKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key] ?: @[];
+    NSMutableArray *updated = [existing mutableCopy];
+    if (![updated containsObject:messageId]) {
+        [updated addObject:messageId];
+        [CTPreferences putObject:updated forKey:key];
+    }
+}
+
+- (void)_removePendingDeleteForMessageId:(NSString *)messageId {
+    if (!messageId) return;
+    NSString *key = [self _pendingDeletesKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key];
+    if (!existing) return;
+    NSMutableArray *updated = [existing mutableCopy];
+    [updated removeObject:messageId];
+    [CTPreferences putObject:updated forKey:key];
+}
+
+- (void)_removePendingReadForMessageId:(NSString *)messageId {
+    if (!messageId) return;
+    NSString *key = [self _pendingReadsKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key];
+    if (!existing) return;
+    NSMutableArray *updated = [existing mutableCopy];
+    [updated removeObject:messageId];
+    [CTPreferences putObject:updated forKey:key];
+}
 
 #pragma mark Inbox Message private
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -3973,38 +3973,42 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)recordInboxNotificationViewedEventForID:(NSString * _Nonnull)messageId {
-    CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
-    if (!msg) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: skipping Viewed — message %@ not found or expired", self, messageId);
-        return;
-    }
-    if (msg.isRead) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: skipping Viewed — message %@ already read", self, messageId);
-        return;
-    }
-    if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME forMessageId:messageId]) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: skipping Viewed — duplicate within debounce window for %@", self, messageId);
-        return;
-    }
-    [self recordInboxMessageStateEvent:NO forMessage:msg andQueryParameters:nil];
+    [self.dispatchQueueManager runSerialAsync:^{
+        CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
+        if (!msg) {
+            CleverTapLogDebug(self.config.logLevel,
+                @"%@: Inbox: skipping Viewed — message %@ not found or expired", self, messageId);
+            return;
+        }
+        if (msg.isRead) {
+            CleverTapLogDebug(self.config.logLevel,
+                @"%@: Inbox: skipping Viewed — message %@ already read", self, messageId);
+            return;
+        }
+        if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME forMessageId:messageId]) {
+            CleverTapLogDebug(self.config.logLevel,
+                @"%@: Inbox: skipping Viewed — duplicate within debounce window for %@", self, messageId);
+            return;
+        }
+        [self recordInboxMessageStateEvent:NO forMessage:msg andQueryParameters:nil];
+    }];
 }
 
 - (void)recordInboxNotificationClickedEventForID:(NSString * _Nonnull)messageId {
-    CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
-    if (!msg) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: skipping Clicked — message %@ not found or expired", self, messageId);
-        return;
-    }
-    if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_CLICKED_EVENT_NAME forMessageId:messageId]) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: Inbox: skipping Clicked — duplicate within debounce window for %@", self, messageId);
-        return;
-    }
-    [self recordInboxMessageStateEvent:YES forMessage:msg andQueryParameters:nil];
+    [self.dispatchQueueManager runSerialAsync:^{
+        CleverTapInboxMessage *msg = [self getInboxMessageForId:messageId];
+        if (!msg) {
+            CleverTapLogDebug(self.config.logLevel,
+                @"%@: Inbox: skipping Clicked — message %@ not found or expired", self, messageId);
+            return;
+        }
+        if ([self _isDuplicateInboxEvent:CLTAP_NOTIFICATION_CLICKED_EVENT_NAME forMessageId:messageId]) {
+            CleverTapLogDebug(self.config.logLevel,
+                @"%@: Inbox: skipping Clicked — duplicate within debounce window for %@", self, messageId);
+            return;
+        }
+        [self recordInboxMessageStateEvent:YES forMessage:msg andQueryParameters:nil];
+    }];
 }
 
 
@@ -4012,6 +4016,18 @@ static BOOL sharedInstanceErrorLogged;
     if (!self.inboxController || !self.inboxController.isInitialized) {
         CleverTapLogDebug(self.config.logLevel,
             @"%@: Inbox refresh skipped — inbox not initialised", self);
+        if (callback) callback(NO);
+        return;
+    }
+    if (self.disableInboxV2) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: InboxV2 fetch skipped — API not enabled for this account", self);
+        if (callback) callback(NO);
+        return;
+    }
+    if (!self.domainFactory.redirectDomain) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: InboxV2 fetch skipped — redirect domain not available", self);
         if (callback) callback(NO);
         return;
     }
@@ -4382,8 +4398,12 @@ static BOOL sharedInstanceErrorLogged;
                     @"%@: InboxV2 fetch response received — response: %@", strongSelf, jsonResp);
                 [strongSelf.dispatchQueueManager runSerialAsync:^{
                     [strongSelf handleAppInboxV2Response:jsonResp];
+                    if (completion) {
+                        [CTUtils runSyncMainQueue:^{
+                            completion(YES);
+                        }];
+                    }
                 }];
-                if (completion) completion(YES);
             } else {
                 CleverTapLogDebug(strongSelf.config.logLevel,
                     @"%@: InboxV2 fetch failed — could not parse response, status: %ld", strongSelf, (long)statusCode);

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4149,6 +4149,7 @@ static BOOL sharedInstanceErrorLogged;
     if (_config.analyticsOnly) return;
     if (sizeof(void*) == 4) return;
 
+    self.isInboxV2Enabled = YES;
     [self.dispatchQueueManager runSerialAsync:^{
         if (!self.deviceInfo.deviceId) return;
         [self _purgeExpiredConfirmedDeletes];
@@ -4270,7 +4271,8 @@ static BOOL sharedInstanceErrorLogged;
                           forMessage:(CleverTapInboxMessage *)message andQueryParameters:(NSDictionary *)params {
     
     [self.dispatchQueueManager runSerialAsync:^{
-        [CTEventBuilder buildInboxMessageStateEvent:clicked forMessage:message andQueryParameters:params completionHandler:^(NSDictionary *event, NSArray<CTValidationResult*>*errors) {
+        BOOL isV2Message = [self.inboxController isV2MessageId:message.messageId];
+        [CTEventBuilder buildInboxMessageStateEvent:clicked forMessage:message isV2Message:isV2Message andQueryParameters:params completionHandler:^(NSDictionary *event, NSArray<CTValidationResult*>*errors) {
             if (event) {
                 if (clicked) {
                     self.wzrkParams = [event[CLTAP_EVENT_DATA] copy];
@@ -4392,15 +4394,12 @@ static BOOL sharedInstanceErrorLogged;
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
             statusCode = ((NSHTTPURLResponse *)response).statusCode;
         }
+        strongSelf.isInboxV2Enabled = (statusCode == 200);
         if (statusCode == 403) {
             CleverTapLogDebug(strongSelf.config.logLevel,
                 @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
-            strongSelf.isInboxV2Enabled = NO;
             if (completion) completion(NO);
             return;
-        }
-        if (statusCode == 200) {
-            strongSelf.isInboxV2Enabled = YES;
         }
         if (shouldThrottle) {
             strongSelf.lastInboxRefreshTimestamp = [[NSDate date] timeIntervalSince1970];
@@ -4432,9 +4431,6 @@ static BOOL sharedInstanceErrorLogged;
     [request onError:^(NSError * _Nullable error) {
         typeof(self) strongSelf = weakSelf;
         if (!strongSelf) return;
-        if (shouldThrottle) {
-            strongSelf.lastInboxRefreshTimestamp = [[NSDate date] timeIntervalSince1970];
-        }
         CleverTapLogDebug(strongSelf.config.logLevel,
             @"%@: InboxV2 fetch failed — error: %@", strongSelf, error.localizedDescription);
         if (completion) completion(NO);
@@ -4529,8 +4525,8 @@ static BOOL sharedInstanceErrorLogged;
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
             statusCode = ((NSHTTPURLResponse *)response).statusCode;
         }
+        strongSelf.isInboxV2Enabled = (statusCode == 200);
         if (statusCode == 403) {
-            strongSelf.isInboxV2Enabled = NO;
             CleverTapLogDebug(strongSelf.config.logLevel,
                 @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
             return;
@@ -4718,8 +4714,8 @@ static BOOL sharedInstanceErrorLogged;
         if (!strongSelf) return;
         NSInteger statusCode = [response isKindOfClass:[NSHTTPURLResponse class]]
             ? ((NSHTTPURLResponse *)response).statusCode : 0;
+        strongSelf.isInboxV2Enabled = (statusCode == 200);
         if (statusCode == 403) {
-            strongSelf.isInboxV2Enabled = NO;
             CleverTapLogDebug(strongSelf.config.logLevel,
                 @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
             return;

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -162,7 +162,7 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 @property(atomic, strong) CTInboxController *inboxController;
 @property(nonatomic, strong) NSMutableArray<CleverTapInboxUpdatedBlock> *inboxUpdateBlocks;
 @property(atomic, assign) NSTimeInterval lastInboxRefreshTimestamp;
-@property(atomic, assign) BOOL disableInboxV2;
+@property(atomic, assign) BOOL isInboxV2Enabled;
 @property(nonatomic, assign) BOOL needsInboxFetchAfterProfileSend;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *inboxViewedDebounceMap;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *inboxClickedDebounceMap;
@@ -4023,7 +4023,7 @@ static BOOL sharedInstanceErrorLogged;
         if (callback) callback(NO);
         return;
     }
-    if (self.disableInboxV2) {
+    if (!self.isInboxV2Enabled) {
         CleverTapLogDebug(self.config.logLevel,
             @"%@: InboxV2 fetch skipped — API not enabled for this account", self);
         if (callback) callback(NO);
@@ -4162,7 +4162,12 @@ static BOOL sharedInstanceErrorLogged;
         self.inboxController = [[CTInboxController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy] encryptionLevel:self.config.encryptionLevel previousEncryptionLevel:self.config.cryptManager.previousEncryptionLevel encryptionManager:self.config.cryptManager];
         self.inboxController.delegate = self;
         self.lastInboxRefreshTimestamp = 0;
-        self.needsInboxFetchAfterProfileSend = YES;
+        if (!self.isInboxV2Enabled) {
+            CleverTapLogDebug(self.config.logLevel,
+                @"%@: InboxV2 fetch on user login skipped — API not enabled for this account", self);
+        } else {
+            self.needsInboxFetchAfterProfileSend = YES;
+        }
     }
 }
 
@@ -4251,6 +4256,10 @@ static BOOL sharedInstanceErrorLogged;
 
 - (void)inboxViewControllerDidRequestRefreshWithCallback:(CleverTapInboxSuccessBlock)callback {
     [self fetchInboxWithCallback:callback];
+}
+
+- (BOOL)inboxViewControllerIsInboxV2Enabled {
+    return self.isInboxV2Enabled;
 }
 
 - (NSArray<CleverTapInboxMessage *> *)inboxViewControllerGetMessages {
@@ -4351,7 +4360,7 @@ static BOOL sharedInstanceErrorLogged;
         if (completion) completion(NO);
         return;
     }
-    if (self.disableInboxV2) {
+    if (!self.isInboxV2Enabled) {
         CleverTapLogDebug(self.config.logLevel,
             @"%@: InboxV2 fetch skipped — API not enabled for this account", self);
         if (completion) completion(NO);
@@ -4392,9 +4401,12 @@ static BOOL sharedInstanceErrorLogged;
         if (statusCode == 403) {
             CleverTapLogDebug(strongSelf.config.logLevel,
                 @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
-            strongSelf.disableInboxV2 = YES;
+            strongSelf.isInboxV2Enabled = NO;
             if (completion) completion(NO);
             return;
+        }
+        if (statusCode == 200) {
+            strongSelf.isInboxV2Enabled = YES;
         }
         if (shouldThrottle) {
             strongSelf.lastInboxRefreshTimestamp = [[NSDate date] timeIntervalSince1970];
@@ -4463,7 +4475,7 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)_sendInboxDeleteForMessages:(NSArray<CleverTapInboxMessage *> *)messages {
-    if (self.disableInboxV2) {
+    if (!self.isInboxV2Enabled) {
         CleverTapLogDebug(self.config.logLevel,
             @"%@: Inbox: deleteMessages skipped — InboxV2 API not enabled for this account", self);
         return;
@@ -4524,7 +4536,7 @@ static BOOL sharedInstanceErrorLogged;
             statusCode = ((NSHTTPURLResponse *)response).statusCode;
         }
         if (statusCode == 403) {
-            strongSelf.disableInboxV2 = YES;
+            strongSelf.isInboxV2Enabled = NO;
             CleverTapLogDebug(strongSelf.config.logLevel,
                 @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
             return;
@@ -4676,7 +4688,7 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)_flushPendingRetryDeletes {
-    if (self.disableInboxV2) return;
+    if (!self.isInboxV2Enabled) return;
     if (!self.domainFactory.redirectDomain) return;
 
     NSArray<NSDictionary *> *entries = [self _retryDeleteEntries];
@@ -4713,7 +4725,7 @@ static BOOL sharedInstanceErrorLogged;
         NSInteger statusCode = [response isKindOfClass:[NSHTTPURLResponse class]]
             ? ((NSHTTPURLResponse *)response).statusCode : 0;
         if (statusCode == 403) {
-            strongSelf.disableInboxV2 = YES;
+            strongSelf.isInboxV2Enabled = NO;
             CleverTapLogDebug(strongSelf.config.logLevel,
                 @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
             return;

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4360,12 +4360,6 @@ static BOOL sharedInstanceErrorLogged;
         if (completion) completion(NO);
         return;
     }
-    if (!self.isInboxV2Enabled) {
-        CleverTapLogDebug(self.config.logLevel,
-            @"%@: InboxV2 fetch skipped — API not enabled for this account", self);
-        if (completion) completion(NO);
-        return;
-    }
     if (!self.domainFactory.redirectDomain) {
         CleverTapLogDebug(self.config.logLevel,
             @"%@: InboxV2 fetch skipped — redirect domain not available", self);

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4226,6 +4226,10 @@ static BOOL sharedInstanceErrorLogged;
     [self refreshInboxWithCallback:callback];
 }
 
+- (NSArray<CleverTapInboxMessage *> *)inboxViewControllerGetMessages {
+    return [self getAllInboxMessages];
+}
+
 - (void)recordInboxMessageStateEvent:(BOOL)clicked
                           forMessage:(CleverTapInboxMessage *)message andQueryParameters:(NSDictionary *)params {
     

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4352,7 +4352,7 @@ static BOOL sharedInstanceErrorLogged;
             id jsonResp = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
             if (jsonResp && [jsonResp isKindOfClass:[NSDictionary class]]) {
                 CleverTapLogDebug(strongSelf.config.logLevel,
-                    @"%@: InboxV2 fetch response received — status: %ld", strongSelf, (long)statusCode);
+                    @"%@: InboxV2 fetch response received — response: %@", strongSelf, jsonResp);
                 [strongSelf.dispatchQueueManager runSerialAsync:^{
                     [strongSelf handleAppInboxV2Response:jsonResp];
                 }];
@@ -4375,6 +4375,9 @@ static BOOL sharedInstanceErrorLogged;
             @"%@: InboxV2 fetch failed — error: %@", strongSelf, error.localizedDescription);
         if (completion) completion(NO);
     }];
+    NSString *fetchJsonBody = [CTUtils jsonObjectToString:params];
+    NSString *fetchEndpoint = [NSString stringWithFormat:@"https://%@/inbox/v2/getMessages", domain];
+    CleverTapLogDebug(self.config.logLevel, @"%@: Sending %@ to servers at %@", self, fetchJsonBody, fetchEndpoint);
     [self.requestSender send:request];
 }
 
@@ -4448,6 +4451,9 @@ static BOOL sharedInstanceErrorLogged;
             CleverTapLogDebug(strongSelf.config.logLevel,
                 @"%@: Inbox: Notification Deleted event failed — error: %@", strongSelf, error.localizedDescription);
         }];
+        NSString *deleteJsonBody = [CTUtils jsonObjectToString:params];
+        NSString *deleteEndpoint = [NSString stringWithFormat:@"https://%@/inbox/v2/events", domain];
+        CleverTapLogDebug(self.config.logLevel, @"%@: Sending %@ to servers at %@", self, deleteJsonBody, deleteEndpoint);
         [self.requestSender send:request];
     }];
 }

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2435,7 +2435,9 @@ static BOOL sharedInstanceErrorLogged;
             if ([_eventsQueue count] > 0) {
                 [_eventsQueue removeObjectsInArray:batch];
             }
-            
+
+            [self _removePendingInboxReadsForSentBatch:batch];
+
             [self parseResponse:responseData responseEncrypted:responseEncrypted];
             
             [self.delegateManager notifyDelegatesBatchDidSend:batchWithHeader withSuccess:YES withQueueType:queueType];
@@ -4555,6 +4557,16 @@ static BOOL sharedInstanceErrorLogged;
     NSMutableArray *updated = [existing mutableCopy];
     [updated removeObject:messageId];
     [CTPreferences putObject:updated forKey:key];
+}
+
+- (void)_removePendingInboxReadsForSentBatch:(NSArray *)batch {
+    for (NSDictionary *event in batch) {
+        if (![event[CLTAP_EVENT_NAME] isEqualToString:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME]) continue;
+        NSString *msgId = event[CLTAP_EVENT_DATA][@"wzrk_mid"];
+        if (msgId) {
+            [self _removePendingReadForMessageId:msgId];
+        }
+    }
 }
 
 // MARK: Confirmed deletes (got 200 from backend; filter until TTL passes)

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -3996,7 +3996,6 @@ static BOOL sharedInstanceErrorLogged;
     if (!message) return;
 
     [self _addPendingDeleteForMessageId:messageId];
-    // V2 delete endpoint — blocked on Q-15 (backend contract TBD).
     [self _sendInboxDeleteForMessage:message];
 }
 
@@ -4389,9 +4388,58 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)_sendInboxDeleteForMessage:(CleverTapInboxMessage *)message {
-    // V2 delete endpoint is blocked on Q-15 (backend contract TBD).
-    CleverTapLogDebug(self.config.logLevel,
-        @"%@: Inbox: Notification Deleted pending — V2 delete endpoint not yet defined (Q-15)", self);
+    if (self.disableInboxV2) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: Notification Deleted skipped — InboxV2 API not enabled for this account", self);
+        return;
+    }
+    if (!self.domainFactory.redirectDomain) {
+        CleverTapLogDebug(self.config.logLevel,
+            @"%@: Inbox: Notification Deleted skipped — redirect domain not available", self);
+        return;
+    }
+
+    NSString *domain = self.domainFactory.redirectDomain;
+    NSDictionary *meta = [self batchHeaderForQueue:CTQueueTypeUndefined];
+
+    [CTEventBuilder buildInboxMessageDeletedEventForMessage:message
+                                         andQueryParameters:nil
+                                          completionHandler:^(NSDictionary *event, NSArray<CTValidationResult *> *errors) {
+        if (!event) return;
+        if (errors) [self.validationResultStack pushValidationResults:errors];
+
+        NSMutableDictionary *eventWithType = [event mutableCopy];
+        eventWithType[@"type"] = @"event";
+        NSArray *params = @[meta, eventWithType];
+
+        CTRequest *request = [CTRequestFactory inboxV2NotificationEventRequestWithConfig:self.config
+                                                                                  params:params
+                                                                                  domain:domain];
+        __weak typeof(self) weakSelf = self;
+        [request onResponse:^(NSData *data, NSURLResponse *response) {
+            typeof(self) strongSelf = weakSelf;
+            if (!strongSelf) return;
+            NSInteger statusCode = 0;
+            if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+                statusCode = ((NSHTTPURLResponse *)response).statusCode;
+            }
+            if (statusCode == 403) {
+                strongSelf.disableInboxV2 = YES;
+                CleverTapLogDebug(strongSelf.config.logLevel,
+                    @"%@: InboxV2 API not enabled for this account (403) — disabling for this session", strongSelf);
+                return;
+            }
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: Inbox: Notification Deleted event sent — status: %ld", strongSelf, (long)statusCode);
+        }];
+        [request onError:^(NSError *error) {
+            typeof(self) strongSelf = weakSelf;
+            if (!strongSelf) return;
+            CleverTapLogDebug(strongSelf.config.logLevel,
+                @"%@: Inbox: Notification Deleted event failed — error: %@", strongSelf, error.localizedDescription);
+        }];
+        [self.requestSender send:request];
+    }];
 }
 
 #pragma mark Inbox Pending Actions (R-15)

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1167,10 +1167,10 @@ static BOOL sharedInstanceErrorLogged;
         [self scheduleQueueFlush];
         CleverTapLogInternal(self.config.logLevel, @"%@: app is in foreground", self);
     }
-    
+
     // Set flag based on actual state
     self.isAppForeground = isActuallyInForeground;
-    
+
 #if !CLEVERTAP_NO_INAPP_SUPPORT
     if (isActuallyInForeground && !_config.analyticsOnly && ![CTUIUtils runningInsideAppExtension]) {
         [self.inAppFCManager checkUpdateDailyLimits];
@@ -4129,23 +4129,7 @@ static BOOL sharedInstanceErrorLogged;
     if (sizeof(void*) == 4) return;
 
     [self.dispatchQueueManager runSerialAsync:^{
-        if (self.inboxController) return;
         if (!self.deviceInfo.deviceId) return;
-
-        self.inboxController = [[CTInboxController alloc]
-            initWithAccountId:[self.config.accountId copy]
-                         guid:[self.deviceInfo.deviceId copy]
-              encryptionLevel:self.config.encryptionLevel
-      previousEncryptionLevel:self.config.cryptManager.previousEncryptionLevel
-            encryptionManager:self.config.cryptManager];
-        self.inboxController.delegate = self;
-        if (!self.inboxViewedDebounceMap) {
-            self.inboxViewedDebounceMap = [NSMutableDictionary new];
-        }
-        if (!self.inboxClickedDebounceMap) {
-            self.inboxClickedDebounceMap = [NSMutableDictionary new];
-        }
-        [self.inboxController performExpiryPurge];
         [self _purgeExpiredConfirmedDeletes];
         [self _flushPendingRetryDeletes];
         [self _fetchInboxV2WithCompletion:nil];
@@ -4321,13 +4305,20 @@ static BOOL sharedInstanceErrorLogged;
         }
     }
 
-    // Persist all V2 message IDs from this response; prune IDs no longer returned by server.
-    [self.inboxController addV2MessageIds:[responseIds allObjects]];
-    [self.inboxController pruneV2MessageIdsNotInSet:responseIds];
+    NSSet *capturedResponseIds = [responseIds copy];
+    NSArray *capturedFiltered = [filtered copy];
 
-    if (filtered.count > 0) {
-        [self.inboxController updateMessages:filtered];
-    }
+    [self initializeInboxWithCallback:^(BOOL success) {
+        if (!success) return;
+        [self.dispatchQueueManager runSerialAsync:^{
+            [self.inboxController performExpiryPurge];
+            [self.inboxController addV2MessageIds:[capturedResponseIds allObjects]];
+            [self.inboxController pruneV2MessageIdsNotInSet:capturedResponseIds];
+            if (capturedFiltered.count > 0) {
+                [self.inboxController updateMessages:capturedFiltered];
+            }
+        }];
+    }];
 }
 
 - (void)_fetchInboxV2WithCompletion:(CleverTapInboxSuccessBlock)completion {

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2437,7 +2437,9 @@ static BOOL sharedInstanceErrorLogged;
                 [_eventsQueue removeObjectsInArray:batch];
             }
 
+#if !CLEVERTAP_NO_INBOX_SUPPORT
             [self _removePendingInboxReadsForSentBatch:batch];
+#endif
 
             [self parseResponse:responseData responseEncrypted:responseEncrypted];
             
@@ -4594,6 +4596,7 @@ static BOOL sharedInstanceErrorLogged;
     [CTPreferences putObject:updated forKey:key];
 }
 
+#if !CLEVERTAP_NO_INBOX_SUPPORT
 - (void)_removePendingInboxReadsForSentBatch:(NSArray *)batch {
     for (NSDictionary *event in batch) {
         if (![event[CLTAP_EVENT_NAME] isEqualToString:CLTAP_NOTIFICATION_VIEWED_EVENT_NAME]) continue;
@@ -4603,6 +4606,7 @@ static BOOL sharedInstanceErrorLogged;
         }
     }
 }
+#endif
 
 // MARK: Confirmed deletes (got 200 from backend; filter until TTL passes)
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4313,7 +4313,7 @@ static BOOL sharedInstanceErrorLogged;
         [self.dispatchQueueManager runSerialAsync:^{
             [self.inboxController performExpiryPurge];
             [self.inboxController addV2MessageIds:[capturedResponseIds allObjects]];
-            [self.inboxController pruneV2MessageIdsNotInSet:capturedResponseIds];
+            [self.inboxController deleteAbsentPersistentV2MessagesFromResponseIds:capturedResponseIds];
             if (capturedFiltered.count > 0) {
                 [self.inboxController updateMessages:capturedFiltered];
             }

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4020,7 +4020,7 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 
-- (void)refreshInboxWithCallback:(CleverTapInboxSuccessBlock)callback {
+- (void)fetchInboxWithCallback:(CleverTapInboxSuccessBlock)callback {
     if (!self.inboxController || !self.inboxController.isInitialized) {
         CleverTapLogDebug(self.config.logLevel,
             @"%@: Inbox refresh skipped — inbox not initialised", self);
@@ -4254,7 +4254,7 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)inboxViewControllerDidRequestRefreshWithCallback:(CleverTapInboxSuccessBlock)callback {
-    [self refreshInboxWithCallback:callback];
+    [self fetchInboxWithCallback:callback];
 }
 
 - (NSArray<CleverTapInboxMessage *> *)inboxViewControllerGetMessages {

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -163,6 +163,7 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 @property(nonatomic, strong) NSMutableArray<CleverTapInboxUpdatedBlock> *inboxUpdateBlocks;
 @property(atomic, assign) NSTimeInterval lastInboxRefreshTimestamp;
 @property(atomic, assign) BOOL disableInboxV2;
+@property(nonatomic, assign) BOOL needsInboxFetchAfterProfileSend;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *inboxViewedDebounceMap;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *inboxClickedDebounceMap;
 @end
@@ -2679,6 +2680,13 @@ static BOOL sharedInstanceErrorLogged;
                 } @catch (NSException *ex) {
                     CleverTapLogInternal(self.config.logLevel, @"%@: Failed to handle ARP update: %@", self, ex.debugDescription);
                 }
+
+#if !CLEVERTAP_NO_INBOX_SUPPORT
+                if (self.needsInboxFetchAfterProfileSend) {
+                    self.needsInboxFetchAfterProfileSend = NO;
+                    [self _fetchInboxV2WithThrottle:NO completion:nil];
+                }
+#endif
                 
                 // Handle dbg_lvl
                 @try {
@@ -4158,7 +4166,7 @@ static BOOL sharedInstanceErrorLogged;
         self.inboxController = [[CTInboxController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy] encryptionLevel:self.config.encryptionLevel previousEncryptionLevel:self.config.cryptManager.previousEncryptionLevel encryptionManager:self.config.cryptManager];
         self.inboxController.delegate = self;
         self.lastInboxRefreshTimestamp = 0;
-        [self _fetchInboxV2WithThrottle:NO completion:nil];
+        self.needsInboxFetchAfterProfileSend = YES;
     }
 }
 

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.h
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addV2MessageIds:(NSArray<NSString *> *)messageIds;
 - (void)removeV2MessageId:(NSString *)messageId;
 - (void)pruneV2MessageIdsNotInSet:(NSSet<NSString *> *)responseIds;
+- (void)deleteAbsentPersistentV2MessagesFromResponseIds:(NSSet<NSString *> *)responseIds;
 
 @end
 

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.h
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.h
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isV2MessageId:(NSString *)messageId;
 - (void)addV2MessageIds:(NSArray<NSString *> *)messageIds;
 - (void)removeV2MessageId:(NSString *)messageId;
-- (void)pruneV2MessageIdsNotInSet:(NSSet<NSString *> *)responseIds;
 - (void)deleteAbsentPersistentV2MessagesFromResponseIds:(NSSet<NSString *> *)responseIds;
 
 @end

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.h
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)deleteMessagesWithId:(NSArray *_Nonnull)messageIds;
 - (void)markReadMessageWithId:(NSString *)messageId;
 - (void)markReadMessagesWithId:(NSArray *_Nonnull)messageIds;
+- (void)performExpiryPurge;
 
 @end
 

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.h
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.h
@@ -37,6 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)markReadMessagesWithId:(NSArray *_Nonnull)messageIds;
 - (void)performExpiryPurge;
 
+- (BOOL)isV2MessageId:(NSString *)messageId;
+- (void)addV2MessageIds:(NSArray<NSString *> *)messageIds;
+- (void)removeV2MessageId:(NSString *)messageId;
+- (void)pruneV2MessageIdsNotInSet:(NSSet<NSString *> *)responseIds;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.m
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.m
@@ -5,6 +5,7 @@
 #import "CTUserMO.h"
 #import "CTMessageMO.h"
 #import "CTInboxUtils.h"
+#import "CTPreferences.h"
 
 
 // Keep the persistent store coordinator static since the inbox file location is shared
@@ -492,6 +493,51 @@ static dispatch_once_t coordinatorOnceToken;
         return [self.encryptionManager isTextAESGCMEncrypted:jsonString];
     }
     return NO;
+}
+
+#pragma mark - V2 Message IDs
+
+- (NSString *)_v2MessageIdsKey {
+    return [NSString stringWithFormat:@"%@%@_%@",
+            CLTAP_INBOX_V2_IDS_KEY_PREFIX, self.accountId, self.guid];
+}
+
+- (BOOL)isV2MessageId:(NSString *)messageId {
+    if (!messageId) return NO;
+    NSArray *stored = [CTPreferences getObjectForKey:[self _v2MessageIdsKey]];
+    return stored ? [stored containsObject:messageId] : NO;
+}
+
+- (void)addV2MessageIds:(NSArray<NSString *> *)messageIds {
+    if (!messageIds.count) return;
+    NSString *key = [self _v2MessageIdsKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key] ?: @[];
+    NSMutableSet *merged = [NSMutableSet setWithArray:existing];
+    [merged addObjectsFromArray:messageIds];
+    [CTPreferences putObject:[merged allObjects] forKey:key];
+}
+
+- (void)removeV2MessageId:(NSString *)messageId {
+    if (!messageId) return;
+    NSString *key = [self _v2MessageIdsKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key];
+    if (!existing) return;
+    NSMutableArray *updated = [existing mutableCopy];
+    [updated removeObject:messageId];
+    [CTPreferences putObject:updated forKey:key];
+}
+
+- (void)pruneV2MessageIdsNotInSet:(NSSet<NSString *> *)responseIds {
+    NSString *key = [self _v2MessageIdsKey];
+    NSArray *existing = [CTPreferences getObjectForKey:key];
+    if (!existing) return;
+    NSMutableArray *updated = [NSMutableArray arrayWithCapacity:existing.count];
+    for (NSString *msgId in existing) {
+        if ([responseIds containsObject:msgId]) {
+            [updated addObject:msgId];
+        }
+    }
+    [CTPreferences putObject:updated forKey:key];
 }
 
 #pragma mark - Delegate Notification

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.m
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.m
@@ -540,6 +540,38 @@ static dispatch_once_t coordinatorOnceToken;
     [CTPreferences putObject:updated forKey:key];
 }
 
+- (void)deleteAbsentPersistentV2MessagesFromResponseIds:(NSSet<NSString *> *)responseIds {
+    NSString *key = [self _v2MessageIdsKey];
+    NSArray *storedIds = [CTPreferences getObjectForKey:key];
+    if (!storedIds || storedIds.count == 0) return;
+
+    NSMutableArray *idsToKeep = [NSMutableArray new];
+    __block NSMutableArray<CTMessageMO *> *msgsToDelete = [NSMutableArray new];
+
+    [self.context performBlockAndWait:^{
+        for (NSString *msgId in storedIds) {
+            if ([responseIds containsObject:msgId]) {
+                [idsToKeep addObject:msgId];
+                continue;
+            }
+            CTMessageMO *msg = [self _messageForId:msgId];
+            if (!msg) continue;
+            if (msg.expires == 0) {
+                // Non-persistent — keep in DB and preferences
+                [idsToKeep addObject:msgId];
+            } else {
+                // Persistent but absent from server — delete
+                [msgsToDelete addObject:msg];
+            }
+        }
+        if (msgsToDelete.count > 0) {
+            [self _deleteMessages:msgsToDelete];
+        }
+    }];
+
+    [CTPreferences putObject:idsToKeep forKey:key];
+}
+
 #pragma mark - Delegate Notification
 
 - (void)_notifyUpdate {

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.m
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.m
@@ -369,6 +369,7 @@ static dispatch_once_t coordinatorOnceToken;
     if (!messages || messages.count == 0) return;
     
     for (CTMessageMO *msg in messages) {
+        [self removeV2MessageId:msg.id];
         [self.context deleteObject:msg];
     }
     
@@ -524,19 +525,6 @@ static dispatch_once_t coordinatorOnceToken;
     if (!existing) return;
     NSMutableArray *updated = [existing mutableCopy];
     [updated removeObject:messageId];
-    [CTPreferences putObject:updated forKey:key];
-}
-
-- (void)pruneV2MessageIdsNotInSet:(NSSet<NSString *> *)responseIds {
-    NSString *key = [self _v2MessageIdsKey];
-    NSArray *existing = [CTPreferences getObjectForKey:key];
-    if (!existing) return;
-    NSMutableArray *updated = [NSMutableArray arrayWithCapacity:existing.count];
-    for (NSString *msgId in existing) {
-        if ([responseIds containsObject:msgId]) {
-            [updated addObject:msgId];
-        }
-    }
     [CTPreferences putObject:updated forKey:key];
 }
 

--- a/CleverTapSDK/Inbox/controllers/CTInboxController.m
+++ b/CleverTapSDK/Inbox/controllers/CTInboxController.m
@@ -375,6 +375,12 @@ static dispatch_once_t coordinatorOnceToken;
     [self _notifyUpdate];
 }
 
+- (void)performExpiryPurge {
+    [self.context performBlock:^{
+        [self _messagesFilteredByPredicate:nil];
+    }];
+}
+
 // Always call from inside context performBlock/performBlockAndWait
 - (NSArray<NSDictionary *> *)_messagesFilteredByPredicate:(NSPredicate *)predicate {
     NSTimeInterval now = (int)[[NSDate date] timeIntervalSince1970];

--- a/CleverTapSDK/Inbox/controllers/CleverTapInboxViewController.m
+++ b/CleverTapSDK/Inbox/controllers/CleverTapInboxViewController.m
@@ -101,6 +101,34 @@ static const int kMaxTags = 3;
     [self addObservers];
     [self registerNibs];
     [self setUpInboxLayout];
+
+    UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
+    [refreshControl addTarget:self
+                       action:@selector(_handlePullToRefresh:)
+             forControlEvents:UIControlEventValueChanged];
+    self.refreshControl = refreshControl;
+}
+
+- (void)_handlePullToRefresh:(UIRefreshControl *)sender {
+    if (![self.analyticsDelegate respondsToSelector:
+            @selector(inboxViewControllerDidRequestRefreshWithCallback:)]) {
+        [sender endRefreshing];
+        return;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    NSTimer *watchdog = [NSTimer scheduledTimerWithTimeInterval:30.0 repeats:NO block:^(NSTimer * _Nonnull t) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.refreshControl endRefreshing];
+        });
+    }];
+
+    [self.analyticsDelegate inboxViewControllerDidRequestRefreshWithCallback:^(BOOL success) {
+        [watchdog invalidate];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.refreshControl endRefreshing];
+        });
+    }];
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/CleverTapSDK/Inbox/controllers/CleverTapInboxViewController.m
+++ b/CleverTapSDK/Inbox/controllers/CleverTapInboxViewController.m
@@ -127,6 +127,17 @@ static const int kMaxTags = 3;
         [watchdog invalidate];
         dispatch_async(dispatch_get_main_queue(), ^{
             [weakSelf.refreshControl endRefreshing];
+            if (success && [weakSelf.analyticsDelegate respondsToSelector:@selector(inboxViewControllerGetMessages)]) {
+                NSArray *updatedMessages = [weakSelf.analyticsDelegate inboxViewControllerGetMessages];
+                weakSelf.messages = updatedMessages;
+                if (weakSelf.selectedSegmentIndex > 0 && weakSelf.selectedSegmentIndex < (int)weakSelf.tags.count) {
+                    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF.tagString CONTAINS[c] %@", weakSelf.tags[weakSelf.selectedSegmentIndex]];
+                    weakSelf.filterMessages = [updatedMessages filteredArrayUsingPredicate:predicate];
+                } else {
+                    weakSelf.filterMessages = updatedMessages;
+                }
+                [weakSelf _reloadTableView];
+            }
         });
     }];
 }

--- a/CleverTapSDK/Inbox/controllers/CleverTapInboxViewController.m
+++ b/CleverTapSDK/Inbox/controllers/CleverTapInboxViewController.m
@@ -102,11 +102,17 @@ static const int kMaxTags = 3;
     [self registerNibs];
     [self setUpInboxLayout];
 
-    UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
-    [refreshControl addTarget:self
-                       action:@selector(_handlePullToRefresh:)
-             forControlEvents:UIControlEventValueChanged];
-    self.refreshControl = refreshControl;
+    BOOL inboxV2Enabled = NO;
+    if ([self.analyticsDelegate respondsToSelector:@selector(inboxViewControllerIsInboxV2Enabled)]) {
+        inboxV2Enabled = [self.analyticsDelegate inboxViewControllerIsInboxV2Enabled];
+    }
+    if (inboxV2Enabled) {
+        UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
+        [refreshControl addTarget:self
+                           action:@selector(_handlePullToRefresh:)
+                 forControlEvents:UIControlEventValueChanged];
+        self.refreshControl = refreshControl;
+    }
 }
 
 - (void)_handlePullToRefresh:(UIRefreshControl *)sender {

--- a/CleverTapSDK/Inbox/controllers/CleverTapInboxViewControllerPrivate.h
+++ b/CleverTapSDK/Inbox/controllers/CleverTapInboxViewControllerPrivate.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import "CleverTap+Inbox.h"
 
 @protocol CleverTapInboxViewControllerDelegate;
 @class CleverTapInboxStyleConfig;
@@ -11,6 +12,12 @@
  Called when app inbox link is tapped for requesting push permission.
  */
 - (void)messageDidSelectForPushPermission:(BOOL)fallbackToSettings;
+@optional
+/**
+ Called when the user pulls to refresh. The callback must always be invoked
+ (throttled or success) so the refresh spinner can be ended.
+ */
+- (void)inboxViewControllerDidRequestRefreshWithCallback:(CleverTapInboxSuccessBlock _Nonnull)callback;
 @end
 
 @interface CleverTapInboxViewController ()

--- a/CleverTapSDK/Inbox/controllers/CleverTapInboxViewControllerPrivate.h
+++ b/CleverTapSDK/Inbox/controllers/CleverTapInboxViewControllerPrivate.h
@@ -18,6 +18,10 @@
  (throttled or success) so the refresh spinner can be ended.
  */
 - (void)inboxViewControllerDidRequestRefreshWithCallback:(CleverTapInboxSuccessBlock _Nonnull)callback;
+/**
+ Returns the current set of inbox messages to display after a refresh.
+ */
+- (NSArray<CleverTapInboxMessage *> * _Nonnull)inboxViewControllerGetMessages;
 @end
 
 @interface CleverTapInboxViewController ()

--- a/CleverTapSDK/Inbox/controllers/CleverTapInboxViewControllerPrivate.h
+++ b/CleverTapSDK/Inbox/controllers/CleverTapInboxViewControllerPrivate.h
@@ -22,6 +22,11 @@
  Returns the current set of inbox messages to display after a refresh.
  */
 - (NSArray<CleverTapInboxMessage *> * _Nonnull)inboxViewControllerGetMessages;
+/**
+ Returns YES if inbox V2 is enabled for this session, NO if disabled (e.g. 403 from server).
+ When NO, pull-to-refresh UI is hidden.
+ */
+- (BOOL)inboxViewControllerIsInboxV2Enabled;
 @end
 
 @interface CleverTapInboxViewController ()

--- a/CleverTapSDK/Inbox/models/CTMessageMO+CoreDataProperties.m
+++ b/CleverTapSDK/Inbox/models/CTMessageMO+CoreDataProperties.m
@@ -46,6 +46,11 @@
         
         NSUInteger expires = [json[@"wzrk_ttl"] longValue];
         self.expires = expires ? expires : 0;
+
+        // Apply backend-provided read state on first insert (V2 response includes isRead).
+        if (json[@"isRead"] != nil) {
+            self.isRead = [json[@"isRead"] boolValue];
+        }
     }
     return self;
 }

--- a/CleverTapSDK/Inbox/models/CTUserMO+CoreDataProperties.m
+++ b/CleverTapSDK/Inbox/models/CTUserMO+CoreDataProperties.m
@@ -108,6 +108,10 @@
             } else {
                 CleverTapLogStaticInternal(@"%@: already have message: %@, updating", self, message);
                 [msg setValue:message forKey:@"json"];
+                // Local read state wins — only promote to read if not already read locally.
+                if (!msg.isRead && [message[@"isRead"] boolValue]) {
+                    msg.isRead = YES;
+                }
                 haveUpdates = YES;
             }
             continue;

--- a/CleverTapSDKTests/CTEventBuilderTest.m
+++ b/CleverTapSDKTests/CTEventBuilderTest.m
@@ -328,8 +328,7 @@
 - (void)test_buildInboxMessageStateEvent_withClickedTrueAndInvalidKey {
     CleverTapInboxMessage *inboxMsg = [[CleverTapInboxMessage alloc] init];
     NSDictionary *queryParam = @{@"key1": @"value1"};
-    
-    [CTEventBuilder buildInboxMessageStateEvent:true forMessage:inboxMsg andQueryParameters:queryParam completionHandler:^(NSDictionary * _Nullable event, NSArray<CTValidationResult *> * _Nullable errors) {
+    [CTEventBuilder buildInboxMessageStateEvent:true forMessage:inboxMsg isV2Message:false andQueryParameters:queryParam completionHandler:^(NSDictionary * _Nullable event, NSArray<CTValidationResult *> * _Nullable errors) {
         XCTAssertNotNil(event);
         XCTAssertEqualObjects(event[@"evtName"], @"Notification Clicked");
         XCTAssertEqual([event[@"evtData"] count], 1);
@@ -340,8 +339,8 @@
 - (void)test_buildInboxMessageStateEvent_withClickedFalseAndInvalidKey {
     CleverTapInboxMessage *inboxMsg = [[CleverTapInboxMessage alloc] init];
     NSDictionary *queryParam = @{@"key1": @"value1"};
-
-    [CTEventBuilder buildInboxMessageStateEvent:false forMessage:inboxMsg andQueryParameters:queryParam completionHandler:^(NSDictionary * _Nullable event, NSArray<CTValidationResult *> * _Nullable errors) {
+    
+    [CTEventBuilder buildInboxMessageStateEvent:false forMessage:inboxMsg isV2Message:false andQueryParameters:queryParam completionHandler:^(NSDictionary * _Nullable event, NSArray<CTValidationResult *> * _Nullable errors) {
         XCTAssertNotNil(event);
         XCTAssertEqualObjects(event[@"evtName"], @"Notification Viewed");
         XCTAssertEqual([event[@"evtData"] count], 1);

--- a/ObjCStarter/ObjCStarter/ViewController.m
+++ b/ObjCStarter/ObjCStarter/ViewController.m
@@ -47,7 +47,8 @@
                       @"Prompt for Push Notification",
                       @"Local Half Interstitial Push Primer",
                       @"Local Alert Push Primer",
-                      @"InApp Campaign Push Primer", nil];
+                      @"InApp Campaign Push Primer",
+                      @"Fetch Inbox", nil];
     [self. tblEvent reloadData];
 }
     
@@ -126,6 +127,9 @@
             break;
         case 14:
             [self createInAppCampaignPushPrimer];
+            break;
+        case 15:
+            [self fetchInbox];
             break;
         default:
             break;
@@ -307,6 +311,12 @@
 
 - (void)createInAppCampaignPushPrimer {
     [[CleverTap sharedInstance] recordEvent:@"InAppCampaignPushPrimer"];
+}
+
+- (void)fetchInbox {
+    [[CleverTap sharedInstance] fetchInboxWithCallback:^(BOOL success) {
+        NSLog(@"Fetch Inbox: %d", success);
+    }];
 }
 
 #pragma mark - CleverTapPushPermissionDelegate

--- a/SwiftStarter/SwiftStarter/ViewController.swift
+++ b/SwiftStarter/SwiftStarter/ViewController.swift
@@ -61,6 +61,7 @@ extension ViewController {
         eventList.append("Native Display")
         eventList.append("Variables")
         eventList.append("Sync Custom Templates")
+        eventList.append("Fetch Inbox")
         self.tblEvent.reloadData()
     }
     
@@ -156,6 +157,9 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate{
         case 20: navigateToVariables()
             break;
         case 21: CleverTap.sharedInstance()?.syncCustomTemplates()
+            break;
+        case 22:
+            fetchInbox()
             break;
         default:
             break;
@@ -346,6 +350,12 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate{
     
     func createInAppCampaignPushPrimer() {
         CleverTap.sharedInstance()?.recordEvent("InAppCampaignPushPrimer")
+    }
+
+    func fetchInbox() {
+        CleverTap.sharedInstance()?.fetchInbox(callback: { success in
+            print("Fetch Inbox: \(success)")
+        })
     }
     
     // MARK: CleverTapPushPermissionDelegate


### PR DESCRIPTION
- Adds new public apis for fetch inbox.
- Adds support for fetch v2 inbox on app launch, api call, pull to refresh and onUserLogin
- Adds support to parse isRead from v2 json and used existing schema for saving it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added pull-to-refresh support to the inbox interface for easy message updates
  * Introduced manual inbox refresh capability with callback notification for better control over message synchronization

* **Bug Fixes**
  * Improved message state handling to properly track read status and deletion state across refresh operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CleverTap/clevertap-ios-sdk/pull/537)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->