### PR TITLE
SDK-5844: CTLogger: Use fixed .default type for os_log

### DIFF
--- a/CleverTapSDK/CTLogger.swift
+++ b/CleverTapSDK/CTLogger.swift
@@ -42,12 +42,7 @@ public class CTLogger: NSObject {
         let fullMessage = "[CleverTap]: \(message)"
         
         if #available(iOS 10.0, tvOS 10.0, *) {
-            switch logType {
-            case .info:
-                os_log("%{public}@", log: osLog, type: .info, fullMessage)
-            case .debug:
-                os_log("%{public}@", log: osLog, type: .debug, fullMessage)
-            }
+            os_log("%{public}@", log: osLog, type: .default, fullMessage)
         } else {
             NSLog("%@", fullMessage)
         }


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging output consistency on iOS 10 and later by standardizing the log type format. The logging mechanism now maintains compatibility with legacy systems while providing more uniform log entries through the system logging framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->