### PR TITLE
[SDK-5913] Fixes potential crashes in variables module

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -5564,9 +5564,9 @@ static BOOL sharedInstanceErrorLogged;
 - (NSArray<NSDictionary<NSString *, id> *> *)variants
 {
     CT_TRY
-    NSArray *variants = [self.variables.varCache variants];
+    NSArray *variants = [self.variables.varCache variantsCopy];
     if (variants) {
-        return [variants copy];
+        return variants;
     }
     CT_END_TRY
     return [NSArray array];

--- a/CleverTapSDK/ProductExperiences/CTVarCache.h
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.h
@@ -34,6 +34,7 @@ NS_SWIFT_NAME(VarCache)
 - (void)loadVariants;
 - (void)applyVariableDiffs:(nullable NSDictionary<NSString *, id> *)diffs_;
 - (void)handleVariantsData:(NSArray<NSDictionary<NSString *, id> *> *)variantsData;
+- (NSArray<NSDictionary<NSString *, id> *> *)variantsCopy;
 
 - (void)registerVariable:(CTVar *)var;
 - (nullable CTVar *)getVariable:(NSString *)name;

--- a/CleverTapSDK/ProductExperiences/CTVarCache.m
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.m
@@ -9,6 +9,7 @@
 @property (strong, nonatomic) NSMutableDictionary<NSString *, id> *valuesFromClient;
 @property (strong, nonatomic) id merged;
 @property (strong, nonatomic) NSDictionary<NSString *, id> *diffs;
+@property (strong, nonatomic) NSObject *diffsLock;   // dedicated monitor for all diffs access
 
 @property (strong, nonatomic) CacheUpdateBlock updateBlock;
 @property (nonatomic, strong) CleverTapInstanceConfig *config;
@@ -36,8 +37,9 @@
 }
 
 - (void)initialize {
+    self.diffsLock = [NSObject new];
     self.vars = [NSMutableDictionary dictionary];
-    self.diffs = [NSMutableDictionary dictionary];
+    self.diffs = @{};
     self.valuesFromClient = [NSMutableDictionary dictionary];
     self.hasVarsRequestCompleted = NO;
     self.hasPendingDownloads = NO;
@@ -217,28 +219,34 @@
     
     // Stores the variables on the device in case we don't have a connection.
     // Restores next time when the app is opened.
-    // Diffs need to be locked incase other thread changes the diffs
-    @synchronized (self.diffs) {
-        // Encrypt diffs if needed before saving
-        NSDictionary *diffsToSave = [self encryptDiffsIfNeeded:self.diffs];
-        
-        NSMutableData *diffsData = [[NSMutableData alloc] init];
+    // Take a private snapshot under the lock so the archiver never encodes the
+    // live diffs container while another thread reassigns/releases it. The values
+    // are plist types built once by unflatten and never mutated in place, so a
+    // one-level copyItems snapshot is sufficient to make encoding race-free.
+    NSDictionary *diffsCopy;
+    @synchronized (self.diffsLock) {
+        diffsCopy = [[NSDictionary alloc] initWithDictionary:(self.diffs ?: @{}) copyItems:YES];
+    }
+
+    // Encrypt diffs if needed before saving
+    NSDictionary *diffsToSave = [self encryptDiffsIfNeeded:diffsCopy];
+
+    NSMutableData *diffsData = [[NSMutableData alloc] init];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:diffsData];
+    NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:diffsData];
 #pragma clang diagnostic pop
-        [archiver encodeObject:diffsToSave forKey:CLEVERTAP_DEFAULTS_VARIABLES_KEY];
-        [archiver finishEncoding];
-        
-        NSError *writeError = nil;
-        NSString *fileName = [self dataArchiveFileName];
-        NSString *filePath = [CTPreferences filePathfromFileName:fileName];
-        NSDataWritingOptions fileProtectionOption = _config.enableFileProtection ?
-        NSDataWritingFileProtectionComplete : NSDataWritingAtomic;
-        [diffsData writeToFile:filePath options:fileProtectionOption error:&writeError];
-        if (writeError) {
-            CleverTapLogStaticInternal(@"%@ failed to write data at %@: %@", self, filePath, writeError);
-        }
+    [archiver encodeObject:diffsToSave forKey:CLEVERTAP_DEFAULTS_VARIABLES_KEY];
+    [archiver finishEncoding];
+
+    NSError *writeError = nil;
+    NSString *fileName = [self dataArchiveFileName];
+    NSString *filePath = [CTPreferences filePathfromFileName:fileName];
+    NSDataWritingOptions fileProtectionOption = _config.enableFileProtection ?
+    NSDataWritingFileProtectionComplete : NSDataWritingAtomic;
+    [diffsData writeToFile:filePath options:fileProtectionOption error:&writeError];
+    if (writeError) {
+        CleverTapLogStaticInternal(@"%@ failed to write data at %@: %@", self, filePath, writeError);
     }
 }
 
