### PR TITLE
SDK-5764: add missing setDisplayUnitCache: implementation

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -4314,6 +4314,10 @@ static BOOL sharedInstanceErrorLogged;
     return [self.displayUnitCache getDisplayUnitForID:unitID];
 }
 
+- (void)setDisplayUnitCache:(nullable id<CleverTapDisplayUnitCache>)cache {
+    _displayUnitCache = cache;
+}
+
 - (void)recordDisplayUnitViewedEventForID:(NSString *)unitID {
     // get the display unit data via the active cache
     CleverTapDisplayUnit *displayUnit = [self getDisplayUnitForID:unitID];


### PR DESCRIPTION
## Why it was missed

PR #547 introduced the `CleverTapDisplayUnitCache` protocol and declared the public setter `-[CleverTap setDisplayUnitCache:]` in `CleverTap+DisplayUnit.h`. The private class extension in `CleverTap.m` already held `@property (nonatomic, strong) id<CleverTapDisplayUnitCache> displayUnitCache`, so the compiler's auto-synthesis silently provided a `setDisplayUnitCache:` method at runtime — the declaration compiled and linked without error. That implicit coverage masked the gap: no explicit method body was ever written, leaving no audit trail, no direct-ivar semantics, and no place to add future logic (logging, thread safety, reset-on-nil, etc.).

On **Android**, the equivalent setter is an explicit public method on `CleverTapAPI` — the same contract was expected here.

## What this PR adds

A single explicit implementation in `CleverTap.m` (4 lines):

```objc
- (void)setDisplayUnitCache:(nullable id<CleverTapDisplayUnitCache>)cache {
    _displayUnitCache = cache;
}
```

- Uses `_displayUnitCache` directly (ivar access) rather than `self.displayUnitCache =` to make the intent unambiguous and future-proof against any property observer additions.
- Handles `nil` per the documented contract: clearing the reference causes the next server response to lazily install a fresh `CTDisplayUnitController`.
- Replaces the implicit auto-synthesized setter with a visible, reviewable implementation — matching parity with the Android `CleverTapAPI` setter.

## Test plan
- [ ] Existing display-unit unit tests pass (`CTEventBuilderTest`)
- [ ] Calling `[cleverTap setDisplayUnitCache:myCache]` routes `getAllDisplayUnits` / `getDisplayUnitForID:` through the custom cache
- [ ] Calling `[cleverTap setDisplayUnitCache:nil]` clears the cache; the next server response re-installs a default `CTDisplayUnitController`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method to explicitly set the display unit cache configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CleverTap/clevertap-ios-sdk/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->