### PR TITLE
[SDK-5787] Fixes a bug where CS InApp were not stored when empty array was received 

### DIFF
--- a/CleverTapSDK/InApps/CTInAppStore.m
+++ b/CleverTapSDK/InApps/CTInAppStore.m
@@ -322,7 +322,7 @@ NSString* const kSERVER_SIDE_MODE = @"SS";
 
 - (void)removeDelayedClientSideInApps {
     @synchronized (self) {
-        _clientSideInApps = [NSArray new];
+        _delayedClientSideInApps = [NSArray new];
         NSString *storageKey = [self storageKeyWithSuffix:CLTAP_PREFS_DELAYED_INAPP_KEY_CS];
         [CTPreferences removeObjectForKey:storageKey];
     }

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -91,23 +91,28 @@
     }
 
     // CS in-apps (inapp_notifs_cs)
-    ImmediateAndDelayed *partitionedClientSideInApps = [InAppDurationPartitioner partitionImmediateDelayedInApps:jsonResp[CLTAP_INAPP_CS_JSON_RESPONSE_KEY]];
+    // Only process when the key is present in the response. When present (even as an
+    // empty array), always store so that stopped campaigns are cleared from preferences.
+    if (jsonResp[CLTAP_INAPP_CS_JSON_RESPONSE_KEY]) {
+        ImmediateAndDelayed *partitionedClientSideInApps = [InAppDurationPartitioner partitionImmediateDelayedInApps:jsonResp[CLTAP_INAPP_CS_JSON_RESPONSE_KEY]];
 
-    if ([partitionedClientSideInApps hasImmediateInApps]) {
         NSArray *immediateInApps = partitionedClientSideInApps.immediateInApps;
         [self.inAppStore storeClientSideInApps:immediateInApps];
-        // Preload CS in-app images to disk cache
-        [self downloadMediaURLs:immediateInApps];
-        // Preload CS custom template in-app files to disk cache
-        [self downloadCustomTemplatesFileURLs:immediateInApps];
-    }
-    if ([partitionedClientSideInApps hasDelayedInApps]) {
+        if ([partitionedClientSideInApps hasImmediateInApps]) {
+            // Preload CS in-app images to disk cache
+            [self downloadMediaURLs:immediateInApps];
+            // Preload CS custom template in-app files to disk cache
+            [self downloadCustomTemplatesFileURLs:immediateInApps];
+        }
+
         NSArray *delayedInApps = partitionedClientSideInApps.delayedInApps;
         [self.inAppStore storeDelayedClientSideInApps:delayedInApps];
-        // Preload CS in-app images to disk cache
-        [self downloadMediaURLs:delayedInApps];
-        // Preload CS custom template in-app files to disk cache
-        [self downloadCustomTemplatesFileURLs:delayedInApps];
+        if ([partitionedClientSideInApps hasDelayedInApps]) {
+            // Preload CS in-app images to disk cache
+            [self downloadMediaURLs:delayedInApps];
+            // Preload CS custom template in-app files to disk cache
+            [self downloadCustomTemplatesFileURLs:delayedInApps];
+        }
     }
     
     // Parse in-app Mode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cleanup of delayed in-app content without affecting other cached in-app data.
  * Improved handling of responses that omit client-side in-app content.
  * Prevented unnecessary media and template downloads when no applicable in-app content is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->