### PR TITLE
[SDK-5842] Silent in foreground push support

### DIFF
--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -153,6 +153,7 @@ static const NSTimeInterval kCTInboxRefreshMinInterval = 300.0;
 #define CLTAP_WZRK_PREFIX @"wzrk_"
 #define CLTAP_NOTIFICATION_TAG_SECONDARY @"wzrk_"
 #define CLTAP_NOTIFICATION_CLICKED_TAG @"wzrk_cts"
+#define CLTAP_NOTIFICATION_SILENT_IN_FOREGROUND @"wzrk_sif"
 #define CLTAP_NOTIFICATION_TAG @"W$"
 #define CLTAP_DATE_FORMAT @"yyyyMMdd"
 #define CLTAP_DATE_PREFIX @"$D_"

--- a/CleverTapSDK/CleverTap.h
+++ b/CleverTapSDK/CleverTap.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <CoreLocation/CoreLocation.h>
+#import <UserNotifications/UserNotifications.h>
 
 #if !TARGET_OS_TV
 #import <WatchConnectivity/WatchConnectivity.h>
@@ -1220,7 +1221,30 @@ extern NSString * _Nonnull const CleverTapProfileDidInitializeNotification;
 
 /*!
  @method
- 
+
+ @abstract
+ Handle a UNNotification in the foreground to support silent-in-foreground behaviour.
+
+ @discussion
+ Call this from your UNUserNotificationCenterDelegate willPresent implementation when using
+ manual SDK integration (i.e. without autoIntegrate). If the notification payload contains
+ wzrk_sif=1, the completionHandler is called with empty presentation options (no banner/sound/badge).
+ Otherwise it is called with the provided defaultOptions.
+ Non-CleverTap notifications are passed through unchanged using defaultOptions.
+ This method also records the Notification Viewed event for CleverTap notifications.
+
+ @param notification      The UNNotification received in willPresent
+ @param defaultOptions    Presentation options to use when wzrk_sif is not set
+ @param completionHandler The completion handler from willPresent
+ */
++ (void)handleWillPresentNotification:(UNNotification *_Nonnull)notification
+                   withDefaultOptions:(UNNotificationPresentationOptions)defaultOptions
+                    completionHandler:(void (^_Nonnull)(UNNotificationPresentationOptions))completionHandler
+    API_AVAILABLE(ios(10.0));
+
+/*!
+ @method
+
  @abstract
  Determine whether a notification originated from CleverTap
  

--- a/CleverTapSDK/CleverTap.h
+++ b/CleverTapSDK/CleverTap.h
@@ -1228,10 +1228,11 @@ extern NSString * _Nonnull const CleverTapProfileDidInitializeNotification;
  @discussion
  Call this from your UNUserNotificationCenterDelegate willPresent implementation when using
  manual SDK integration (i.e. without autoIntegrate). If the notification payload contains
- wzrk_sif=1, the completionHandler is called with empty presentation options (no banner/sound/badge).
- Otherwise it is called with the provided defaultOptions.
+ wzrk_sif=1, the banner, sound, and badge are suppressed. On iOS 14 and later the notification
+ is still delivered to Notification Center only (UNNotificationPresentationOptionList); on
+ earlier versions it is suppressed entirely (UNNotificationPresentationOptionNone).
+ Otherwise the completionHandler is called with the provided defaultOptions.
  Non-CleverTap notifications are passed through unchanged using defaultOptions.
- This method also records the Notification Viewed event for CleverTap notifications.
 
  @param notification      The UNNotification received in willPresent
  @param defaultOptions    Presentation options to use when wzrk_sif is not set

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2978,7 +2978,15 @@ static BOOL sharedInstanceErrorLogged;
         }
         [self recordNotificationViewedEventWithData:userInfo];
         BOOL silentInForeground = [userInfo[CLTAP_NOTIFICATION_SILENT_IN_FOREGROUND] boolValue];
-        completionHandler(silentInForeground ? UNNotificationPresentationOptionNone : defaultOptions);
+        if (silentInForeground) {
+            if (@available(iOS 14.0, *)) {
+                completionHandler(UNNotificationPresentationOptionList);
+            } else {
+                completionHandler(UNNotificationPresentationOptionNone);
+            }
+        } else {
+            completionHandler(defaultOptions);
+        }
     } else {
         completionHandler(defaultOptions);
     }

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2976,7 +2976,6 @@ static BOOL sharedInstanceErrorLogged;
             completionHandler(defaultOptions);
             return;
         }
-        [self recordNotificationViewedEventWithData:userInfo];
         BOOL silentInForeground = [userInfo[CLTAP_NOTIFICATION_SILENT_IN_FOREGROUND] boolValue];
         if (silentInForeground) {
             if (@available(iOS 14.0, *)) {
@@ -3002,17 +3001,23 @@ static BOOL sharedInstanceErrorLogged;
         }
         NSDictionary *userInfo = notification.request.content.userInfo;
         NSString *accountId = (NSString *)userInfo[@"wzrk_acct_id"];
+
+        CleverTap *targetInstance = nil;
         if (!_instances || [_instances count] <= 0 || !accountId) {
-            [[self sharedInstance] _handleWillPresentNotification:notification withDefaultOptions:defaultOptions completionHandler:completionHandler];
-            return;
-        }
-        for (CleverTap *instance in [_instances allValues]) {
-            if ([accountId isEqualToString:instance.config.accountId]) {
-                [instance _handleWillPresentNotification:notification withDefaultOptions:defaultOptions completionHandler:completionHandler];
-                return;
+            targetInstance = [self sharedInstance];
+        } else {
+            for (CleverTap *instance in [_instances allValues]) {
+                if ([accountId isEqualToString:instance.config.accountId]) {
+                    targetInstance = instance;
+                    break;
+                }
             }
         }
-        [[self sharedInstance] _handleWillPresentNotification:notification withDefaultOptions:defaultOptions completionHandler:completionHandler];
+        if (!targetInstance) {
+            completionHandler(defaultOptions);
+            return;
+        }
+        [targetInstance _handleWillPresentNotification:notification withDefaultOptions:defaultOptions completionHandler:completionHandler];
     } else {
         completionHandler(defaultOptions);
     }

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -389,6 +389,7 @@ static BOOL sharedInstanceErrorLogged;
                     } error:nil];
                 }
             }
+            [CTSwizzleManager swizzleWillPresentOnClass:cls];
         }
     }
 #endif
@@ -2959,6 +2960,56 @@ static BOOL sharedInstanceErrorLogged;
         }
     }
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+- (void)_handleWillPresentNotification:(UNNotification *)notification
+                    withDefaultOptions:(UNNotificationPresentationOptions)defaultOptions
+                     completionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    if (@available(iOS 10.0, *)) {
+        if ([CTUIUtils runningInsideAppExtension]) {
+            completionHandler(defaultOptions);
+            return;
+        }
+        NSDictionary *userInfo = notification.request.content.userInfo;
+        if (![self _isCTPushNotification:userInfo]) {
+            completionHandler(defaultOptions);
+            return;
+        }
+        [self recordNotificationViewedEventWithData:userInfo];
+        BOOL silentInForeground = [userInfo[CLTAP_NOTIFICATION_SILENT_IN_FOREGROUND] boolValue];
+        completionHandler(silentInForeground ? UNNotificationPresentationOptionNone : defaultOptions);
+    } else {
+        completionHandler(defaultOptions);
+    }
+}
+
++ (void)handleWillPresentNotification:(UNNotification *)notification
+                   withDefaultOptions:(UNNotificationPresentationOptions)defaultOptions
+                    completionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    if (@available(iOS 10.0, *)) {
+        if ([CTUIUtils runningInsideAppExtension]) {
+            completionHandler(defaultOptions);
+            return;
+        }
+        NSDictionary *userInfo = notification.request.content.userInfo;
+        NSString *accountId = (NSString *)userInfo[@"wzrk_acct_id"];
+        if (!_instances || [_instances count] <= 0 || !accountId) {
+            [[self sharedInstance] _handleWillPresentNotification:notification withDefaultOptions:defaultOptions completionHandler:completionHandler];
+            return;
+        }
+        for (CleverTap *instance in [_instances allValues]) {
+            if ([accountId isEqualToString:instance.config.accountId]) {
+                [instance _handleWillPresentNotification:notification withDefaultOptions:defaultOptions completionHandler:completionHandler];
+                return;
+            }
+        }
+        [[self sharedInstance] _handleWillPresentNotification:notification withDefaultOptions:defaultOptions completionHandler:completionHandler];
+    } else {
+        completionHandler(defaultOptions);
+    }
+}
+#pragma clang diagnostic pop
 
 + (void)handleOpenURL:(NSURL*)url {
     if ([CTUIUtils runningInsideAppExtension]){

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -3000,7 +3000,8 @@ static BOOL sharedInstanceErrorLogged;
             return;
         }
         NSDictionary *userInfo = notification.request.content.userInfo;
-        NSString *accountId = (NSString *)userInfo[@"wzrk_acct_id"];
+        id rawAccountId = userInfo[@"wzrk_acct_id"];
+        NSString *accountId = [rawAccountId isKindOfClass:[NSString class]] ? rawAccountId : nil;
 
         CleverTap *targetInstance = nil;
         if (!_instances || [_instances count] <= 0 || !accountId) {

--- a/CleverTapSDK/Swizzling/CTSwizzleManager.h
+++ b/CleverTapSDK/Swizzling/CTSwizzleManager.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CTSwizzleManager : NSObject
 + (void)swizzleAppDelegate;
++ (void)swizzleWillPresentOnClass:(Class)cls;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/Swizzling/CTSwizzleManager.m
+++ b/CleverTapSDK/Swizzling/CTSwizzleManager.m
@@ -69,16 +69,19 @@
             Class ncdCls = [[UNUserNotificationCenter currentNotificationCenter].delegate class];
             if ([UNUserNotificationCenter class] && !ncdCls) {
                 [[UNUserNotificationCenter currentNotificationCenter] addObserver:[CleverTap sharedInstance] forKeyPath:@"delegate" options:0 context:nil];
-            } else if (class_getInstanceMethod(ncdCls, NSSelectorFromString(@"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"))) {
-                sel = NSSelectorFromString(@"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:");
-                __block NSInvocation *invocation = nil;
-                invocation = [ncdCls ct_swizzleMethod:sel withBlock:^(id obj, UNUserNotificationCenter *center, UNNotificationResponse *response, void (^completion)(void) ) {
-                    [CleverTap handlePushNotification:response.notification.request.content.userInfo openDeepLinksInForeground:YES];
-                    [invocation setArgument:&center atIndex:2];
-                    [invocation setArgument:&response atIndex:3];
-                    [invocation setArgument:&completion atIndex:4];
-                    [invocation invokeWithTarget:obj];
-                } error:nil];
+            } else {
+                if (class_getInstanceMethod(ncdCls, NSSelectorFromString(@"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"))) {
+                    sel = NSSelectorFromString(@"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:");
+                    __block NSInvocation *invocation = nil;
+                    invocation = [ncdCls ct_swizzleMethod:sel withBlock:^(id obj, UNUserNotificationCenter *center, UNNotificationResponse *response, void (^completion)(void) ) {
+                        [CleverTap handlePushNotification:response.notification.request.content.userInfo openDeepLinksInForeground:YES];
+                        [invocation setArgument:&center atIndex:2];
+                        [invocation setArgument:&response atIndex:3];
+                        [invocation setArgument:&completion atIndex:4];
+                        [invocation invokeWithTarget:obj];
+                    } error:nil];
+                }
+                [CTSwizzleManager swizzleWillPresentOnClass:ncdCls];
             }
         }
         if (class_getInstanceMethod(cls, NSSelectorFromString(@"application:didReceiveRemoteNotification:fetchCompletionHandler:"))) {
@@ -195,6 +198,41 @@
 }
 + (void)ct_application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
     [CleverTap handlePushNotification:userInfo openDeepLinksInForeground:NO];
+}
+
++ (void)swizzleWillPresentOnClass:(Class)cls {
+    if (!cls) return;
+#if !defined(CLEVERTAP_TVOS)
+    if (@available(iOS 10.0, *)) {
+        SEL willPresentSel = NSSelectorFromString(@"userNotificationCenter:willPresentNotification:withCompletionHandler:");
+        if (!class_getInstanceMethod(cls, willPresentSel)) return;
+
+        __block NSInvocation *willPresentInvocation = nil;
+        willPresentInvocation = [cls ct_swizzleMethod:willPresentSel
+                                           withBlock:^(id obj,
+                                                       UNUserNotificationCenter *center,
+                                                       UNNotification *notification,
+                                                       void (^completion)(UNNotificationPresentationOptions)) {
+            NSDictionary *userInfo = notification.request.content.userInfo;
+            BOOL isCTPush = [[CleverTap sharedInstance] isCleverTapNotification:userInfo];
+            BOOL silentInForeground = isCTPush && [userInfo[CLTAP_NOTIFICATION_SILENT_IN_FOREGROUND] boolValue];
+
+            if (silentInForeground) {
+                void (^wrappedCompletion)(UNNotificationPresentationOptions) = ^(UNNotificationPresentationOptions options) {
+                    completion(UNNotificationPresentationOptionNone);
+                };
+                [willPresentInvocation setArgument:&center atIndex:2];
+                [willPresentInvocation setArgument:&notification atIndex:3];
+                [willPresentInvocation setArgument:&wrappedCompletion atIndex:4];
+            } else {
+                [willPresentInvocation setArgument:&center atIndex:2];
+                [willPresentInvocation setArgument:&notification atIndex:3];
+                [willPresentInvocation setArgument:&completion atIndex:4];
+            }
+            [willPresentInvocation invokeWithTarget:obj];
+        } error:nil];
+    }
+#endif
 }
 
 #pragma clang diagnostic pop

--- a/CleverTapSDK/Swizzling/CTSwizzleManager.m
+++ b/CleverTapSDK/Swizzling/CTSwizzleManager.m
@@ -205,36 +205,43 @@
 #if !defined(CLEVERTAP_TVOS)
     if (@available(iOS 10.0, *)) {
         SEL willPresentSel = NSSelectorFromString(@"userNotificationCenter:willPresentNotification:withCompletionHandler:");
-        if (!class_getInstanceMethod(cls, willPresentSel)) return;
+        Method willPresentMethod = class_getInstanceMethod(cls, willPresentSel);
+        if (!willPresentMethod) return;
 
-        __block NSInvocation *willPresentInvocation = nil;
-        willPresentInvocation = [cls ct_swizzleMethod:willPresentSel
-                                           withBlock:^(id obj,
-                                                       UNUserNotificationCenter *center,
-                                                       UNNotification *notification,
-                                                       void (^completion)(UNNotificationPresentationOptions)) {
+        // Capture the original IMP as a typed C function pointer to avoid
+        // passing blocks through NSInvocation (which bypasses ARC and can
+        // cause crashes with stack-allocated completion handler wrappers).
+        IMP originalIMP = method_getImplementation(willPresentMethod);
+        typedef void (*WillPresentIMP)(id, SEL, UNUserNotificationCenter *, UNNotification *, void (^)(UNNotificationPresentationOptions));
+
+        IMP newIMP = imp_implementationWithBlock(^(id obj,
+                                                    UNUserNotificationCenter *center,
+                                                    UNNotification *notification,
+                                                    void (^completion)(UNNotificationPresentationOptions)) {
             NSDictionary *userInfo = notification.request.content.userInfo;
             BOOL isCTPush = [[CleverTap sharedInstance] isCleverTapNotification:userInfo];
             BOOL silentInForeground = isCTPush && [userInfo[CLTAP_NOTIFICATION_SILENT_IN_FOREGROUND] boolValue];
 
             if (silentInForeground) {
                 void (^wrappedCompletion)(UNNotificationPresentationOptions) = ^(UNNotificationPresentationOptions options) {
-                    completion(UNNotificationPresentationOptionNone);
+                    if (@available(iOS 14.0, *)) {
+                        completion(UNNotificationPresentationOptionList);
+                    } else {
+                        completion(UNNotificationPresentationOptionNone);
+                    }
                 };
-                [willPresentInvocation setArgument:&center atIndex:2];
-                [willPresentInvocation setArgument:&notification atIndex:3];
-                [willPresentInvocation setArgument:&wrappedCompletion atIndex:4];
+                ((WillPresentIMP)originalIMP)(obj, willPresentSel, center, notification, wrappedCompletion);
             } else {
-                [willPresentInvocation setArgument:&center atIndex:2];
-                [willPresentInvocation setArgument:&notification atIndex:3];
-                [willPresentInvocation setArgument:&completion atIndex:4];
+                ((WillPresentIMP)originalIMP)(obj, willPresentSel, center, notification, completion);
             }
-            [willPresentInvocation invokeWithTarget:obj];
-        } error:nil];
+        });
+
+        const char *typeEncoding = method_getTypeEncoding(willPresentMethod);
+        if (!class_addMethod(cls, willPresentSel, newIMP, typeEncoding)) {
+            method_setImplementation(willPresentMethod, newIMP);
+        }
     }
 #endif
 }
-
-#pragma clang diagnostic pop
 
 @end

--- a/ObjCStarter/ObjCStarter/AppDelegate.h
+++ b/ObjCStarter/ObjCStarter/AppDelegate.h
@@ -7,8 +7,9 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, UNUserNotificationCenterDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/ObjCStarter/ObjCStarter/AppDelegate.m
+++ b/ObjCStarter/ObjCStarter/AppDelegate.m
@@ -32,9 +32,8 @@
 }
 
 - (void)registerPush {
-   
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    
+    center.delegate = self;
     [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error){
         if( !error ){
             dispatch_async(dispatch_get_main_queue(), ^(void) {
@@ -43,6 +42,18 @@
         }
     }];
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    NSLog(@"will present notification: %@", notification.request.content.userInfo);
+    [CleverTap handleWillPresentNotification:notification
+                          withDefaultOptions:(UNNotificationPresentationOptionSound | UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionBadge)
+                           completionHandler:completionHandler];
+}
+#pragma clang diagnostic pop
 
 - (void)applicationWillResignActive:(UIApplication *)application {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.

--- a/SwiftStarter/SwiftStarter/AppDelegate.swift
+++ b/SwiftStarter/SwiftStarter/AppDelegate.swift
@@ -82,10 +82,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        
         NSLog("%@: will present notification: %@", self.description, notification.request.content.userInfo)
-        CleverTap.sharedInstance()?.recordNotificationViewedEvent(withData: notification.request.content.userInfo)
-        completionHandler([.badge, .sound, .alert])
+        CleverTap.handleWillPresent(notification, withDefaultOptions: [.badge, .sound, .alert], completionHandler: completionHandler)
     }
     
     func application(_ application: UIApplication,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for "silent-in-foreground" push notifications so pushes can be delivered/tracked without showing banner/sound/badge while the app is foregrounded.
  * Improved foreground notification handling and presentation control across iOS versions, with app templates updated to route presentation decisions to the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->