### PR TITLE
SDK-5888: Add accessibility support to CleverTap in-app view controllers

### DIFF
--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -352,6 +352,10 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
 - (UIButton*)setupViewForButton:(UIButton *)buttonView withData:(CTNotificationButton *)button withIndex:(NSInteger)index {
     [buttonView setTag: index];
     buttonView.titleLabel.adjustsFontSizeToFitWidth = YES;
+    if (@available(iOS 11.0, *)) {
+        buttonView.titleLabel.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:buttonView.titleLabel.font];
+        buttonView.titleLabel.adjustsFontForContentSizeCategory = YES;
+    }
     buttonView.hidden = NO;
     if (_notification.inAppType != CTInAppTypeHeader && _notification.inAppType != CTInAppTypeFooter) {
         buttonView.layer.borderWidth = 1.0f;

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -539,16 +539,8 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
 }
 
 - (void)announceInAppShown {
-    NSString *announcementText = @"Popup shown";
-
-    if (@available(iOS 11.0, tvOS 11.0, *)) {
-        NSAttributedString *announcement = [[NSAttributedString alloc] initWithString:announcementText attributes:@{
-            UIAccessibilitySpeechAttributeQueueAnnouncement: @NO
-        }];
-        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement);
-    } else {
-        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementText);
-    }
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, [self accessibilityFocusTarget]);
+    UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, @"Popup shown");
 }
 
 @end

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -287,6 +287,7 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
         if (self.delegate) {
             [self.delegate notificationDidShow:self.notification];
         }
+        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, @"inapp message shown");
     };
     
     if (animated) {

--- a/CleverTapSDK/CTInAppDisplayViewController.m
+++ b/CleverTapSDK/CTInAppDisplayViewController.m
@@ -287,7 +287,7 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
         if (self.delegate) {
             [self.delegate notificationDidShow:self.notification];
         }
-        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, @"inapp message shown");
+        [self announceInAppShown];
     };
     
     if (animated) {
@@ -529,6 +529,25 @@ API_AVAILABLE(ios(13.0), tvos(13.0)) {
 - (void)dealloc {
     if (@available(iOS 13.0, tvOS 13.0, *)) {
         [[NSNotificationCenter defaultCenter] removeObserver:self];
+    }
+}
+
+#pragma mark - Accessibility
+
+- (UIView *)accessibilityFocusTarget {
+    return self.view;
+}
+
+- (void)announceInAppShown {
+    NSString *announcementText = @"Popup shown";
+
+    if (@available(iOS 11.0, tvOS 11.0, *)) {
+        NSAttributedString *announcement = [[NSAttributedString alloc] initWithString:announcementText attributes:@{
+            UIAccessibilitySpeechAttributeQueueAnnouncement: @NO
+        }];
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement);
+    } else {
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcementText);
     }
 }
 

--- a/CleverTapSDK/CTInAppDisplayViewControllerPrivate.h
+++ b/CleverTapSDK/CTInAppDisplayViewControllerPrivate.h
@@ -30,7 +30,6 @@
 - (void)handleImageTapGesture;
 - (UIButton*)setupViewForButton:(UIButton *)buttonView withData:(CTNotificationButton *)button withIndex:(NSInteger)index;
 
-- (UIView *)accessibilityFocusTarget;
 - (void)announceInAppShown;
 
 @end

--- a/CleverTapSDK/CTInAppDisplayViewControllerPrivate.h
+++ b/CleverTapSDK/CTInAppDisplayViewControllerPrivate.h
@@ -30,4 +30,7 @@
 - (void)handleImageTapGesture;
 - (UIButton*)setupViewForButton:(UIButton *)buttonView withData:(CTNotificationButton *)button withIndex:(NSInteger)index;
 
+- (UIView *)accessibilityFocusTarget;
+- (void)announceInAppShown;
+
 @end

