### PR TITLE
[SDK-5984] Adds public new api dismissPipInApp to dismiss PiP InApp

### DIFF
--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -263,6 +263,7 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_CTA_SWIPE_DISMISS @"Swipe to Dismiss"
 #define CLTAP_CTA_TAP_OUTSIDE_DISMISS @"Tap Outside to Dismiss"
 #define CLTAP_CTA_DISMISS_BUTTON @"Dismiss Button"
+#define CLTAP_CTA_DISMISS_PIP_API @"Dismiss PiP API"
 
 // Split of Clicks: per-element identity and action descriptors added to the
 // Notification Clicked event for basic (native) and custom HTML in-apps.
@@ -271,6 +272,7 @@ extern NSString *CLTAP_PROFILE_IDENTITY_KEY;
 #define CLTAP_PROP_WZRK_DATA @"wzrk_data"
 #define CLTAP_INAPP_ELEMENT_CLOSE_BUTTON @"closeButton"
 #define CLTAP_INAPP_ELEMENT_IMAGE @"image-1"
+#define CLTAP_INAPP_ELEMENT_DISMISS_API @"dismissApi"
 #define CLTAP_INAPP_DATA_CLOSE @"close"
 
 // Advanced-builder media preload failures. The HTML template (image_interstitial.html)

--- a/CleverTapSDK/CleverTap+InAppNotifications.h
+++ b/CleverTapSDK/CleverTap+InAppNotifications.h
@@ -55,6 +55,17 @@
  */
 - (void)discardInAppNotifications:(BOOL)dismissInAppIfVisible;
 
+/*!
+ @method
+
+ @abstract
+ Dismisses the currently displaying Picture-in-Picture (PiP) InApp notification, if one is showing.
+
+ If a PiP InApp is currently visible, it is dismissed immediately. If no InApp is showing, or the
+ currently showing InApp is not a PiP type, this method is a no-op.
+ */
+- (void)dismissPipInApp;
+
 #endif
 
 @end

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1633,6 +1633,10 @@ static BOOL sharedInstanceErrorLogged;
     [self.inAppDisplayManager _discardInAppNotifications:dismissInAppIfVisible];
 }
 
+- (void)dismissPipInApp {
+    [self.inAppDisplayManager _dismissPipInApp];
+}
+
 + (void)registerCustomInAppTemplates:(id<CTTemplateProducer> _Nonnull)producer {
     [CTCustomTemplatesManager registerTemplateProducer:producer];
 }

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.h
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.h
@@ -50,6 +50,7 @@ typedef NS_ENUM(NSInteger, CleverTapInAppRenderingStatus) {
 - (void)_showNotificationIfAvailable;
 - (void)_suspendInAppNotifications;
 - (void)_discardInAppNotifications:(BOOL)dismissInAppIfVisible;
+- (void)_dismissPipInApp;
 - (void)_resumeInAppNotifications;
 - (void)_showInAppNotificationIfAny;
 

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -345,19 +345,24 @@ static NSMutableArray<NSArray *> *pendingNotifications;
         return;
     }
 
