### PR TITLE
fix(SDK-5787): anchor CS in-app TTL in store after evaluation

### DIFF
--- a/CleverTapSDK/InApps/CTInAppEvaluationManager.m
+++ b/CleverTapSDK/InApps/CTInAppEvaluationManager.m
@@ -222,10 +222,14 @@
     }];
     //Strategy-specific TTL update (only if context allows)
     if(shouldUpdateTTLForThisContext && [strategy shouldUpdateTTL]) {
+        NSMutableArray *updatedInApps = [NSMutableArray arrayWithCapacity:selectedInApps.count];
         for (NSDictionary *inApp in selectedInApps) {
-            NSMutableDictionary  *mutableInApp = [inApp mutableCopy];
+            NSMutableDictionary *mutableInApp = [inApp mutableCopy];
             [self.inAppStore updateTTL:mutableInApp];
+            [updatedInApps addObject:mutableInApp];
         }
+        [self.inAppStore storeClientSideInApps:updatedInApps];
+        return updatedInApps;
     }
     return selectedInApps;
 }


### PR DESCRIPTION
## Problem
CS in-app TTL was being set on a `mutableCopy` in `CTInAppEvaluationManager.m`but the copy was never written back to the store. This caused TTL to reset to `now + offset` on every evaluation — stopped campaigns kept showing indefinitely.