--- a/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
+++ b/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
@@ -405,6 +405,7 @@ typedef enum {
         if (self.delegate) {
             [self.delegate notificationDidShow:self.notification];
         }
+        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, @"inapp message shown");
     };
     if (animated) {
         [UIView animateWithDuration:0.25 animations:^{

--- a/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
+++ b/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
@@ -125,6 +125,10 @@ typedef enum {
         self.titleLabel.backgroundColor = [UIColor clearColor];
         self.titleLabel.textColor = [CTUIUtils ct_colorWithHexString:self.notification.titleColor];
         self.titleLabel.text = self.notification.title;
+        if (@available(iOS 11.0, *)) {
+            self.titleLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleHeadline] scaledFontForFont:self.titleLabel.font];
+            self.titleLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
     
     if (self.notification.message) {
@@ -133,6 +137,10 @@ typedef enum {
         self.bodyLabel.textColor = [CTUIUtils ct_colorWithHexString:self.notification.messageColor];
         self.bodyLabel.numberOfLines = 0;
         self.bodyLabel.text = self.notification.message;
+        if (@available(iOS 11.0, *)) {
+            self.bodyLabel.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:self.bodyLabel.font];
+            self.bodyLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
 }
 

--- a/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
+++ b/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
@@ -405,7 +405,7 @@ typedef enum {
         if (self.delegate) {
             [self.delegate notificationDidShow:self.notification];
         }
-        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, @"inapp message shown");
+        [self announceInAppShown];
     };
     if (animated) {
         [UIView animateWithDuration:0.25 animations:^{

--- a/CleverTapSDK/InApps/CTCoverViewController.m
+++ b/CleverTapSDK/InApps/CTCoverViewController.m
@@ -146,6 +146,8 @@
             }
         }
     }
+
+    self.view.accessibilityViewIsModal = YES;
 }
 
 

--- a/CleverTapSDK/InApps/CTCoverViewController.m
+++ b/CleverTapSDK/InApps/CTCoverViewController.m
@@ -105,6 +105,10 @@
         self.titleLabel.backgroundColor = [UIColor clearColor];
         self.titleLabel.textColor = [CTUIUtils ct_colorWithHexString:self.notification.titleColor];
         self.titleLabel.text = self.notification.title;
+        if (@available(iOS 11.0, *)) {
+            self.titleLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleHeadline] scaledFontForFont:self.titleLabel.font];
+            self.titleLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
     
     if (self.notification.message) {
@@ -113,6 +117,10 @@
         self.bodyLabel.textColor = [CTUIUtils ct_colorWithHexString:self.notification.messageColor];
         self.bodyLabel.numberOfLines = 0;
         self.bodyLabel.text = self.notification.message;
+        if (@available(iOS 11.0, *)) {
+            self.bodyLabel.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:self.bodyLabel.font];
+            self.bodyLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
     
     self.firstButton.hidden = YES;

--- a/CleverTapSDK/InApps/CTDismissButton.m
+++ b/CleverTapSDK/InApps/CTDismissButton.m
@@ -37,6 +37,13 @@ static UIImage *dismissButtonImage;
             dismissButtonImage = [self dismissButtonImage];
         });
     }
+    self.accessibilityLabel = @"Close";
+}
+
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+    CGFloat expansion = MAX(0.0, (44.0 - self.bounds.size.width) / 2.0);
+    CGRect expandedBounds = CGRectInset(self.bounds, -expansion, -expansion);
+    return CGRectContainsPoint(expandedBounds, point);
 }
 
 - (UIImage *)dismissButtonImage {

--- a/CleverTapSDK/InApps/CTDismissButton.m
+++ b/CleverTapSDK/InApps/CTDismissButton.m
@@ -41,8 +41,9 @@ static UIImage *dismissButtonImage;
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-    CGFloat expansion = MAX(0.0, (44.0 - self.bounds.size.width) / 2.0);
-    CGRect expandedBounds = CGRectInset(self.bounds, -expansion, -expansion);
+    CGFloat xExpansion = MAX(0.0, (44.0 - self.bounds.size.width) / 2.0);
+    CGFloat yExpansion = MAX(0.0, (44.0 - self.bounds.size.height) / 2.0);
+    CGRect expandedBounds = CGRectInset(self.bounds, -xExpansion, -yExpansion);
     return CGRectContainsPoint(expandedBounds, point);
 }
 

--- a/CleverTapSDK/InApps/CTHalfInterstitialViewController.m
+++ b/CleverTapSDK/InApps/CTHalfInterstitialViewController.m
@@ -191,6 +191,8 @@
             [self.secondButton setHidden:YES];
         }
     }
+
+    self.view.accessibilityViewIsModal = YES;
 }
 
 

