### PR TITLE
Display missed in-app notifications when app enters foreground

### DIFF
--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1183,7 +1183,7 @@ static BOOL sharedInstanceErrorLogged;
 #if !CLEVERTAP_NO_INAPP_SUPPORT
     if (isActuallyInForeground && !_config.analyticsOnly && ![CTUIUtils runningInsideAppExtension]) {
         [self.inAppFCManager checkUpdateDailyLimits];
-        // Show inapps that werent shown cuz of the app being in the background
+        // Show inapps that were not shown because of the app being in the background
         [self.inAppDisplayManager _showInAppNotificationIfAny];
     }
 #endif

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1183,6 +1183,8 @@ static BOOL sharedInstanceErrorLogged;
 #if !CLEVERTAP_NO_INAPP_SUPPORT
     if (isActuallyInForeground && !_config.analyticsOnly && ![CTUIUtils runningInsideAppExtension]) {
         [self.inAppFCManager checkUpdateDailyLimits];
+        // Show inapps that werent shown cuz of the app being in the background
+        [self.inAppDisplayManager _showInAppNotificationIfAny];
     }
 #endif
 }


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In-app notifications that were missed while the app was in the background can now be displayed when the app returns to the foreground.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->