### PR TITLE
SDK-5764: [iOS Core SDK] Add CleverTapDisplayUnitCache protocol + setter on CleverTap

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0701E95C2372BA250034AAC2 /* CleverTap+DisplayUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0701E95A2372BA250034AAC2 /* CleverTap+DisplayUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0701E9622372C1950034AAC2 /* CTDisplayUnitController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0701E9602372C1950034AAC2 /* CTDisplayUnitController.h */; };
+		0701E9812372C2000034AAC2 /* CleverTapDisplayUnitCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 0701E9802372C2000034AAC2 /* CleverTapDisplayUnitCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0701E9632372C1950034AAC2 /* CTDisplayUnitController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0701E9612372C1950034AAC2 /* CTDisplayUnitController.m */; };
 		0701E9652372DE9C0034AAC2 /* CleverTapDisplayUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 0701E9642372DE9C0034AAC2 /* CleverTapDisplayUnit.m */; };
 		0701E975237A9A760034AAC2 /* CleverTapDisplayUnitContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 0701E973237A9A760034AAC2 /* CleverTapDisplayUnitContent.m */; };
@@ -625,6 +626,7 @@
 /* Begin PBXFileReference section */
 		0701E95A2372BA250034AAC2 /* CleverTap+DisplayUnit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CleverTap+DisplayUnit.h"; sourceTree = "<group>"; };
 		0701E9602372C1950034AAC2 /* CTDisplayUnitController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTDisplayUnitController.h; sourceTree = "<group>"; };
+		0701E9802372C2000034AAC2 /* CleverTapDisplayUnitCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CleverTapDisplayUnitCache.h; sourceTree = "<group>"; };
 		0701E9612372C1950034AAC2 /* CTDisplayUnitController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTDisplayUnitController.m; sourceTree = "<group>"; };
 		0701E9642372DE9C0034AAC2 /* CleverTapDisplayUnit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CleverTapDisplayUnit.m; sourceTree = "<group>"; };
 		0701E973237A9A760034AAC2 /* CleverTapDisplayUnitContent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CleverTapDisplayUnitContent.m; sourceTree = "<group>"; };
@@ -1136,6 +1138,7 @@
 		0701E9572372AD550034AAC2 /* DisplayUnit */ = {
 			isa = PBXGroup;
 			children = (
+				0701E9802372C2000034AAC2 /* CleverTapDisplayUnitCache.h */,
 				0701E95F2372C0970034AAC2 /* models */,
 				0701E95E2372BC550034AAC2 /* controllers */,
 			);
@@ -2049,6 +2052,7 @@
 				07D8C08B21DDEC54006F5A1B /* CTCarouselImageView.h in Headers */,
 				071EB515217F6427008F0FAB /* CTInterstitialViewController.h in Headers */,
 				0701E9622372C1950034AAC2 /* CTDisplayUnitController.h in Headers */,
+				0701E9812372C2000034AAC2 /* CleverTapDisplayUnitCache.h in Headers */,
 				6BAFFEA82C45243B00654CAF /* CTFileDownloader.h in Headers */,
 				4E7929F929799E8F00B81F3C /* CTDomainFactory.h in Headers */,
 				6A775C3329BE78C7007790E0 /* CTVariables.h in Headers */,

--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		02BFCD20137CFABB41FD2CFE /* CleverTapProductConfigTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 66EFE13AB9558473A73BC740 /* CleverTapProductConfigTest.m */; };
 		0701E95C2372BA250034AAC2 /* CleverTap+DisplayUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0701E95A2372BA250034AAC2 /* CleverTap+DisplayUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0701E9622372C1950034AAC2 /* CTDisplayUnitController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0701E9602372C1950034AAC2 /* CTDisplayUnitController.h */; };
+		0701E9812372C2000034AAC2 /* CleverTapDisplayUnitCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 0701E9802372C2000034AAC2 /* CleverTapDisplayUnitCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0701E9632372C1950034AAC2 /* CTDisplayUnitController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0701E9612372C1950034AAC2 /* CTDisplayUnitController.m */; };
 		0701E9652372DE9C0034AAC2 /* CleverTapDisplayUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = 0701E9642372DE9C0034AAC2 /* CleverTapDisplayUnit.m */; };
 		0701E975237A9A760034AAC2 /* CleverTapDisplayUnitContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 0701E973237A9A760034AAC2 /* CleverTapDisplayUnitContent.m */; };
@@ -783,6 +784,7 @@
 /* Begin PBXFileReference section */
 		0701E95A2372BA250034AAC2 /* CleverTap+DisplayUnit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CleverTap+DisplayUnit.h"; sourceTree = "<group>"; };
 		0701E9602372C1950034AAC2 /* CTDisplayUnitController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CTDisplayUnitController.h; sourceTree = "<group>"; };
+		0701E9802372C2000034AAC2 /* CleverTapDisplayUnitCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CleverTapDisplayUnitCache.h; sourceTree = "<group>"; };
 		0701E9612372C1950034AAC2 /* CTDisplayUnitController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTDisplayUnitController.m; sourceTree = "<group>"; };
 		0701E9642372DE9C0034AAC2 /* CleverTapDisplayUnit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CleverTapDisplayUnit.m; sourceTree = "<group>"; };
 		0701E973237A9A760034AAC2 /* CleverTapDisplayUnitContent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CleverTapDisplayUnitContent.m; sourceTree = "<group>"; };
@@ -1451,6 +1453,7 @@
 		0701E9572372AD550034AAC2 /* DisplayUnit */ = {
 			isa = PBXGroup;
 			children = (
+				0701E9802372C2000034AAC2 /* CleverTapDisplayUnitCache.h */,
 				0701E95F2372C0970034AAC2 /* models */,
 				0701E95E2372BC550034AAC2 /* controllers */,
 			);
@@ -2647,6 +2650,7 @@
 				07D8C08B21DDEC54006F5A1B /* CTCarouselImageView.h in Headers */,
 				071EB515217F6427008F0FAB /* CTInterstitialViewController.h in Headers */,
 				0701E9622372C1950034AAC2 /* CTDisplayUnitController.h in Headers */,
+				0701E9812372C2000034AAC2 /* CleverTapDisplayUnitCache.h in Headers */,
 				6BAFFEA82C45243B00654CAF /* CTFileDownloader.h in Headers */,
 				4E7929F929799E8F00B81F3C /* CTDomainFactory.h in Headers */,
 				6A775C3329BE78C7007790E0 /* CTVariables.h in Headers */,

--- a/CleverTapSDK/CTEventBuilder.m
+++ b/CleverTapSDK/CTEventBuilder.m
@@ -276,6 +276,14 @@ static CTDataValidator *_eventDataValidator;
             id value = data[x];
             notif[key] = value;
         }