-    if (currentlyDisplayingNotification == nil || currentDisplayController == nil) {
-        CleverTapLogDebug(self.config.logLevel, @"%@: No PiP InApp is currently displayed, nothing to dismiss.", self);
-        return;
-    }
-
-    if (currentlyDisplayingNotification.inAppType != CTInAppTypePiP) {
-        CleverTapLogDebug(self.config.logLevel, @"%@: Currently displaying InApp %@ is not a PiP InApp, nothing to dismiss.", self, currentlyDisplayingNotification.campaignId);
-        return;
-    }
-
-    CleverTapLogDebug(self.config.logLevel, @"%@: Dismissing currently displaying PiP InApp: %@", self, currentlyDisplayingNotification.campaignId);
-    CTInAppDisplayViewController *controller = currentDisplayController;
     [CTUtils runSyncMainQueue:^{
+        if (currentlyDisplayingNotification == nil || currentDisplayController == nil) {
+            CleverTapLogDebug(self.config.logLevel, @"%@: No PiP InApp is currently displayed, nothing to dismiss.", self);
+            return;
+        }
+
+        if (currentlyDisplayingNotification.inAppType != CTInAppTypePiP) {
+            CleverTapLogDebug(self.config.logLevel, @"%@: Currently displaying InApp %@ is not a PiP InApp, nothing to dismiss.", self, currentlyDisplayingNotification.campaignId);
+            return;
+        }
+
+        if (currentDisplayController.delegate != self) {
+            CleverTapLogDebug(self.config.logLevel, @"%@: Currently displaying PiP InApp %@ belongs to another CleverTap instance, not dismissing.", self, currentlyDisplayingNotification.campaignId);
+            return;
+        }
+
+        CleverTapLogDebug(self.config.logLevel, @"%@: Dismissing currently displaying PiP InApp: %@", self, currentlyDisplayingNotification.campaignId);
+        CTInAppDisplayViewController *controller = currentDisplayController;
         [controller triggerCloseActionWithCallToAction:CLTAP_CTA_DISMISS_PIP_API
                                              elementId:CLTAP_INAPP_ELEMENT_DISMISS_API];
         [controller hide:YES];

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -338,6 +338,26 @@ static NSMutableArray<NSArray *> *pendingNotifications;
     }
 }
 
+- (void)_dismissPipInApp {
+    if ([CTUIUtils runningInsideAppExtension]) {
+        CleverTapLogDebug(self.config.logLevel, @"%@: dismissPipInApp is a no-op in an app extension.", self);
+        return;
+    }
+
+    if (currentlyDisplayingNotification == nil || currentDisplayController == nil) {
+        CleverTapLogDebug(self.config.logLevel, @"%@: No PiP InApp is currently displayed, nothing to dismiss.", self);
+        return;
+    }
+
+    if (currentlyDisplayingNotification.inAppType != CTInAppTypePiP) {
+        CleverTapLogDebug(self.config.logLevel, @"%@: Currently displaying InApp %@ is not a PiP InApp, nothing to dismiss.", self, currentlyDisplayingNotification.campaignId);
+        return;
+    }
+
+    CleverTapLogDebug(self.config.logLevel, @"%@: Dismissing currently displaying PiP InApp: %@", self, currentlyDisplayingNotification.campaignId);
+    [[self class] hideCurrentInAppDisplayController];
+}
+
 - (void)_resumeInAppNotifications {
     if ([CTUIUtils runningInsideAppExtension]) {
         CleverTapLogDebug(self.config.logLevel, @"%@: resumeInAppNotifications is a no-op in an app extension.", self);

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -12,6 +12,7 @@
 #import "CTConstants.h"
 #import "CTInAppNotification.h"
 #import "CTInAppDisplayViewController.h"
+#import "CTInAppDisplayViewControllerPrivate.h"
 #import "CleverTapJSInterface.h"
 #import "CTInAppFCManager.h"
 #import "CTDeviceInfo.h"
@@ -355,7 +356,12 @@ static NSMutableArray<NSArray *> *pendingNotifications;
     }
 
     CleverTapLogDebug(self.config.logLevel, @"%@: Dismissing currently displaying PiP InApp: %@", self, currentlyDisplayingNotification.campaignId);
-    [[self class] hideCurrentInAppDisplayController];
+    CTInAppDisplayViewController *controller = currentDisplayController;
+    [CTUtils runSyncMainQueue:^{
+        [controller triggerCloseActionWithCallToAction:CLTAP_CTA_DISMISS_PIP_API
+                                             elementId:CLTAP_INAPP_ELEMENT_DISMISS_API];
+        [controller hide:YES];
+    }];
 }
 
 - (void)_resumeInAppNotifications {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public method to dismiss a currently visible Picture-in-Picture in-app notification.
  * The dismissal safely does nothing when no notification is visible or when the displayed notification is not Picture-in-Picture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->