### PR TITLE
Fix code rabbit & pr comments for BIS

### DIFF
--- a/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
+++ b/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m
@@ -405,9 +405,7 @@ typedef enum {
     [self.window setHidden:NO];
     
     void (^completionBlock)(void) = ^ {
-        if (self.delegate) {
-            [self.delegate notificationDidShow:self.notification];
-        }
+        [self handleNotificationDidShow];
         [self announceInAppShown];
     };
     if (animated) {

--- a/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
@@ -274,11 +274,12 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
 
     if (!self.volumeButton) {
         self.volumeButton = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 44.f, 44.f)];
+        self.volumeButton.accessibilityHint = @"Toggles audio";
+        self.volumeButton.accessibilityTraits = UIAccessibilityTraitButton;
         [self.volumeButton addTarget:self action:@selector(volumeButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
         [self.avPlayerControlsView addSubview:self.volumeButton];
     }
-    self.volumeButton.accessibilityHint = @"Toggles audio";
-    self.volumeButton.accessibilityTraits = UIAccessibilityTraitButton;
+
 
     CleverTapInboxMessageContent *content = self.message.content[0];
     if (content.mediaUrl == nil || content.mediaUrl.length == 0) {

--- a/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
+++ b/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m
@@ -71,8 +71,10 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
     if (self.bodyLabel) [labels addObject:self.bodyLabel];
     if (self.dateLabel) [labels addObject:self.dateLabel];
     for (UILabel *label in labels) {
-        label.font = [UIFontMetrics.defaultMetrics scaledFontForFont:label.font];
-        label.adjustsFontForContentSizeCategory = YES;
+        if (@available(iOS 11.0, *)) {
+            label.font = [UIFontMetrics.defaultMetrics scaledFontForFont:label.font];
+            label.adjustsFontForContentSizeCategory = YES;
+        }
     }
 }
 
@@ -272,11 +274,11 @@ static const CGFloat kDefaultFallbackAspectRatio = 0.5625f; // 16:9
 
     if (!self.volumeButton) {
         self.volumeButton = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 44.f, 44.f)];
-        self.volumeButton.accessibilityHint = @"Toggles audio";
-        self.volumeButton.accessibilityTraits = UIAccessibilityTraitButton;
         [self.volumeButton addTarget:self action:@selector(volumeButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
         [self.avPlayerControlsView addSubview:self.volumeButton];
     }
+    self.volumeButton.accessibilityHint = @"Toggles audio";
+    self.volumeButton.accessibilityTraits = UIAccessibilityTraitButton;
 
     CleverTapInboxMessageContent *content = self.message.content[0];
     if (content.mediaUrl == nil || content.mediaUrl.length == 0) {

--- a/CleverTapSDK/Inbox/views/CTCarouselImageView.m
+++ b/CleverTapSDK/Inbox/views/CTCarouselImageView.m
@@ -121,8 +121,12 @@ static float captionHeight = 0.f;
     self.captionLabel = [[UILabel alloc]initWithFrame:CGRectMake(kCaptionLeftPadding, kCaptionTopPadding + imageViewSize.height, viewWidth - kCaptionLeftPadding * 2, kCaptionHeight)];
     self.captionLabel.textAlignment = NSTextAlignmentLeft;
     self.captionLabel.adjustsFontSizeToFitWidth = NO;
-    self.captionLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:[UIFont boldSystemFontOfSize:15.f]];
-    self.captionLabel.adjustsFontForContentSizeCategory = YES;
+    if (@available(iOS 11.0, *)) {
+        self.captionLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:[UIFont boldSystemFontOfSize:15.f]];
+        self.captionLabel.adjustsFontForContentSizeCategory = YES;
+    } else {
+        self.captionLabel.font = [UIFont boldSystemFontOfSize:15.f];
+    }
     self.captionLabel.textColor = [CTUIUtils ct_colorWithHexString:self.captionColor];
     self.captionLabel.text = self.caption;
     [self addSubview:self.captionLabel];
@@ -131,8 +135,12 @@ static float captionHeight = 0.f;
     self.subcaptionLabel.numberOfLines = 0;
     self.subcaptionLabel.textAlignment = NSTextAlignmentLeft;
     self.subcaptionLabel.adjustsFontSizeToFitWidth = NO;
-    self.subcaptionLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:[UIFont systemFontOfSize:13.f]];
-    self.subcaptionLabel.adjustsFontForContentSizeCategory = YES;
+    if (@available(iOS 11.0, *)) {
+        self.subcaptionLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:[UIFont systemFontOfSize:13.f]];
+        self.subcaptionLabel.adjustsFontForContentSizeCategory = YES;
+    } else {
+        self.subcaptionLabel.font = [UIFont systemFontOfSize:13.f];
+    }
     self.subcaptionLabel.textColor = [CTUIUtils ct_colorWithHexString:self.subcaptionColor];
     self.subcaptionLabel.text = self.subcaption;
     [self addSubview:self.subcaptionLabel];