+        // Merge caller-supplied params (e.g. `wzrk_element_id` and
+        // `additionalProperties` from the element-aware click selector).
+        // Mirrors the inbox-event path above (~line 361) which already did
+        // this; the display-unit path missed it. Existing callers pass nil
+        // for `params` so they are unaffected.
+        if (params) {
+            [notif addEntriesFromDictionary:params];
+        }
         notif[CLTAP_NOTIFICATION_CLICKED_TAG] = @((long) [[NSDate date] timeIntervalSince1970]);
         event[CLTAP_EVENT_NAME] = clicked ? CLTAP_NOTIFICATION_CLICKED_EVENT_NAME : CLTAP_NOTIFICATION_VIEWED_EVENT_NAME;
         event[CLTAP_EVENT_DATA] = notif;

--- a/CleverTapSDK/CleverTap+DisplayUnit.h
+++ b/CleverTapSDK/CleverTap+DisplayUnit.h
@@ -157,6 +157,36 @@ typedef void (^CleverTapDisplayUnitSuccessBlock)(BOOL success);
 - (void)recordDisplayUnitClickedEventForID:(NSString *_Nonnull)unitID;
 
 /*!
+ @method recordDisplayUnitElementClickedEventForID:elementID:additionalProperties:
+
+ @abstract Element-level click attribution for Native Display units.
+
+ Element-level analog of @c -recordDisplayUnitClickedEventForID: — for Native
+ Display units that host multiple interactive child elements (buttons,
+ images, etc.), this method records which child element was clicked
+ alongside the existing @c wzrk_* campaign attribution.
+
+ The resulting @c "Notification Clicked" event:
+ - Carries the campaign's @c wzrk_* fields from the cached unit JSON (same
+   enrichment as the unit-level method).
+ - Adds @c wzrk_element_id = elementID to the event's @c evtData.
+ - Merges @c additionalProperties into @c evtData after the @c wzrk_*
+   enrichment. Keys in @c additionalProperties starting with @c wzrk_ are
+   stripped defensively — that prefix is reserved for server-controlled
+   attribution fields.
+
+ @param unitID                  the unitID of the Display Unit.
+ @param elementID               identifier of the clicked child element
+                                (from the Native Display config; typically
+                                a button node id).
+ @param additionalProperties    optional per-click context (action url,
+                                custom KVs, …).
+ */
+- (void)recordDisplayUnitElementClickedEventForID:(NSString *_Nonnull)unitID
+                                        elementID:(NSString *_Nonnull)elementID
+                             additionalProperties:(nullable NSDictionary<NSString *, id> *)additionalProperties;
+
+/*!
  @method
 
  @abstract

--- a/CleverTapSDK/CleverTap+DisplayUnit.h
+++ b/CleverTapSDK/CleverTap+DisplayUnit.h
@@ -108,11 +108,14 @@ typedef void (^CleverTapDisplayUnitSuccessBlock)(BOOL success);
 
 /*!
  @method
- 
+
  @abstract
  This method returns all the display units.
+
+ @return all units currently held, or @c nil if no cache has been installed
+ yet or the cache holds no units. Matches the Android contract.
  */
-- (NSArray<CleverTapDisplayUnit *>*_Nonnull)getAllDisplayUnits;
+- (NSArray<CleverTapDisplayUnit *>*_Nullable)getAllDisplayUnits;
 
 /*!
  @method

--- a/CleverTapSDK/CleverTap+DisplayUnit.h
+++ b/CleverTapSDK/CleverTap+DisplayUnit.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "CleverTap.h"
 @class CleverTapDisplayUnitContent;
+@protocol CleverTapDisplayUnitCache;
 
 /*!
  
@@ -147,12 +148,34 @@ typedef void (^CleverTapDisplayUnitSuccessBlock)(BOOL success);
 
 /*!
  @method
- 
+
  @abstract
  Record Notification Clicked for display unit.
- 
+
  @param unitID       unique id of the display unit
  */
 - (void)recordDisplayUnitClickedEventForID:(NSString *_Nonnull)unitID;