--- a/CleverTapSDK/InApps/CTHalfInterstitialViewController.m
+++ b/CleverTapSDK/InApps/CTHalfInterstitialViewController.m
@@ -151,6 +151,10 @@
         self.titleLabel.backgroundColor = [UIColor clearColor];
         self.titleLabel.textColor = [CTUIUtils ct_colorWithHexString:self.notification.titleColor];
         self.titleLabel.text = self.notification.title;
+        if (@available(iOS 11.0, *)) {
+            self.titleLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleHeadline] scaledFontForFont:self.titleLabel.font];
+            self.titleLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
     
     if (self.notification.message) {
@@ -159,6 +163,10 @@
         self.bodyLabel.textColor = [CTUIUtils ct_colorWithHexString:self.notification.messageColor];
         self.bodyLabel.numberOfLines = 0;
         self.bodyLabel.text = self.notification.message;
+        if (@available(iOS 11.0, *)) {
+            self.bodyLabel.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:self.bodyLabel.font];
+            self.bodyLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
     
     self.firstButton.hidden = YES;

--- a/CleverTapSDK/InApps/CTImageInAppViewController.m
+++ b/CleverTapSDK/InApps/CTImageInAppViewController.m
@@ -58,6 +58,8 @@ static const CGFloat kSpacingConstant = 160.f;
     }
     
     [self setUpImage];
+
+    self.view.accessibilityViewIsModal = YES;
 }
 
 - (void)handleLayoutForIdiomPad {

--- a/CleverTapSDK/InApps/CTInterstitialViewController.m
+++ b/CleverTapSDK/InApps/CTInterstitialViewController.m
@@ -186,6 +186,10 @@
         self.titleLabel.backgroundColor = [UIColor clearColor];
         self.titleLabel.textColor = [CTUIUtils ct_colorWithHexString:self.notification.titleColor];
         self.titleLabel.text = self.notification.title;
+        if (@available(iOS 11.0, *)) {
+            self.titleLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleHeadline] scaledFontForFont:self.titleLabel.font];
+            self.titleLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
     
     if (self.notification.message) {
@@ -193,6 +197,10 @@
         self.bodyLabel.backgroundColor = [UIColor clearColor];
         self.bodyLabel.textColor = [CTUIUtils ct_colorWithHexString:self.notification.messageColor];
         self.bodyLabel.text = self.notification.message;
+        if (@available(iOS 11.0, *)) {
+            self.bodyLabel.font = [[UIFontMetrics defaultMetrics] scaledFontForFont:self.bodyLabel.font];
+            self.bodyLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
     
     self.firstButton.hidden = YES;

--- a/CleverTapSDK/InApps/CTInterstitialViewController.m
+++ b/CleverTapSDK/InApps/CTInterstitialViewController.m
@@ -223,10 +223,12 @@
                                               attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual
                                                  toItem:nil attribute:NSLayoutAttributeNotAnAttribute
                                              multiplier:1 constant:0] setActive:YES];
-                
+
             }
         }
     }
+
+    self.view.accessibilityViewIsModal = YES;
 }
 
 - (void)embedAvPlayerView {

--- a/CleverTapSDK/InApps/PiP/CTPiPWindowController.m
+++ b/CleverTapSDK/InApps/PiP/CTPiPWindowController.m
@@ -358,6 +358,7 @@
     if (self.delegate) {
         [self.delegate notificationDidShow:self.notification];
     }
+    [self announceInAppShown];
     [self observeAppLifecycle];
 
     // Image/GIF: show controls immediately then auto-hide after 3 sec.
@@ -365,6 +366,14 @@
     if (self.pipPayload.media.contentType != CTPiPContentTypeVideo) {
         [self.containerView showControlsAndScheduleAutoHide];
     }
+}
+
+#pragma mark - Accessibility
+
+// PiP is a persistent, non-modal floating widget (see viewWillPassThroughTouch above),
+// so focus should land on the widget itself rather than the full-screen passthrough view.
+- (UIView *)accessibilityFocusTarget {
+    return self.containerView;
 }
 
 - (void)hide:(BOOL)animated {


### PR DESCRIPTION
 @coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved VoiceOver announcements when in-app messages appear.
  * Added meaningful image and close-button labels when content descriptions are available.
  * Expanded the close button’s touch target for easier activation.

* **Usability**
  * Added tap-to-dismiss behavior for supported in-app message layouts.
  * In-app titles, messages, and button text now scale with the device’s preferred text size through Dynamic Type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->