--- a/CleverTapSDK/Inbox/views/CTInboxMessageActionView.m
+++ b/CleverTapSDK/Inbox/views/CTInboxMessageActionView.m
@@ -34,9 +34,11 @@
 
 - (UIButton*)setupViewForButton:(UIButton *)buttonView forText:(NSDictionary *)messageButton withIndex:(int)index; {
     buttonView.tag = index;
-    if (!buttonView.titleLabel.adjustsFontForContentSizeCategory) {
-        buttonView.titleLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:buttonView.titleLabel.font];
-        buttonView.titleLabel.adjustsFontForContentSizeCategory = YES;
+    if (@available(iOS 11.0, *)) {
+        if (!buttonView.titleLabel.adjustsFontForContentSizeCategory) {
+            buttonView.titleLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:buttonView.titleLabel.font];
+            buttonView.titleLabel.adjustsFontForContentSizeCategory = YES;
+        }
     }
     buttonView.accessibilityTraits = UIAccessibilityTraitButton;
     buttonView.hidden = NO;


### PR DESCRIPTION
#### 1. [[CTBaseHeaderFooterViewController.m](https://claude.ai/epitaxy/CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m)](CleverTapSDK/InApps/CTBaseHeaderFooterViewController.m)
Replaced inline delegate callback with `[self handleNotificationDidShow]` — consistent with other subclasses (`CTAlertViewController`, `CTInAppHTMLViewController`) and adds the `respondsToSelector:` safety check.

#### 2. [[CTInboxBaseMessageCell.m](https://claude.ai/epitaxy/CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m)](CleverTapSDK/Inbox/cells/CTInboxBaseMessageCell.m)
- Added `@available(iOS 11.0, *)` guard around `UIFontMetrics` usage in the label loop.
- Moved `accessibilityHint` and `accessibilityTraits` outside the `if (!self.volumeButton)` block so nib-provided buttons also get accessibility properties.

#### 3. [[CTCarouselImageView.m](https://claude.ai/epitaxy/CleverTapSDK/Inbox/views/CTCarouselImageView.m)](CleverTapSDK/Inbox/views/CTCarouselImageView.m)
Added `@available(iOS 11.0, *)` guards around both `UIFontMetrics` calls (caption and subcaption labels), with fallback to unscaled fonts on older iOS.

#### 4. [[CTInboxMessageActionView.m](https://claude.ai/epitaxy/CleverTapSDK/Inbox/views/CTInboxMessageActionView.m)](CleverTapSDK/Inbox/views/CTInboxMessageActionView.m)
Added `@available(iOS 11.0, *)` guard around the `UIFontMetrics` call for button title labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-app notification display callbacks for more reliable show-event handling.
  * Fixed Inbox media controls so accessibility settings remain consistent when reused.
  * Improved compatibility with older iOS versions by preventing unsupported text-scaling features from being used.
* **Accessibility**
  * Enhanced Dynamic Type support for Inbox captions, subcaptions, and action buttons on supported iOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->