+
+/*!
+ @method
+
+ @abstract
+ Replaces the SDK's display-unit cache with the supplied implementation.
+ Pass `nil` to clear the reference (subsequent server responses will lazily
+ install a fresh default cache).
+
+ The new instance receives subsequent `updateDisplayUnits:` calls (e.g. from
+ server responses) and serves all lookup sites: `getAllDisplayUnits`,
+ `getDisplayUnitForID:`, `recordDisplayUnitViewedEventForID:`, and
+ `recordDisplayUnitClickedEventForID:`.
+
+ Implementations must be thread-safe. The display-unit delegate registered
+ via `-setDisplayUnitDelegate:` fires only for server-pipeline activity —
+ replacing the cache or mutating its contents from outside the SDK does not
+ synthesise a delegate fire.
+
+ @since 7.x.0
+ */
+- (void)setDisplayUnitCache:(nullable id<CleverTapDisplayUnitCache>)cache;
 
 @end

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4202,34 +4202,24 @@ static BOOL sharedInstanceErrorLogged;
 
 - (void)initializeDisplayUnitWithCallback:(CleverTapDisplayUnitSuccessBlock)callback {
     [self.dispatchQueueManager runSerialAsync:^{
-        if (self.displayUnitCache) {
+        id<CleverTapDisplayUnitCache> cache = self.displayUnitCache;
+        if (cache) {
             [CTUtils runSyncMainQueue: ^{
-                callback([self _isDisplayUnitCacheInitialized]);
+                callback(YES);
             }];
             return;
         }
         if (self.deviceInfo.deviceId) {
             self.displayUnitCache = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
             [CTUtils runSyncMainQueue: ^{
-                callback([self _isDisplayUnitCacheInitialized]);
+                callback(YES);
             }];
         }
     }];
 }
 
-- (BOOL)_isDisplayUnitCacheInitialized {
-    if ([self.displayUnitCache isKindOfClass:[CTDisplayUnitController class]]) {
-        return ((CTDisplayUnitController *)self.displayUnitCache).isInitialized;
-    }
-    return self.displayUnitCache != nil;
-}
-
 - (void)_resetDisplayUnit {
-    if ([self.displayUnitCache isKindOfClass:[CTDisplayUnitController class]]
-        && ((CTDisplayUnitController *)self.displayUnitCache).isInitialized
-        && self.deviceInfo.deviceId) {
-        self.displayUnitCache = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
-    }
+    [self.displayUnitCache reset];
 }
 
 - (void)_notifyDisplayUnitsUpdated {

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -78,6 +78,7 @@ static NSArray *sslCertNames;
 #if !CLEVERTAP_NO_DISPLAY_UNIT_SUPPORT
 #import "CTDisplayUnitController.h"
 #import "CleverTap+DisplayUnit.h"
+#import "CleverTapDisplayUnitCache.h"
 #endif
 
 #import "CTBatchSentDelegate.h"
@@ -171,8 +172,8 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 @end
 
 #if !CLEVERTAP_NO_DISPLAY_UNIT_SUPPORT
-@interface CleverTap () <CTDisplayUnitDelegate> {}
-@property (nonatomic, strong) CTDisplayUnitController *displayUnitController;
+@interface CleverTap () {}
+@property (nonatomic, strong) id<CleverTapDisplayUnitCache> displayUnitCache;
 @property (atomic, weak) id <CleverTapDisplayUnitDelegate> displayUnitDelegate;
 @end
 #endif
@@ -2463,7 +2464,8 @@ static BOOL sharedInstanceErrorLogged;
             [self initializeDisplayUnitWithCallback:^(BOOL success) {
                 if (success) {
                     NSArray <NSDictionary*> *displayUnits = [displayUnitNotifs mutableCopy];
-                    [self.displayUnitController updateDisplayUnits:displayUnits];
+                    [self.displayUnitCache updateDisplayUnits:displayUnits];
+                    [self _notifyDisplayUnitsUpdated];
                 }
             }];
         }
@@ -4200,26 +4202,39 @@ static BOOL sharedInstanceErrorLogged;
 
 - (void)initializeDisplayUnitWithCallback:(CleverTapDisplayUnitSuccessBlock)callback {
     [self.dispatchQueueManager runSerialAsync:^{
-        if (self.displayUnitController) {
+        if (self.displayUnitCache) {
             [CTUtils runSyncMainQueue: ^{
-                callback(self.displayUnitController.isInitialized);
+                callback([self _isDisplayUnitCacheInitialized]);
             }];
             return;
         }
         if (self.deviceInfo.deviceId) {
-            self.displayUnitController = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
-            self.displayUnitController.delegate = self;
+            self.displayUnitCache = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
             [CTUtils runSyncMainQueue: ^{
-                callback(self.displayUnitController.isInitialized);
+                callback([self _isDisplayUnitCacheInitialized]);
             }];
         }
     }];
 }
 
+- (BOOL)_isDisplayUnitCacheInitialized {
+    if ([self.displayUnitCache isKindOfClass:[CTDisplayUnitController class]]) {
+        return ((CTDisplayUnitController *)self.displayUnitCache).isInitialized;
+    }
+    return self.displayUnitCache != nil;
+}
+
 - (void)_resetDisplayUnit {
-    if (self.displayUnitController && self.displayUnitController.isInitialized && self.deviceInfo.deviceId) {
-        self.displayUnitController = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
-        self.displayUnitController.delegate = self;
+    if ([self.displayUnitCache isKindOfClass:[CTDisplayUnitController class]]
+        && ((CTDisplayUnitController *)self.displayUnitCache).isInitialized
+        && self.deviceInfo.deviceId) {
+        self.displayUnitCache = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
+    }
+}
+
+- (void)_notifyDisplayUnitsUpdated {
+    if (self.displayUnitDelegate && [self.displayUnitDelegate respondsToSelector:@selector(displayUnitsUpdated:)]) {
+        [self.displayUnitDelegate displayUnitsUpdated:[self.displayUnitCache getAllDisplayUnits]];
     }
 }
 
@@ -4237,12 +4252,6 @@ static BOOL sharedInstanceErrorLogged;
 
 - (id<CleverTapDisplayUnitDelegate>)displayUnitDelegate {
     return _displayUnitDelegate;
-}
-
-- (void)displayUnitsDidUpdate {
-    if (self.displayUnitDelegate && [self.displayUnitDelegate respondsToSelector:@selector(displayUnitsUpdated:)]) {
-        [self.displayUnitDelegate displayUnitsUpdated:self.displayUnitController.displayUnits];
-    }
 }
 
 - (BOOL)didHandleDisplayUnitTestFromPushNotificaton:(NSDictionary*)notification {
@@ -4271,7 +4280,8 @@ static BOOL sharedInstanceErrorLogged;
                 @try {
                     [self initializeDisplayUnitWithCallback:^(BOOL success) {
                         if (success) {
-                            [self.displayUnitController updateDisplayUnits:displayUnits];
+                            [self.displayUnitCache updateDisplayUnits:displayUnits];
+                            [self _notifyDisplayUnitsUpdated];
                         }
                     }];
                 } @catch (NSException *e) {
@@ -4296,24 +4306,15 @@ static BOOL sharedInstanceErrorLogged;
 #pragma mark Display Unit Public
 
 - (NSArray<CleverTapDisplayUnit *>*)getAllDisplayUnits {
-    return self.displayUnitController.displayUnits;
+    return [self.displayUnitCache getAllDisplayUnits];
 }
 
 - (CleverTapDisplayUnit *_Nullable)getDisplayUnitForID:(NSString *)unitID {
-    for (CleverTapDisplayUnit *displayUnit in self.displayUnitController.displayUnits) {
-        if ([displayUnit.unitID isEqualToString:unitID]) {
-            @try {
-                return displayUnit;
-            } @catch (NSException *e) {
-                CleverTapLogDebug(_config.logLevel, @"Error getting display unit: %@", e.debugDescription);
-            }
-        }
-    };
-    return nil;
+    return [self.displayUnitCache getDisplayUnitForID:unitID];
 }
 
 - (void)recordDisplayUnitViewedEventForID:(NSString *)unitID {
-    // get the display unit data
+    // get the display unit data via the active cache
     CleverTapDisplayUnit *displayUnit = [self getDisplayUnitForID:unitID];
 #if !defined(CLEVERTAP_TVOS)
     [self.dispatchQueueManager runSerialAsync:^{

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4349,6 +4349,72 @@ static BOOL sharedInstanceErrorLogged;
 #endif
 }
 
+- (void)recordDisplayUnitElementClickedEventForID:(NSString *)unitID
+                                        elementID:(NSString *)elementID
+                             additionalProperties:(NSDictionary *)additionalProperties {
+    CleverTapDisplayUnit *displayUnit = [self getDisplayUnitForID:unitID];
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    if (elementID.length > 0) {
+        params[@"wzrk_element_id"] = elementID;
+    }
+    NSDictionary *sanitized = [self ct_sanitizedDisplayUnitProperties:additionalProperties];
+    if (sanitized) {
+        [params addEntriesFromDictionary:sanitized];
+    }
+#if !defined(CLEVERTAP_TVOS)
+    [self.dispatchQueueManager runSerialAsync:^{
+        [CTEventBuilder buildDisplayViewStateEvent:YES
+                                   forDisplayUnit:displayUnit
+                               andQueryParameters:params
+                                completionHandler:^(NSDictionary *event,
+                                                    NSArray<CTValidationResult*> *errors) {
+            if (event) {
+                self.wzrkParams = [self ct_filteredWzrkFields:event[CLTAP_EVENT_DATA]];
+                [self queueEvent:event withType:CleverTapEventTypeRaised];
+            }
+            if (errors) {
+                [self.validationResultStack pushValidationResults:errors];
+            }
+        }];
+    }];
+#endif
+}
+
+/// Strip @c wzrk_-prefixed keys, @c NSNull, and unsupported types from a
+/// caller-supplied dict. The @c wzrk_ namespace is reserved for server-
+/// controlled attribution fields; this keeps it one-way (server → client).
+- (nullable NSDictionary *)ct_sanitizedDisplayUnitProperties:(nullable NSDictionary *)props {
+    if (props.count == 0) return nil;
+    NSMutableDictionary *out = [NSMutableDictionary dictionaryWithCapacity:props.count];
+    for (NSString *key in props) {
+        if (![key isKindOfClass:[NSString class]] || key.length == 0) continue;
+        if ([CTUtils doesString:key startWith:CLTAP_WZRK_PREFIX]) {
+            CleverTapLogDebug(self.config.logLevel,
+                @"%@: Dropping reserved wzrk_* key from additionalProperties: %@",
+                self, key);
+            continue;
+        }
+        id value = props[key];
+        if (value == nil || value == [NSNull null]) continue;
+        out[key] = value;
+    }
+    return out.count > 0 ? [out copy] : nil;
+}
+
+/// Project only @c wzrk_* fields back out of the merged event data — so the
+/// existing @c wzrkParams contract (used for batch-header attachment as
+/// @c wzrk_ref) is unchanged; caller-supplied non-wzrk extras must not ride
+/// on subsequent batch headers.
+- (NSDictionary *)ct_filteredWzrkFields:(NSDictionary *)merged {
+    NSMutableDictionary *out = [NSMutableDictionary dictionary];
+    for (NSString *k in merged) {
+        if ([CTUtils doesString:k startWith:CLTAP_WZRK_PREFIX]) {
+            out[k] = merged[k];
+        }
+    }
+    return [out copy];
+}
+
 #endif
 
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2448,22 +2448,15 @@ static BOOL sharedInstanceErrorLogged;
 #if !CLEVERTAP_NO_DISPLAY_UNIT_SUPPORT
 - (void)handleDisplayUnitResponse:(id)jsonResp {
     NSArray *displayUnitJSON = jsonResp[CLTAP_DISPLAY_UNIT_JSON_RESPONSE_KEY];
-    if (displayUnitJSON) {
+    if ([displayUnitJSON isKindOfClass:[NSArray class]] && displayUnitJSON.count > 0) {
         if (self.isUserSwitching) {
             CleverTapLogDebug(self.config.logLevel, @"%@: Display Units response will not be handled due to user switch", self);
             return;
         }
-        
-        NSMutableArray *displayUnitNotifs;
-        @try {
-            displayUnitNotifs = [[NSMutableArray alloc] initWithArray:displayUnitJSON];
-        } @catch (NSException *e) {
-            CleverTapLogInternal(self.config.logLevel, @"%@: Error parsing Display Unit JSON: %@", self, e.debugDescription);
-        }
-        if (displayUnitNotifs && [displayUnitNotifs count] > 0) {
+        NSArray<CleverTapDisplayUnit *> *displayUnits = [self _parseDisplayUnitsFromJSONArray:displayUnitJSON];
+        if (displayUnits.count > 0) {
             [self initializeDisplayUnitWithCallback:^(BOOL success) {
                 if (success) {
-                    NSArray <NSDictionary*> *displayUnits = [displayUnitNotifs mutableCopy];
                     [self.displayUnitCache updateDisplayUnits:displayUnits];
                     [self _notifyDisplayUnitsUpdated];
                 }
@@ -4222,6 +4215,18 @@ static BOOL sharedInstanceErrorLogged;
     [self.displayUnitCache reset];
 }
 
+- (NSArray<CleverTapDisplayUnit *> *)_parseDisplayUnitsFromJSONArray:(NSArray *)jsonArray {
+    NSMutableArray<CleverTapDisplayUnit *> *units = [NSMutableArray new];
+    for (id obj in jsonArray) {
+        if (![obj isKindOfClass:[NSDictionary class]]) continue;
+        CleverTapDisplayUnit *unit = [[CleverTapDisplayUnit alloc] initWithJSON:(NSDictionary *)obj];
+        if (unit) {
+            [units addObject:unit];
+        }
+    }
+    return units;
+}
+
 - (void)_notifyDisplayUnitsUpdated {
     if (self.displayUnitDelegate && [self.displayUnitDelegate respondsToSelector:@selector(displayUnitsUpdated:)]) {
         [self.displayUnitDelegate displayUnitsUpdated:[self.displayUnitCache getAllDisplayUnits]];
@@ -4256,15 +4261,16 @@ static BOOL sharedInstanceErrorLogged;
         CleverTapLogDebug(self.config.logLevel, @"%@: Received display unit from push payload: %@", self, notification);
         
         NSString *jsonString = notification[@"wzrk_adunit"];
-        
+
         NSDictionary *displayUnitDict = [NSJSONSerialization JSONObjectWithData:[jsonString dataUsingEncoding:NSUTF8StringEncoding]
                                                                         options:0
                                                                           error:nil];
-        
-        NSMutableArray<NSDictionary*> *displayUnits = [NSMutableArray new];
-        [displayUnits addObject:displayUnitDict];
-        
-        if (displayUnits && displayUnits.count > 0) {
+
+        NSArray<CleverTapDisplayUnit *> *displayUnits = displayUnitDict
+            ? [self _parseDisplayUnitsFromJSONArray:@[displayUnitDict]]
+            : @[];
+
+        if (displayUnits.count > 0) {
             float delay = self.isAppForeground ? 0.5 : 2.0;
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                 @try {

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -74,6 +74,7 @@ static NSArray *sslCertNames;
 #if !CLEVERTAP_NO_DISPLAY_UNIT_SUPPORT
 #import "CTDisplayUnitController.h"
 #import "CleverTap+DisplayUnit.h"
+#import "CleverTapDisplayUnitCache.h"
 #endif
 
 #import "CTBatchSentDelegate.h"
@@ -170,8 +171,8 @@ typedef NS_ENUM(NSInteger, CleverTapPushTokenRegistrationAction) {
 @end
 
 #if !CLEVERTAP_NO_DISPLAY_UNIT_SUPPORT
-@interface CleverTap () <CTDisplayUnitDelegate> {}
-@property (nonatomic, strong) CTDisplayUnitController *displayUnitController;
+@interface CleverTap () {}
+@property (nonatomic, strong) id<CleverTapDisplayUnitCache> displayUnitCache;
 @property (atomic, weak) id <CleverTapDisplayUnitDelegate> displayUnitDelegate;
 @end
 #endif
@@ -2329,7 +2330,8 @@ static BOOL sharedInstanceErrorLogged;
                         [self initializeDisplayUnitWithCallback:^(BOOL success) {
                             if (success) {
                                 NSArray <NSDictionary*> *displayUnits = [displayUnitNotifs mutableCopy];
-                                [self.displayUnitController updateDisplayUnits:displayUnits];
+                                [self.displayUnitCache updateDisplayUnits:displayUnits];
+                                [self _notifyDisplayUnitsUpdated];
                             }
                         }];
                     }
@@ -3858,26 +3860,39 @@ static BOOL sharedInstanceErrorLogged;
 
 - (void)initializeDisplayUnitWithCallback:(CleverTapDisplayUnitSuccessBlock)callback {
     [self.dispatchQueueManager runSerialAsync:^{
-        if (self.displayUnitController) {
+        if (self.displayUnitCache) {
             [CTUtils runSyncMainQueue: ^{
-                callback(self.displayUnitController.isInitialized);
+                callback([self _isDisplayUnitCacheInitialized]);
             }];
             return;
         }
         if (self.deviceInfo.deviceId) {
-            self.displayUnitController = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
-            self.displayUnitController.delegate = self;
+            self.displayUnitCache = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
             [CTUtils runSyncMainQueue: ^{
-                callback(self.displayUnitController.isInitialized);
+                callback([self _isDisplayUnitCacheInitialized]);
             }];
         }
     }];
 }
 
+- (BOOL)_isDisplayUnitCacheInitialized {
+    if ([self.displayUnitCache isKindOfClass:[CTDisplayUnitController class]]) {
+        return ((CTDisplayUnitController *)self.displayUnitCache).isInitialized;
+    }
+    return self.displayUnitCache != nil;
+}
+
 - (void)_resetDisplayUnit {
-    if (self.displayUnitController && self.displayUnitController.isInitialized && self.deviceInfo.deviceId) {
-        self.displayUnitController = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
-        self.displayUnitController.delegate = self;
+    if ([self.displayUnitCache isKindOfClass:[CTDisplayUnitController class]]
+        && ((CTDisplayUnitController *)self.displayUnitCache).isInitialized
+        && self.deviceInfo.deviceId) {
+        self.displayUnitCache = [[CTDisplayUnitController alloc] initWithAccountId: [self.config.accountId copy] guid: [self.deviceInfo.deviceId copy]];
+    }
+}
+
+- (void)_notifyDisplayUnitsUpdated {
+    if (self.displayUnitDelegate && [self.displayUnitDelegate respondsToSelector:@selector(displayUnitsUpdated:)]) {
+        [self.displayUnitDelegate displayUnitsUpdated:[self.displayUnitCache getAllDisplayUnits]];
     }
 }
 
@@ -3895,12 +3910,6 @@ static BOOL sharedInstanceErrorLogged;
 
 - (id<CleverTapDisplayUnitDelegate>)displayUnitDelegate {
     return _displayUnitDelegate;
-}
-
-- (void)displayUnitsDidUpdate {
-    if (self.displayUnitDelegate && [self.displayUnitDelegate respondsToSelector:@selector(displayUnitsUpdated:)]) {
-        [self.displayUnitDelegate displayUnitsUpdated:self.displayUnitController.displayUnits];
-    }
 }
 
 - (BOOL)didHandleDisplayUnitTestFromPushNotificaton:(NSDictionary*)notification {
@@ -3929,7 +3938,8 @@ static BOOL sharedInstanceErrorLogged;
                 @try {
                     [self initializeDisplayUnitWithCallback:^(BOOL success) {
                         if (success) {
-                            [self.displayUnitController updateDisplayUnits:displayUnits];
+                            [self.displayUnitCache updateDisplayUnits:displayUnits];
+                            [self _notifyDisplayUnitsUpdated];
                         }
                     }];
                 } @catch (NSException *e) {
@@ -3954,24 +3964,15 @@ static BOOL sharedInstanceErrorLogged;
 #pragma mark Display Unit Public
 
 - (NSArray<CleverTapDisplayUnit *>*)getAllDisplayUnits {
-    return self.displayUnitController.displayUnits;
+    return [self.displayUnitCache getAllDisplayUnits];
 }
 
 - (CleverTapDisplayUnit *_Nullable)getDisplayUnitForID:(NSString *)unitID {
-    for (CleverTapDisplayUnit *displayUnit in self.displayUnitController.displayUnits) {
-        if ([displayUnit.unitID isEqualToString:unitID]) {
-            @try {
-                return displayUnit;
-            } @catch (NSException *e) {
-                CleverTapLogDebug(_config.logLevel, @"Error getting display unit: %@", e.debugDescription);
-            }
-        }
-    };
-    return nil;
+    return [self.displayUnitCache getDisplayUnitForID:unitID];
 }
 
 - (void)recordDisplayUnitViewedEventForID:(NSString *)unitID {
-    // get the display unit data
+    // get the display unit data via the active cache
     CleverTapDisplayUnit *displayUnit = [self getDisplayUnitForID:unitID];
 #if !defined(CLEVERTAP_TVOS)
     [self.dispatchQueueManager runSerialAsync:^{

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4229,7 +4229,8 @@ static BOOL sharedInstanceErrorLogged;
 
 - (void)_notifyDisplayUnitsUpdated {
     if (self.displayUnitDelegate && [self.displayUnitDelegate respondsToSelector:@selector(displayUnitsUpdated:)]) {
-        [self.displayUnitDelegate displayUnitsUpdated:[self.displayUnitCache getAllDisplayUnits]];
+        // delegate signature is _Nonnull; coalesce a nullable cache result to an empty array.
+        [self.displayUnitDelegate displayUnitsUpdated:[self.displayUnitCache getAllDisplayUnits] ?: @[]];
     }
 }
 

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4303,6 +4303,10 @@ static BOOL sharedInstanceErrorLogged;
 #pragma mark Display Unit Public
 
 - (NSArray<CleverTapDisplayUnit *>*)getAllDisplayUnits {
+    if (!self.displayUnitCache) {
+        CleverTapLogInternal(self.config.logLevel, @"%@: DisplayUnit: Failed to get all Display Units", self);
+        return nil;
+    }
     return [self.displayUnitCache getAllDisplayUnits];
 }
 

--- a/CleverTapSDK/DisplayUnit/CleverTapDisplayUnitCache.h
+++ b/CleverTapSDK/DisplayUnit/CleverTapDisplayUnitCache.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  units. The default implementation replaces the cache contents; hosts may
  choose merge semantics for their own implementations.
  */
-- (void)updateDisplayUnits:(nullable NSArray<NSDictionary *> *)displayUnits;
+- (void)updateDisplayUnits:(nullable NSArray<CleverTapDisplayUnit *> *)displayUnits;
 
 /*! Clears all units. Called by the SDK on logout / reset flows. */
 - (void)reset;

--- a/CleverTapSDK/DisplayUnit/CleverTapDisplayUnitCache.h
+++ b/CleverTapSDK/DisplayUnit/CleverTapDisplayUnitCache.h
@@ -24,8 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol CleverTapDisplayUnitCache <NSObject>
 @required
 
-/*! @return all units currently held; empty array if none. */
-- (NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits;
+/*! @return all units currently held; {@code nil} if none. */
+- (nullable NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits;
 
 /*! @return the unit with the given unitID, or nil if absent. */
 - (nullable CleverTapDisplayUnit *)getDisplayUnitForID:(NSString *)unitID;

--- a/CleverTapSDK/DisplayUnit/CleverTapDisplayUnitCache.h
+++ b/CleverTapSDK/DisplayUnit/CleverTapDisplayUnitCache.h
@@ -1,0 +1,45 @@
+#import <Foundation/Foundation.h>
+
+@class CleverTapDisplayUnit;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ @protocol CleverTapDisplayUnitCache
+
+ In-memory storage contract for `CleverTapDisplayUnit` objects. The default
+ implementation (`CTDisplayUnitController`) is server-pipeline-driven. Hosts
+ may install their own implementation via `-[CleverTap setDisplayUnitCache:]`
+ to expose units produced outside the standard server-response pipeline (for
+ example, server-driven UI SDKs that fetch units through their own pipeline).
+
+ Implementations must be thread-safe — methods may be invoked from any thread.
+
+ The display-unit delegate registered via `-setDisplayUnitDelegate:` only
+ fires for server-pipeline activity. Replacing the cache or mutating its
+ contents from outside the SDK does not synthesise a delegate fire.
+
+ @since 7.x.0
+ */
+@protocol CleverTapDisplayUnitCache <NSObject>
+@required
+
+/*! @return all units currently held; empty array if none. */
+- (NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits;
+
+/*! @return the unit with the given unitID, or nil if absent. */
+- (nullable CleverTapDisplayUnit *)getDisplayUnitForID:(NSString *)unitID;
+
+/*!
+ Called by the SDK when a server response delivers an updated set of display
+ units. The default implementation replaces the cache contents; hosts may
+ choose merge semantics for their own implementations.
+ */
+- (void)updateDisplayUnits:(nullable NSArray<NSDictionary *> *)displayUnits;
+
+/*! Clears all units. Called by the SDK on logout / reset flows. */
+- (void)reset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.h
+++ b/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.h
@@ -1,25 +1,30 @@
 #import <Foundation/Foundation.h>
 #import "CleverTap+DisplayUnit.h"
+#import "CleverTapDisplayUnitCache.h"
 
-@protocol CTDisplayUnitDelegate <NSObject>
-@required
-- (void)displayUnitsDidUpdate;
-@end
+NS_ASSUME_NONNULL_BEGIN
 
-@interface CTDisplayUnitController : NSObject
+/*!
+ Default `CleverTapDisplayUnitCache` implementation, populated by the SDK's
+ server-response pipeline.
+ */
+@interface CTDisplayUnitController : NSObject <CleverTapDisplayUnitCache>
 
 @property (nonatomic, assign, readonly) BOOL isInitialized;
-@property (nonatomic, copy, readonly) NSArray <CleverTapDisplayUnit *> * _Nullable displayUnits;
+@property (nonatomic, copy, readonly, nullable) NSArray<CleverTapDisplayUnit *> *displayUnits;
 
-@property (nonatomic, weak) id<CTDisplayUnitDelegate> _Nullable delegate;
-
-- (instancetype _Nullable ) init __unavailable;
+- (instancetype)init __unavailable;
 
 // blocking, call off main thread
-- (instancetype _Nullable)initWithAccountId:(NSString *_Nonnull)accountId
-                                       guid:(NSString *_Nonnull)guid;
+- (nullable instancetype)initWithAccountId:(NSString *)accountId
+                                      guid:(NSString *)guid;
 
-- (void)updateDisplayUnits:(NSArray<NSDictionary*> *_Nullable)displayUnits;
+// CleverTapDisplayUnitCache
+- (NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits;
+- (nullable CleverTapDisplayUnit *)getDisplayUnitForID:(NSString *)unitID;
+- (void)updateDisplayUnits:(nullable NSArray<NSDictionary *> *)displayUnits;
+- (void)reset;
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.h
+++ b/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
                                       guid:(NSString *)guid;
 
 // CleverTapDisplayUnitCache
-- (NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits;
+- (nullable NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits;
 - (nullable CleverTapDisplayUnit *)getDisplayUnitForID:(NSString *)unitID;
 - (void)updateDisplayUnits:(nullable NSArray<CleverTapDisplayUnit *> *)displayUnits;
 - (void)reset;

--- a/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.h
+++ b/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 // CleverTapDisplayUnitCache
 - (NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits;
 - (nullable CleverTapDisplayUnit *)getDisplayUnitForID:(NSString *)unitID;
-- (void)updateDisplayUnits:(nullable NSArray<NSDictionary *> *)displayUnits;
+- (void)updateDisplayUnits:(nullable NSArray<CleverTapDisplayUnit *> *)displayUnits;
 - (void)reset;
 
 @end

--- a/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.m
+++ b/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.m
@@ -2,7 +2,7 @@
 #import "CTPreferences.h"
 
 @interface CTDisplayUnitController() {
-    
+
 }
 
 @property (nonatomic, copy, readonly) NSString *accountId;
@@ -24,8 +24,29 @@
     return self;
 }
 
+#pragma mark - CleverTapDisplayUnitCache
+
+- (NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits {
+    NSArray *units = self.displayUnits;
+    return units ?: @[];
+}
+
+- (CleverTapDisplayUnit *)getDisplayUnitForID:(NSString *)unitID {
+    if (unitID.length == 0) return nil;
+    for (CleverTapDisplayUnit *displayUnit in self.displayUnits) {
+        if ([displayUnit.unitID isEqualToString:unitID]) {
+            return displayUnit;
+        }
+    }
+    return nil;
+}
+
 - (void)updateDisplayUnits:(NSArray<NSDictionary *> *)displayUnits {
     [self _updateDisplayUnits:displayUnits];
+}
+
+- (void)reset {
+    _displayUnits = nil;
 }
 
 // be sure to call off the main thread
@@ -37,18 +58,11 @@
         [units addObject:displayUnit];
     }
     _displayUnits = units;
-    [self notifyUpdate];
 }
 
 - (NSArray *)displayUnits {
     if (!self.isInitialized) return nil;
     return _displayUnits;
-}
-
-- (void)notifyUpdate {
-    if (self.delegate && [self.delegate respondsToSelector:@selector(displayUnitsDidUpdate)]) {
-        [self.delegate displayUnitsDidUpdate];
-    }
 }
 
 @end

--- a/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.m
+++ b/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.m
@@ -27,26 +27,34 @@
 #pragma mark - CleverTapDisplayUnitCache
 
 - (NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits {
-    NSArray *units = self.displayUnits;
-    return units ?: @[];
+    @synchronized (self) {
+        NSArray *units = self.displayUnits;
+        return units.count > 0 ? units : nil;
+    }
 }
 
 - (CleverTapDisplayUnit *)getDisplayUnitForID:(NSString *)unitID {
     if (unitID.length == 0) return nil;
-    for (CleverTapDisplayUnit *displayUnit in self.displayUnits) {
-        if ([displayUnit.unitID isEqualToString:unitID]) {
-            return displayUnit;
+    @synchronized (self) {
+        for (CleverTapDisplayUnit *displayUnit in self.displayUnits) {
+            if ([displayUnit.unitID isEqualToString:unitID]) {
+                return displayUnit;
+            }
         }
     }
     return nil;
 }
 
 - (void)updateDisplayUnits:(NSArray<CleverTapDisplayUnit *> *)displayUnits {
-    _displayUnits = [displayUnits copy];
+    @synchronized (self) {
+        _displayUnits = [displayUnits copy];
+    }
 }
 
 - (void)reset {
-    _displayUnits = nil;
+    @synchronized (self) {
+        _displayUnits = nil;
+    }
 }
 
 - (NSArray *)displayUnits {

--- a/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.m
+++ b/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.m
@@ -1,4 +1,5 @@
 #import "CTDisplayUnitController.h"
+#import "CTConstants.h"
 #import "CTPreferences.h"
 
 @interface CTDisplayUnitController() {
@@ -29,7 +30,11 @@
 - (NSArray<CleverTapDisplayUnit *> *)getAllDisplayUnits {
     @synchronized (self) {
         NSArray *units = self.displayUnits;
-        return units.count > 0 ? units : nil;
+        if (units.count == 0) {
+            CleverTapLogStaticDebug(@"DisplayUnit: Failed to return Display Units, nothing found in the cache");
+            return nil;
+        }
+        return units;
     }
 }
 

--- a/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.m
+++ b/CleverTapSDK/DisplayUnit/controllers/CTDisplayUnitController.m
@@ -41,23 +41,12 @@
     return nil;
 }
 
-- (void)updateDisplayUnits:(NSArray<NSDictionary *> *)displayUnits {
-    [self _updateDisplayUnits:displayUnits];
+- (void)updateDisplayUnits:(NSArray<CleverTapDisplayUnit *> *)displayUnits {
+    _displayUnits = [displayUnits copy];
 }
 
 - (void)reset {
     _displayUnits = nil;
-}
-
-// be sure to call off the main thread
-- (void)_updateDisplayUnits:(NSArray<NSDictionary*> *)displayUnits {
-    NSMutableArray *units = [NSMutableArray new];
-    NSMutableArray *tempArray = [displayUnits mutableCopy];
-    for (NSDictionary *obj in tempArray) {
-        CleverTapDisplayUnit *displayUnit = [[CleverTapDisplayUnit alloc] initWithJSON:obj];
-        [units addObject:displayUnit];
-    }
-    _displayUnits = units;
 }
 
 - (NSArray *)displayUnits {

--- a/CleverTapSDKTests/CTEventBuilderTest.m
+++ b/CleverTapSDKTests/CTEventBuilderTest.m
@@ -11,6 +11,8 @@
 #import "CTValidationConfig.h"
 #import "CTEventNameValidator.h"
 #import "CTInAppNotification.h"
+#import "CleverTap+DisplayUnit.h"
+#import "CTConstants.h"
 
 @interface CTEventBuilderTest : XCTestCase
 @end
@@ -448,6 +450,74 @@
         }
         XCTAssertTrue(found524);
     }];
+}
+
+#pragma mark - Display Unit element-click params merging
+
+/// Verifies the bug fix in `buildDisplayViewStateEvent:`: the `params` argument
+/// is now merged into `notif` alongside the wzrk_* fields extracted from the
+/// cached unit JSON. Required for `-recordDisplayUnitElementClickedEventForID:`
+/// to deliver `wzrk_element_id` and `additionalProperties` to the event.
+- (void)testBuildDisplayViewStateEvent_mergesParamsAlongsideWzrkFields {
+    NSDictionary *unitJson = @{
+        @"wzrk_id": @"1234",
+        @"wzrk_pivot": @"wzrk_default"
+    };
+    CleverTapDisplayUnit *displayUnit = [[CleverTapDisplayUnit alloc] initWithJSON:unitJson];
+    NSDictionary *params = @{
+        @"wzrk_element_id": @"button-1",
+        @"action_type": @"open_url",
+        @"action_url": @"https://example.com"
+    };
+
+    XCTestExpectation *exp = [self expectationWithDescription:@"build"];
+    __block NSDictionary *captured = nil;
+    [CTEventBuilder buildDisplayViewStateEvent:YES
+                                forDisplayUnit:displayUnit
+                            andQueryParameters:params
+                             completionHandler:^(NSDictionary *event,
+                                                 NSArray<CTValidationResult *> *errors) {
+        captured = event;
+        [exp fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+
+    XCTAssertEqualObjects(captured[CLTAP_EVENT_NAME], CLTAP_NOTIFICATION_CLICKED_EVENT_NAME);
+    NSDictionary *evtData = captured[CLTAP_EVENT_DATA];
+    // wzrk_* extraction from cached unit JSON preserved.
+    XCTAssertEqualObjects(evtData[@"wzrk_id"], @"1234");
+    XCTAssertEqualObjects(evtData[@"wzrk_pivot"], @"wzrk_default");
+    // params merged in (the bug fix).
+    XCTAssertEqualObjects(evtData[@"wzrk_element_id"], @"button-1");
+    XCTAssertEqualObjects(evtData[@"action_type"], @"open_url");
+    XCTAssertEqualObjects(evtData[@"action_url"], @"https://example.com");
+    // Timestamp tag still set.
+    XCTAssertNotNil(evtData[CLTAP_NOTIFICATION_CLICKED_TAG]);
+}
+
+/// Regression guard: the existing single-arg
+/// `-recordDisplayUnitClickedEventForID:` passes `nil` for `params`.
+/// The bug fix must not regress that path — only wzrk_* fields appear on the
+/// event, no spurious entries leak from the new merge step.
+- (void)testBuildDisplayViewStateEvent_nilParamsBehavesAsBefore {
+    NSDictionary *unitJson = @{ @"wzrk_id": @"x" };
+    CleverTapDisplayUnit *displayUnit = [[CleverTapDisplayUnit alloc] initWithJSON:unitJson];
+
+    XCTestExpectation *exp = [self expectationWithDescription:@"build"];
+    __block NSDictionary *captured = nil;
+    [CTEventBuilder buildDisplayViewStateEvent:YES
+                                forDisplayUnit:displayUnit
+                            andQueryParameters:nil
+                             completionHandler:^(NSDictionary *event,
+                                                 NSArray<CTValidationResult *> *errors) {
+        captured = event;
+        [exp fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+
+    NSDictionary *evtData = captured[CLTAP_EVENT_DATA];
+    XCTAssertEqualObjects(evtData[@"wzrk_id"], @"x");
+    XCTAssertNil(evtData[@"wzrk_element_id"]);
 }
 
 @end


### PR DESCRIPTION
## Jira

[SDK-5764](https://wizrocket.atlassian.net/browse/SDK-5764) — child of epic [SDK-5256](https://wizrocket.atlassian.net/browse/SDK-5256) (Native Display v2).
Companion PRs: Android Core SDK [SDK-5763](https://wizrocket.atlassian.net/browse/SDK-5763) and Native Display SDK [SDK-5765](https://wizrocket.atlassian.net/browse/SDK-5765).

## Summary

Extracts `CTDisplayUnitController`'s public surface into a new `CleverTapDisplayUnitCache` protocol and exposes `-[CleverTap setDisplayUnitCache:]` so external SDKs (Native Display) can install their own cache implementation.

**Why:** ND SDK's manual JSON mode feeds units the Core SDK never received from its server pipeline, so `recordDisplayUnit*EventForID:`'s mandatory `getDisplayUnitForID:` lookup misses and analytics are unattributed. `recordEvent:` with `Notification Viewed` / `Notification Clicked` is rejected by `CTValidator.m:231–244` (error 513). Letting ND SDK plug its own cache implementation lets attribution events resolve through the bridge's existing cache.

## Changes

| File | Change |
|---|---|
| `DisplayUnit/CleverTapDisplayUnitCache.h` | **new** public `@protocol` (`getAllDisplayUnits`, `getDisplayUnitForID:`, `updateDisplayUnits:`, `reset`) |
| `DisplayUnit/controllers/CTDisplayUnitController.h/.m` | conforms to protocol; adds `getAllDisplayUnits`, `getDisplayUnitForID:`, `reset` |
| `CleverTap+DisplayUnit.h` | new public `-setDisplayUnitCache:` |
| `CleverTap.m` | `displayUnitController` property replaced by `displayUnitCache: id<CleverTapDisplayUnitCache>`. `-getDisplayUnitForID:` and `-getAllDisplayUnits` delegate via the cache. Internal `CTDisplayUnitDelegate` plumbing removed; public `CleverTapDisplayUnitDelegate` fire hoisted into `_notifyDisplayUnitsUpdated` called from server-response handler and `wzrk_adunit` test path |
| `CleverTapSDK.xcodeproj` | registers `CleverTapDisplayUnitCache.h` as Public header |

## Backwards compatibility

- Hosts that don't call the new setter: identical behaviour. The default `CTDisplayUnitController` is lazy-installed in `initializeDisplayUnitWithCallback:` on first `adUnit_notifs` response (same lazy-init point as before, just routed via the new property type).
- `CleverTapDisplayUnitDelegate` (`displayUnitsUpdated:`) continues to fire only for server-pipeline activity.
- `wzrk_adunit` test-push path preserved.

## Test plan

- [x] `xcodebuild -sdk iphoneos` builds clean (device target)
- [ ] Reviewer: simulator linker error is a pre-existing SDWebImage architecture mismatch (reproduces on `develop`), unrelated
- [ ] Reviewer: confirm a host that ignores the new setter sees no behaviour change
- [ ] Reviewer: validate header docs on new public types read cleanly

[SDK-5764]: https://wizrocket.atlassian.net/browse/SDK-5764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-5256]: https://wizrocket.atlassian.net/browse/SDK-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-5763]: https://wizrocket.atlassian.net/browse/SDK-5763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-5765]: https://wizrocket.atlassian.net/browse/SDK-5765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `setDisplayUnitCache:` method to the CleverTap API for custom display unit cache implementations.
  * Introduced `CleverTapDisplayUnitCache` protocol with required methods for retrieving, updating, and managing cached display units.

* **Improvements**
  * Enhanced internal display unit management with a cache-based architecture for improved performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CleverTap/clevertap-ios-sdk/pull/538)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->