### PR TITLE
Account for Safe-Area Insets in iOS In-App WebView Height Calculation

### DIFF
--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -206,6 +206,12 @@ typedef enum {
             if (@available(iOS 11.0, *)) {
                 safeInsets = [CTUIUtils getSharedApplication].keyWindow.safeAreaInsets;
             }
+            else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                safeInsets.top = [CTUIUtils getSharedApplication].statusBarFrame.size.height;
+#pragma clang diagnostic pop
+            }
 
             // Calculate safe area height
             CGFloat safeAreaHeight = [[UIScreen mainScreen] bounds].size.height - safeInsets.top - safeInsets.bottom;

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -200,7 +200,22 @@ typedef enum {
         fixedHeight = true;
     } else {
         float percent = self.notification.heightPercent;
-        size.height = (CGFloat) ceil([[UIScreen mainScreen] bounds].size.height * (percent / 100.0f));
+        if (percent == 100.0) {
+            // Get the safe area insets
+            UIEdgeInsets safeInsets = UIEdgeInsetsZero;
+            if (@available(iOS 11.0, *)) {
+                safeInsets = [CTUIUtils getSharedApplication].keyWindow.safeAreaInsets;
+            }
+
+            // Calculate safe area height
+            CGFloat safeAreaHeight = [[UIScreen mainScreen] bounds].size.height - safeInsets.top - safeInsets.bottom;
+
+            // Calculate percentage-based height
+            size.height = (CGFloat) ceil(safeAreaHeight * (percent / 100.0f));
+        }
+        else {
+            size.height = (CGFloat) ceil([[UIScreen mainScreen] bounds].size.height * (percent / 100.0f));
+        }
     }
     
     // prevent webview content insets for Cover

--- a/CleverTapSDK/InApps/CTInAppHTMLViewController.m
+++ b/CleverTapSDK/InApps/CTInAppHTMLViewController.m
@@ -211,7 +211,7 @@ typedef enum {
             CGFloat safeAreaHeight = [[UIScreen mainScreen] bounds].size.height - safeInsets.top - safeInsets.bottom;
 
             // Calculate percentage-based height
-            size.height = (CGFloat) ceil(safeAreaHeight * (percent / 100.0f));
+            size.height = (CGFloat) ceil(safeAreaHeight);
         }
         else {
             size.height = (CGFloat) ceil([[UIScreen mainScreen] bounds].size.height * (percent / 100.0f));


### PR DESCRIPTION
- Fixed a bug where the AIB inapp would not respect safe area for full screen cover inapps

@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-height in-app messages on iOS 11 and later.
  * In-app content now accounts for device safe areas, preventing overlap with system elements such as the status bar or home indicator.
  * Percentage-based heights below 100% continue to display using the existing screen-height calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->