### PR TITLE
ci: notify Bearded Robot (CT-Apps) on core SDK release

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -67,3 +67,24 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Notify the Bearded Robot test app (CleverTap/CT-Apps) that a new core
+      # SDK version has been cut, so it can open a version-bump PR.
+      # NOTE: this fires when the draft release / tag is created. If the pod is
+      # only resolvable from CleverTap/podspecs at a later publish step, move
+      # this step (or add a `release: [published]` trigger) to that point so the
+      # CT-Apps `pod update` can find the version. Until then the CT-Apps side
+      # can be re-run manually via workflow_dispatch.
+      - name: Dispatch core-sdk-released to CT-Apps
+        env:
+          GH_TOKEN: ${{ secrets.CT_APPS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::CT_APPS_DISPATCH_TOKEN is not set. Add a PAT with 'repo' scope on CleverTap/CT-Apps as a repo secret."
+            exit 1
+          fi
+          VERSION=$(cat sdk-version.txt)
+          echo "📣 Notifying CT-Apps: ios core $VERSION released"
+          PAYLOAD=$(printf '{"event_type":"core-sdk-released","client_payload":{"platform":"ios","version":"%s"}}' "$VERSION")
+          echo "$PAYLOAD" | gh api repos/CleverTap/CT-Apps/dispatches --method POST --input -
+          echo "✅ Dispatch sent to CleverTap/CT-Apps."


### PR DESCRIPTION
## What
Adds a "Dispatch core-sdk-released to CT-Apps" step to `create_draft_release.yml`. After the draft release/tag is created, it fires a `repository_dispatch` to **CleverTap/CT-Apps** so the Bearded Robot test app can automatically open a PR bumping to the new core SDK version.

## How
- Reads the version from `sdk-version.txt`.
- Sends:
  ```json
  { "event_type": "core-sdk-released", "client_payload": { "platform": "ios", "version": "<version>" } }
  ```

## Prerequisite (repo secret)
- **`CT_APPS_DISPATCH_TOKEN`** — a PAT with `repo` scope on `CleverTap/CT-Apps`. The step fails fast with a clear error if it's missing, so merging before the secret exists is safe.

## Timing note
This fires when the **draft** release/tag is created. If the pod only becomes resolvable from `CleverTap/podspecs` at a later publish step, move this step (or add a `release: [published]` trigger) to that point so the CT-Apps `pod update` can find the version. Until then, the CT-Apps workflow can be re-run manually via `workflow_dispatch`. This caveat is also documented inline in the workflow.

## Companion work
- CT-Apps side: a new `br-sync-core-sdk.yml` workflow consumes this dispatch and opens the bump PR (separate change in CT-Apps).
- Android SDK: matching PR in `clevertap-android-sdk`.

## Impact
Additive only — one new step at the end of the existing job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)