@@ -305,10 +313,10 @@
         // Prevent overriding variables if API returns null
         // If no variables are defined, API returns {}
         if (diffs_ != nil && ![diffs_ isEqual:[NSNull null]]) {
-            self.diffs = diffs_;
-            
             // We need to lock it in case multiple threads will be accessing this.
-            @synchronized (self.diffs) {
+            // Store an immutable copy so the ivar never aliases a caller-held mutable dictionary.
+            @synchronized (self.diffsLock) {
+                self.diffs = [diffs_ copy];
                 self.merged = [ContentMerger mergeWithVars:self.valuesFromClient diff:self.diffs];
             }
             
@@ -514,36 +522,38 @@
 }
 
 - (void)migrateVariablesEncryption {
-    if (!self.diffs || [self.diffs count] == 0) {
-        return;
-    }
-    
-    CleverTapLogStaticInternal(@"Migrating variables encryption from level %d to %d",
-                              (int)self.previousEncryptionLevel, (int)self.encryptionLevel);
-    
-    // Create mutable copy for migration
-    NSMutableDictionary *migratedDiffs = [self.diffs mutableCopy];
-    
-    // Scenario 1: None/Medium → High (encrypt)
-    if ((self.previousEncryptionLevel == CleverTapEncryptionNone ||
-         self.previousEncryptionLevel == CleverTapEncryptionMedium) &&
-        self.encryptionLevel == CleverTapEncryptionHigh) {
-        
-        // If diffs are not encrypted, they will be encrypted in saveDiffs
-        CleverTapLogStaticInternal(@"Variables will be encrypted on next save");
-    }
-    
-    // Scenario 2: High → None/Medium (decrypt)
-    else if (self.previousEncryptionLevel == CleverTapEncryptionHigh &&
-             (self.encryptionLevel == CleverTapEncryptionNone ||
-              self.encryptionLevel == CleverTapEncryptionMedium)) {
-        
-        // If diffs are encrypted, decrypt them
-        if (migratedDiffs[@"_ct_encrypted_vars"]) {
-            NSDictionary *decryptedDiffs = [self decryptDiffsIfNeeded:migratedDiffs];
-            if (decryptedDiffs && decryptedDiffs != migratedDiffs) {
-                self.diffs = decryptedDiffs;
-                CleverTapLogStaticInternal(@"Decrypted variables for level change");
+    @synchronized (self.diffsLock) {
+        if (!self.diffs || [self.diffs count] == 0) {
+            return;
+        }
+
+        CleverTapLogStaticInternal(@"Migrating variables encryption from level %d to %d",
+                                  (int)self.previousEncryptionLevel, (int)self.encryptionLevel);
+
+        // Create mutable copy for migration
+        NSMutableDictionary *migratedDiffs = [self.diffs mutableCopy];
+
+        // Scenario 1: None/Medium → High (encrypt)
+        if ((self.previousEncryptionLevel == CleverTapEncryptionNone ||
+             self.previousEncryptionLevel == CleverTapEncryptionMedium) &&
+            self.encryptionLevel == CleverTapEncryptionHigh) {
+
+            // If diffs are not encrypted, they will be encrypted in saveDiffs
+            CleverTapLogStaticInternal(@"Variables will be encrypted on next save");
+        }
+
+        // Scenario 2: High → None/Medium (decrypt)
+        else if (self.previousEncryptionLevel == CleverTapEncryptionHigh &&
+                 (self.encryptionLevel == CleverTapEncryptionNone ||
+                  self.encryptionLevel == CleverTapEncryptionMedium)) {
+
+            // If diffs are encrypted, decrypt them
+            if (migratedDiffs[@"_ct_encrypted_vars"]) {
+                NSDictionary *decryptedDiffs = [self decryptDiffsIfNeeded:migratedDiffs];
+                if (decryptedDiffs && decryptedDiffs != migratedDiffs) {
+                    self.diffs = decryptedDiffs;
+                    CleverTapLogStaticInternal(@"Decrypted variables for level change");
+                }
             }
         }
     }

--- a/CleverTapSDK/ProductExperiences/CTVarCache.m
+++ b/CleverTapSDK/ProductExperiences/CTVarCache.m
@@ -376,6 +376,14 @@
     }
 }
 
+// Returns an immutable copy of the variants under the same lock the writers use,
+// so a caller on another thread can never copy the array while it is being replaced.
+- (NSArray<NSDictionary<NSString *, id> *> *)variantsCopy {
+    @synchronized (self) {
+        return [self.variants copy];
+    }
+}
+
 - (void)clearUserContent {
     // Disable callbacks and wait until fetch is finished
     [self setHasVarsRequestCompleted:NO];


### PR DESCRIPTION
- Fixes a potential crash at NSKeyedArchiver replaceObject: while saving variable diffs.
- Fixes a crash in [CleverTap variants] during concurrent variants update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of product experience variants when accessed or updated concurrently.
  * Prevented inconsistent variable and variant data during background updates, persistence, and encryption transitions.
  * Ensured consumers receive stable variant data snapshots without unexpected changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->