### PR TITLE
SDK-6002: Fixes evaluation for event where app fields were not added

### DIFF
--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		0B82CD102DC2407200756998 /* CTAESGCMCryptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B82CD0F2DC2407200756998 /* CTAESGCMCryptTests.swift */; };
 		0B836117E159C83D50F7571F /* InAppDurationPartitionerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C16E1FBDB18DC1C7AA2479 /* InAppDurationPartitionerTests.swift */; };
 		0B995A4A2C36AEDC00AF6006 /* CTLocalDataStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B995A492C36AEDC00AF6006 /* CTLocalDataStoreTests.m */; };
+		CT01MUTAB111100000000002 /* CTProfileDeleteOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CT01MUTAB111100000000001 /* CTProfileDeleteOperationTests.m */; };
 		0C546401FA049D50AAE04697 /* CTConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = D0213D53207D93C300FE5740 /* CTConstants.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0D4CEABE7531E4DE87CF23A9 /* CTIdentityRepoFactoryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = FA88FE3C12519A1823AF5285 /* CTIdentityRepoFactoryTest.m */; };
 		10147FD40479E958BC4F769A /* CTMultiDelegateManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B535FB42AD56C60002A2663 /* CTMultiDelegateManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -920,6 +921,7 @@
 		0B660AC62D8999A200683869 /* SDWebImage.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SDWebImage.xcframework; path = Vendors/SDWebImage.xcframework; sourceTree = "<group>"; };
 		0B82CD0F2DC2407200756998 /* CTAESGCMCryptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CTAESGCMCryptTests.swift; sourceTree = "<group>"; };
 		0B995A492C36AEDC00AF6006 /* CTLocalDataStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTLocalDataStoreTests.m; sourceTree = "<group>"; };
+		CT01MUTAB111100000000001 /* CTProfileDeleteOperationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTProfileDeleteOperationTests.m; sourceTree = "<group>"; };
 		10405BF7AEB9D1E6730686C3 /* CTInAppUtilsTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CTInAppUtilsTest.m; sourceTree = "<group>"; };
 		14A6E5036771123B9E893C2D /* CTFlattenedEventDataTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CTFlattenedEventDataTest.m; sourceTree = "<group>"; };
 		1D79C2B6FCEBDB269140A380 /* CTFlexibleIdentityRepoTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CTFlexibleIdentityRepoTest.m; sourceTree = "<group>"; };
@@ -2142,6 +2144,7 @@
 				6BD851C82B45CD1800FA5298 /* CTMultiDelegateManager+Tests.h */,
 				0B5564552C25946C00B87284 /* CTUserInfoMigratorTest.m */,
 				0B995A492C36AEDC00AF6006 /* CTLocalDataStoreTests.m */,
+				CT01MUTAB111100000000001 /* CTProfileDeleteOperationTests.m */,
 				4E07214D2D09738F000DE9C6 /* CTLocalDataStore+Tests.h */,
 				4E0721502D0974B6000DE9C6 /* CTLocalDataStore+Tests.m */,
 				4E8739772C921D9000FDFDFD /* CTDomainFactoryTests.m */,
@@ -3206,6 +3209,7 @@
 				32790959299F4B29001FE140 /* CTDeviceInfoTest.m in Sources */,
 				48FA82C52DAD3D9100AB8651 /* CTPushPrimerManagerTests.m in Sources */,
 				0B995A4A2C36AEDC00AF6006 /* CTLocalDataStoreTests.m in Sources */,
+				CT01MUTAB111100000000002 /* CTProfileDeleteOperationTests.m in Sources */,
 				6A4427C52AA6515A0098866F /* CTTriggersMatcherTest.m in Sources */,
 				6B32A0B02B9DC374009ADC57 /* CTTemplateArgumentTest.m in Sources */,
 				4E87397B2C92223C00FDFDFD /* CTDomainFactoryTests.m in Sources */,

--- a/CleverTapSDK.xcodeproj/project.pbxproj
+++ b/CleverTapSDK.xcodeproj/project.pbxproj
@@ -576,6 +576,7 @@
 		7632C18E471A1CDF4E16CC49 /* CTInActionResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DF7B086F8FC5305D81405B0 /* CTInActionResultTests.swift */; };
 		76B45B38A5B1283E8D7BFDBF /* CleverTapFeatureFlagsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C4EB6D79842FF5DDE75C6D08 /* CleverTapFeatureFlagsTest.m */; };
 		784FEA3C94ECE9143D761BCB /* InAppSelectionStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE6298F5BDD0BCAE1740F0D /* InAppSelectionStrategyTests.swift */; };
+		A1B2C3D40001E5F600001001 /* InAppSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40002E5F600001002 /* InAppSchedulerTests.swift */; };
 		7ACDCC2E32FD54E579929F45 /* CTMultiDelegateManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = A5858A0E994EC529904E271C /* CTMultiDelegateManagerTest.m */; };
 		7DD6BFD3CE84075AB727F21C /* CTLoginInfoProviderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 919D12C82BD89CE13EDE525C /* CTLoginInfoProviderTest.m */; };
 		837036E25A3D14C8BE2785F5 /* CTAppRatingSystemAppFunctionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = A415F802C7FFE6DD7712EE2C /* CTAppRatingSystemAppFunctionTest.m */; };
@@ -937,6 +938,7 @@
 		32A61E6CAE1EC35B9C7315F2 /* CTTimerResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CTTimerResult.swift; sourceTree = "<group>"; };
 		39C16E1FBDB18DC1C7AA2479 /* InAppDurationPartitionerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppDurationPartitionerTests.swift; sourceTree = "<group>"; };
 		3CE6298F5BDD0BCAE1740F0D /* InAppSelectionStrategyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppSelectionStrategyTests.swift; sourceTree = "<group>"; };
+		A1B2C3D40002E5F600001002 /* InAppSchedulerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InAppSchedulerTests.swift; sourceTree = "<group>"; };
 		4032D1E7BFC02C3560EA977D /* CTTriggerValueTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CTTriggerValueTest.m; sourceTree = "<group>"; };
 		439EFEFCFEE3AC26B3EECFF3 /* CTValidationConfigTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CTValidationConfigTest.m; sourceTree = "<group>"; };
 		4806346E2CEB620400E39E9B /* CTInAppDisplayViewControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CTInAppDisplayViewControllerTests.m; sourceTree = "<group>"; };
@@ -2165,6 +2167,7 @@
 				83B02535120793C05F208D08 /* InactionInAppStorageStrategyTests.swift */,
 				10405BF7AEB9D1E6730686C3 /* CTInAppUtilsTest.m */,
 				3CE6298F5BDD0BCAE1740F0D /* InAppSelectionStrategyTests.swift */,
+				A1B2C3D40002E5F600001002 /* InAppSchedulerTests.swift */,
 				C4EB6D79842FF5DDE75C6D08 /* CleverTapFeatureFlagsTest.m */,
 				997881C7B7B5276373B4FD43 /* CTLegacyIdentityRepoTest.m */,
 				9B983A84382C8A34E2292BA7 /* CTNestedJsonBuilderTest.m */,
@@ -3231,6 +3234,7 @@
 				A5324FD2D644B9AC9E6D2F32 /* InactionInAppStorageStrategyTests.swift in Sources */,
 				4ABB80A0173C15BEE7F38D2A /* CTInAppUtilsTest.m in Sources */,
 				784FEA3C94ECE9143D761BCB /* InAppSelectionStrategyTests.swift in Sources */,
+				A1B2C3D40001E5F600001001 /* InAppSchedulerTests.swift in Sources */,
 				76B45B38A5B1283E8D7BFDBF /* CleverTapFeatureFlagsTest.m in Sources */,
 				83999BF9B2CD23F1A6141576 /* CTLegacyIdentityRepoTest.m in Sources */,
 				996618D659D00AAE332278DF /* CTNestedJsonBuilderTest.m in Sources */,

--- a/CleverTapSDK/CTFlattenedEventData.h
+++ b/CleverTapSDK/CTFlattenedEventData.h
@@ -17,7 +17,6 @@ typedef NS_ENUM(NSInteger, CTFlattenedEventDataType) {
 + (instancetype)noData;
 - (nullable NSDictionary<NSString *, id> *)profileChanges;
 - (nullable NSDictionary<NSString *, id> *)eventProperties;
-- (BOOL)isNoData;
 
 @end
 

--- a/CleverTapSDK/CTFlattenedEventData.m
+++ b/CleverTapSDK/CTFlattenedEventData.m
@@ -38,8 +38,4 @@
     return self.type == CTFlattenedEventDataTypeEventProperties ? self.data : nil;
 }
 
-- (BOOL)isNoData {
-    return self.type == CTFlattenedEventDataTypeNoData;
-}
-
 @end

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -1927,7 +1927,7 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)queueEvent:(NSDictionary *)event withType:(CleverTapEventType)type {
-    [self queueEvent:event withType:type flattenedEventData:CTFlattenedEventData.noData];
+    [self queueEvent:event withType:type flattenedEventData:[self getFlattenedEventProperties:event[CLTAP_EVENT_DATA]]];
 }
 
 - (void)queueEvent:(NSDictionary *)event withType:(CleverTapEventType)type flattenedEventData:(CTFlattenedEventData *)flattenedEventData {

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -607,6 +607,7 @@ static BOOL sharedInstanceErrorLogged;
     self.inAppEvaluationManager = evaluationManager;
     self.inAppEvaluationManager.location = self.userSetLocation;
     self.inAppDisplayManager = displayManager;
+    [self.delegateManager addSwitchUserDelegate:displayManager];
     
     self.sessionManager = [[CTSessionManager alloc] initWithConfig:self.config impressionManager:self.impressionManager inAppStore:inAppStore validationConfig:self.validationConfig];
     

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2099,8 +2099,8 @@ static BOOL sharedInstanceErrorLogged;
     // Add the system properties for evaluation
     NSMutableDictionary *eventData = [[NSMutableDictionary alloc] initWithDictionary:[self generateAppFields]];
     // Add the event properties last, so custom properties are not overriden
-    [eventData addEntriesFromDictionary:event[CLTAP_EVENT_DATA]];
     if (eventName && [eventName isEqualToString:CLTAP_CHARGED_EVENT]) {
+        [eventData addEntriesFromDictionary:event[CLTAP_EVENT_DATA]];
         NSArray *items = eventData[CLTAP_CHARGED_EVENT_ITEMS];
         [self.inAppEvaluationManager evaluateOnChargedEvent:eventData andItems:items];
     } else if (eventType == CleverTapEventTypeProfile) {
@@ -2108,7 +2108,8 @@ static BOOL sharedInstanceErrorLogged;
         [self.inAppEvaluationManager evaluateOnUserAttributeChange:flattenedProfileChanges];
     } else if (eventName) {
         NSDictionary<NSString *, NSDictionary<NSString *, id> *> *flattenedEventChanges = flattenedEventData.eventProperties;
-        [self.inAppEvaluationManager evaluateOnEvent:eventName withProps:flattenedEventChanges];
+        [eventData addEntriesFromDictionary:flattenedEventChanges];
+        [self.inAppEvaluationManager evaluateOnEvent:eventName withProps:eventData];
     }
 #endif
 }

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.h
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.h
@@ -15,6 +15,7 @@
 #import "CTInAppStore.h"
 #import "CTFileDownloader.h"
 #import "CTCustomTemplatesManager.h"
+#import "CTSwitchUserDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,7 +25,7 @@ typedef NS_ENUM(NSInteger, CleverTapInAppRenderingStatus) {
     CleverTapInAppResume,
 };
 
-@interface CTInAppDisplayManager : NSObject {
+@interface CTInAppDisplayManager : NSObject <CTSwitchUserDelegate> {
     __weak CTPushPrimerManager *pushPrimerManager;
 }
 

--- a/CleverTapSDK/InApps/CTInAppDisplayManager.m
+++ b/CleverTapSDK/InApps/CTInAppDisplayManager.m
@@ -150,9 +150,19 @@ static NSMutableArray<NSArray *> *pendingNotifications;
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self 
+    [[NSNotificationCenter defaultCenter] removeObserver:self
                                                     name:[self.class pendingNotificationKey:self.config.accountId]
                                                   object:nil];
+}
+
+#pragma mark CTSwitchUserDelegate
+
+- (void)deviceIdWillChange {
+    // We're switching users. Cancel any pending delayed or inaction in-app
+    // timers so an in-app meant for the previous user can't fire for the next
+    // one, and clear their stored data.
+    [self.inAppDelayManager cancelAllSchedulingWithCompletion:nil];
+    [self.inAppInActionManager cancelAllSchedulingWithCompletion:nil];
 }
 
 - (void)setPushPrimerManager:(CTPushPrimerManager *)pushPrimerManagerObj {

--- a/CleverTapSDK/InApps/CTInAppEvaluationManager.m
+++ b/CleverTapSDK/InApps/CTInAppEvaluationManager.m
@@ -125,7 +125,7 @@
         NSString *eventName = [key stringByAppendingString:CLTAP_USER_ATTRIBUTE_CHANGE];
         NSMutableDictionary *eventProperties = [NSMutableDictionary dictionaryWithDictionary:value];
         [eventProperties addEntriesFromDictionary:appFields];
-        CTEventAdapter *event = [[CTEventAdapter alloc] initWithEventName:eventName profileAttrName:key eventProperties: value andLocation:self.location];
+        CTEventAdapter *event = [[CTEventAdapter alloc] initWithEventName:eventName profileAttrName:key eventProperties: eventProperties andLocation:self.location];
         [eventAdapterList addObject:event];
     }];
     [self evaluateServerSide:eventAdapterList withQueueType:CTQueueTypeProfile];

--- a/CleverTapSDK/InApps/CTInAppStore.m
+++ b/CleverTapSDK/InApps/CTInAppStore.m
@@ -303,10 +303,12 @@ NSString* const kSERVER_SIDE_MODE = @"SS";
             [self removeserverSideInActionMetaData];
         } else if ([mode isEqualToString:kSERVER_SIDE_MODE]) {
             [self removeClientSideInApps];
+            [self removeDelayedClientSideInApps];
         } else {
             [self removeserverSideInActionMetaData];
             [self removeServerSideInApps];
             [self removeClientSideInApps];
+            [self removeDelayedClientSideInApps];
         }
     }
 }

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -115,9 +115,11 @@
         }
     }
     
-    // Parse in-app Mode
+    // Parse in-app Mode. Only apply it when the response actually carries a mode
     NSString *mode = jsonResp[CLTAP_INAPP_MODE_JSON_RESPONSE_KEY];
-    [self.inAppStore setMode:mode];
+    if ([mode isKindOfClass:[NSString class]] && mode.length > 0) {
+        [self.inAppStore setMode:mode];
+    }
     
     // Handle stale in-apps
     @try {

--- a/CleverTapSDK/InApps/InAppsScheduler/InAppDataExtractor.swift
+++ b/CleverTapSDK/InApps/InAppsScheduler/InAppDataExtractor.swift
@@ -28,7 +28,7 @@ import Foundation
         if let delayMs = inApp[InAppDelayConstants.INAPP_DELAY_AFTER_TRIGGER] as? Int {
             return TimeInterval(delayMs)
         }
-        if let delayMs = inApp[InAppDelayConstants.INAPP_DELAY_AFTER_TRIGGER] as? Int {
+        if let delayMs = inApp[InAppDelayConstants.INAPP_DELAY_AFTER_TRIGGER] as? Double {
             return TimeInterval(delayMs)
         }
         return 0

--- a/CleverTapSDK/InApps/InAppsScheduler/InAppScheduler.swift
+++ b/CleverTapSDK/InApps/InAppsScheduler/InAppScheduler.swift
@@ -92,7 +92,7 @@ import Foundation
     }
     
     /// Cancel all scheduling
-    func cancelAllScheduling(completion: (() -> Void)? = nil) {
+    @objc public func cancelAllScheduling(completion: (() -> Void)? = nil) {
         queue.async { [weak self] in
             guard let self = self else {
                 completion?()

--- a/CleverTapSDK/InApps/InAppsScheduler/InAppScheduler.swift
+++ b/CleverTapSDK/InApps/InAppsScheduler/InAppScheduler.swift
@@ -48,26 +48,33 @@ import Foundation
                     newInApps.append(inApp)
                 }
             }
-            // Step 2: Prepare/store data using strategy
-            let prepared = self.storageStrategy?.prepareForScheduling(inApps: newInApps)
-            if !(prepared ?? false) {
-                CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "\(self.tag) Failed to prepare in-apps for scheduling")
-                for inApp in newInApps {
-                    guard let id = inApp[InAppDelayConstants.INAPP_ID_IN_PAYLOAD] as? String else { continue }
-                    let result = self.dataExtractor?.createErrorResult(id: id, message: "Preparation failed")
-                    onComplete(result)
-                }
-                return
-            }
-            // Step 3: Schedule timers for each in-app
+            // Step 2: Keep only the in-apps that will actually get a timer.
+            var schedulable: [(id: String, inApp: [String: Any], delay: TimeInterval)] = []
             for inApp in newInApps {
                 let inAppId = "\(inApp[InAppDelayConstants.INAPP_ID_IN_PAYLOAD] ?? "")"
                 guard !inAppId.isEmpty else { continue }
                 let delay = self.dataExtractor?.extractDelay(inApp: inApp) ?? 0
-                
-                if delay > 0 {
-                    self.scheduleWithTimer(id: inAppId, delay: delay, onComplete: onComplete)
+                guard delay > 0 else {
+                    CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "\(self.tag) Skipping in-app with non-positive delay: \(inAppId)")
+                    continue
                 }
+                schedulable.append((id: inAppId, inApp: inApp, delay: delay))
+            }
+            guard !schedulable.isEmpty else { return }
+
+            // Step 3: Prepare/store data using strategy
+            let prepared = self.storageStrategy?.prepareForScheduling(inApps: schedulable.map { $0.inApp })
+            if !(prepared ?? false) {
+                CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "\(self.tag) Failed to prepare in-apps for scheduling")
+                for entry in schedulable {
+                    let result = self.dataExtractor?.createErrorResult(id: entry.id, message: "Preparation failed")
+                    onComplete(result)
+                }
+                return
+            }
+            // Step 4: Schedule timers for each in-app
+            for entry in schedulable {
+                self.scheduleWithTimer(id: entry.id, delay: entry.delay, onComplete: onComplete)
             }
         }
     }

--- a/CleverTapSDK/InApps/InAppsScheduler/InAppSelectionStrategy.swift
+++ b/CleverTapSDK/InApps/InAppsScheduler/InAppSelectionStrategy.swift
@@ -81,29 +81,29 @@ public class DelayedInAppSelectionStrategy: NSObject, InAppSelectionStrategy {
     }
     
     public func selectInApps(_ sortedInApps: [NSDictionary], suppressionHandler: @escaping SuppressionHandler) -> [NSDictionary] {
-        var delayedInApps: [NSNumber: [NSDictionary]] = [:]
+        var delayedInApps: [Int: [NSDictionary]] = [:]
         for inApp in sortedInApps {
-            guard let inAppId = inApp[InAppDelayConstants.INAPP_ID_IN_PAYLOAD] as? NSNumber else {
+            guard let inAppId = inApp[InAppDelayConstants.INAPP_ID_IN_PAYLOAD], !"\(inAppId)".isEmpty else {
                 continue
             }
-            if delayedInApps[inAppId] == nil {
-                delayedInApps[inAppId] = []
-            }
-            delayedInApps[inAppId]?.append(inApp)
+            let delay = (inApp[InAppDelayConstants.INAPP_DELAY_AFTER_TRIGGER] as? NSNumber)?.intValue ?? 0
+            delayedInApps[delay, default: []].append(inApp)
         }
         var selectedInApps: [NSDictionary] = []
         CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Processing \(delayedInApps.count) delayed in-apps")
         // For each delay group, select first non-suppressed in-app
-        for (inAppId, inAppsWithSameDelay) in delayedInApps {
-            // Find first non-suppressed in-app
+        for (delay, inAppsWithSameDelay) in delayedInApps {
+            CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Processing \(inAppsWithSameDelay.count) in-apps with delay: \(delay)s")
+            // Find first non-suppressed in-app. suppressionHandler records the
+            // suppression as a side effect, so invoke it exactly once per in-app.
             let selectedInApp = inAppsWithSameDelay.first { inApp in
-                CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Delayed inApp suppressed: \(suppressionHandler(inApp))")
-                return !suppressionHandler(inApp)
+                let isSuppressed = suppressionHandler(inApp)
+                CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Delayed inApp suppressed: \(isSuppressed)")
+                return !isSuppressed
             }
             if let inApp = selectedInApp {
                 selectedInApps.append(inApp)
-                let inAppDelay = inApp[InAppDelayConstants.INAPP_DELAY_AFTER_TRIGGER] ?? 0
-                CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Selected in-app for delay \(inAppDelay)s: \(inAppId)")
+                CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Selected in-app for delay \(delay)s: \(inApp[InAppDelayConstants.INAPP_ID_IN_PAYLOAD] ?? "")")
             }
         }
         return selectedInApps

--- a/CleverTapSDK/InApps/InAppsScheduler/InAppTimerManager.swift
+++ b/CleverTapSDK/InApps/InAppsScheduler/InAppTimerManager.swift
@@ -22,7 +22,6 @@ private struct TimerData {
     
     // MARK: - Properties
     private let tagSuffix: String
-    private let queue = DispatchQueue(label: "com.clevertap.InAppTimerManager", attributes: .concurrent)
     private let workQueue = DispatchQueue(label: "com.clevertap.InAppTimerManager.work", attributes: .concurrent)
     
     private var activeJobs: [String: TimerData] = [:]
@@ -197,6 +196,7 @@ private struct TimerData {
         }
         // Now cancel all work items
         let jobsToCancel = activeJobs.values.map { $0.workItem }
+        activeJobs.removeAll()
         lock.unlock()
         for workItem in jobsToCancel {
             workItem.cancel()
@@ -233,10 +233,8 @@ private struct TimerData {
         lock.unlock()
         
         // Reschedule timers
-        var rescheduledCount = 0
         for data in toReschedule {
             scheduleTimer(id: data.id, delay: data.remainingTime, callback: data.callback)
-            rescheduledCount += 1
             CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "\(tag) Rescheduled \(data.id) with \(data.remainingTime)s remaining")
         }
         // Discard expired timers

--- a/CleverTapSDK/InApps/InAppsScheduler/InactionInAppStorageStrategy.swift
+++ b/CleverTapSDK/InApps/InAppsScheduler/InactionInAppStorageStrategy.swift
@@ -16,13 +16,11 @@ public class InactionInAppStorageStrategy:NSObject, InAppSchedulingStrategy {
     
     @objc public func prepareForScheduling(inApps: [[String : Any]]) -> Bool {
         CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Preparing \(inApps.count) in-actions inapps for scheduling")
-        var cachedIds: [String] = []
         var newEntries: [String: [String: Any]] = [:]
         for inApp in inApps {
             let inAppId = "\(inApp[InAppDelayConstants.INAPP_ID_IN_PAYLOAD] ?? "")"
             if !inAppId.isEmpty {
                 newEntries[inAppId] = inApp
-                cachedIds.append(inAppId)
             }
         }
         cacheQueue.sync(flags: .barrier) {
@@ -30,7 +28,7 @@ public class InactionInAppStorageStrategy:NSObject, InAppSchedulingStrategy {
                 inActionCache[inAppId] = inApp
             }
         }
-        CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Cached \(cachedIds.count) in-action inapps in memory")
+        CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Cached \(newEntries.count) in-action inapps in memory")
         return true
     }
     

--- a/CleverTapSDK/InApps/InAppsScheduler/InactionInAppStorageStrategy.swift
+++ b/CleverTapSDK/InApps/InAppsScheduler/InactionInAppStorageStrategy.swift
@@ -16,27 +16,28 @@ public class InactionInAppStorageStrategy:NSObject, InAppSchedulingStrategy {
     
     @objc public func prepareForScheduling(inApps: [[String : Any]]) -> Bool {
         CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Preparing \(inApps.count) in-actions inapps for scheduling")
-        var swiftInApps: [[String: Any]] = []
-        for i in 0..<inApps.count {
-            swiftInApps.append(inApps[i])
-        }
-        var cachedCount = 0
-        for inApp in swiftInApps {
+        var cachedIds: [String] = []
+        var newEntries: [String: [String: Any]] = [:]
+        for inApp in inApps {
             let inAppId = "\(inApp[InAppDelayConstants.INAPP_ID_IN_PAYLOAD] ?? "")"
             if !inAppId.isEmpty {
-                self.inActionCache[inAppId] = inApp
-                cachedCount += 1
-                CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Cached in-action inapp: \(inAppId)")
+                newEntries[inAppId] = inApp
+                cachedIds.append(inAppId)
             }
         }
-        CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Cached \(cachedCount) in-action inapps in memory")
+        cacheQueue.sync(flags: .barrier) {
+            for (inAppId, inApp) in newEntries {
+                inActionCache[inAppId] = inApp
+            }
+        }
+        CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Cached \(cachedIds.count) in-action inapps in memory")
         return true
     }
     
     @objc public func retrieveAfterTimer(id: String) -> [String : Any]? {
         var result: [String: Any]?
-        cacheQueue.sync {
-            result = inActionCache[id]
+        cacheQueue.sync(flags: .barrier) {
+            result = inActionCache.removeValue(forKey: id)
         }
         if result != nil {
             CTLogger.logWithLevel(CTLogger.getDebugLevel(), type: CTLogType.debug.rawValue, message: "Retrieved in-action inapps from cache: \(id)")

--- a/CleverTapSDK/Profile/CTProfileChangeTracker.m
+++ b/CleverTapSDK/Profile/CTProfileChangeTracker.m
@@ -129,11 +129,10 @@
     if (!oldValue) {
         return NO;
     }
-    BOOL didModify = NO;
+    NSUInteger beforeChangeCount = changes.count;
     if ([CTProfileOperationUtils isDeleteMarker:newValue]) {
-        // Delete this key entirely
+        // Delete this key entirely. deleteValue: refuses non-leaf values.
         [self deleteValue:target key:key value:oldValue path:currentPath changes:changes];
-        didModify = YES;
     }
     else if ([oldValue isKindOfClass:[NSDictionary class]] && [newValue isKindOfClass:[NSDictionary class]]) {
         NSMutableDictionary *mutableOldValue;
@@ -143,16 +142,11 @@
             mutableOldValue = [oldValue mutableCopy];
             target[key] = mutableOldValue;  // Replace immutable with mutable
         }
-        NSUInteger beforeCount = mutableOldValue.count;
         // Recurse into nested objects for deletion
         recursiveMerge(mutableOldValue, (NSDictionary *)newValue, currentPath, changes);
         // Remove the object if it's now empty
         if (mutableOldValue.count == 0) {
             [target removeObjectForKey:key];
-            didModify = YES;
-        }
-        else if (mutableOldValue.count != beforeCount) {
-            didModify = YES;
         }
     }
     else if ([oldValue isKindOfClass:[NSArray class]] && [newValue isKindOfClass:[NSArray class]]) {
@@ -163,28 +157,22 @@
             mutableOldValue = [oldValue mutableCopy];
             target[key] = mutableOldValue;  // Replace immutable with mutable
         }
-        NSUInteger beforeCount = mutableOldValue.count;
         // Handle array element deletions
         [self handleArrayDeletion:target key:key oldArray:mutableOldValue newArray:(NSArray *)newValue currentPath:currentPath changes:changes];
-        if (mutableOldValue.count != beforeCount) {
-            didModify = YES;
-        }
     }
-    return didModify;
+    return target[key] == nil || changes.count != beforeChangeCount;
 }
 
 - (void)handleArrayDeletion:(NSMutableDictionary *)parentJson key:(NSString *)key oldArray:(NSMutableArray *)oldArray newArray:(NSArray *)newArray currentPath:(NSString *)currentPath changes:(NSMutableDictionary<NSString *, NSDictionary *> *)changes {
     if ([newArray count] == 0) return;
     BOOL hasDeleteMarkers = [CTArrayMergeUtils hasDeleteMarkerElements:newArray];
     BOOL hasObjectsToDelete = [CTArrayMergeUtils hasJsonObjectElements:newArray];
-    if (hasDeleteMarkers) {
-        [self deleteArrayElements:parentJson key:key oldArray:oldArray newArray:newArray basePath:currentPath changes:changes];
-    }
-    else if (hasObjectsToDelete) {
+    if (hasDeleteMarkers || hasObjectsToDelete) {
         [self deleteFromArrayElements:oldArray newArray:newArray basePath:currentPath changes:changes];
-    } else {
-        [self deleteValue:parentJson key:key value:oldArray path:currentPath changes:changes];
+        return;
     }
+    // No per-index instruction, so the array itself is the value being removed.
+    [self deleteValue:parentJson key:key value:oldArray path:currentPath changes:changes];
 }
 
 - (void)deleteFromArrayElements:(NSMutableArray *)oldArray newArray:(NSArray *)newArray basePath:(NSString *)basePath changes:(NSMutableDictionary<NSString *, NSDictionary *> *)changes {
@@ -196,22 +184,36 @@
     for (NSUInteger i = 0; i < minLength; i++) {
         id oldElement = oldArray[i];
         id newElement = newArray[i];
-        if (![oldElement isKindOfClass:[NSDictionary class]] || ![oldElement isKindOfClass:[NSDictionary class]] || ![newElement isKindOfClass:[NSDictionary class]]) {
+        // A marker at this index removes the whole element.
+        if ([CTProfileOperationUtils isDeleteMarker:newElement]) {
+            // Check is needed since BE can only delete leaf nodes
+            if (![oldElement isKindOfClass:[NSDictionary class]] && ![oldElement isKindOfClass:[NSArray class]]) {
+                [indicesToRemove addObject:@(i)];
+                arrayModified = YES;
+            }
             continue;
         }
+        if (![oldElement isKindOfClass:[NSDictionary class]] || ![newElement isKindOfClass:[NSDictionary class]]) {
+            continue;
+        }
+        BOOL elementWasCopied = ![oldElement isKindOfClass:[NSMutableDictionary class]];
         NSMutableDictionary *oldDict =
-        [oldElement isKindOfClass:[NSMutableDictionary class]] ? (NSMutableDictionary *)oldElement : [oldElement mutableCopy];
+        elementWasCopied ? [oldElement mutableCopy] : (NSMutableDictionary *)oldElement;
         NSDictionary *newDict = (NSDictionary *)newElement;
+        NSMutableDictionary<NSString *, NSDictionary *> *elementChanges = [NSMutableDictionary dictionary];
         for (NSString *key in newDict) {
             id value = newDict[key];
-            [self handleDelete:oldDict key:key newValue:value currentPath:@"" changes:[NSMutableDictionary dictionary] recursiveMerge:^(NSMutableDictionary * _Nonnull target, NSDictionary * _Nullable source, NSString * _Nonnull path, NSMutableDictionary<NSString *,NSDictionary *> * _Nonnull changes) {
+            [self handleDelete:oldDict key:key newValue:value currentPath:key changes:elementChanges recursiveMerge:^(NSMutableDictionary * _Nonnull target, NSDictionary * _Nullable source, NSString * _Nonnull path, NSMutableDictionary<NSString *,NSDictionary *> * _Nonnull innerChanges) {
                 if (source != nil) {
-                    [self handleDeleteRecursive:target source:source];
+                    [self handleDeleteRecursive:target source:source path:path changes:innerChanges];
                 }
             }];
         }
+        if (elementWasCopied) {
+            oldArray[i] = oldDict;
+        }
         arrayModified = YES;
-        // Remove empty dictionaries
+        // Mark for removal if empty
         if (oldDict.count == 0) {
             [indicesToRemove addObject:@(i)];
         }
@@ -230,50 +232,15 @@
     }
 }
 
-- (void)handleDeleteRecursive:(NSMutableDictionary *)target source:(NSDictionary *)source {
+- (void)handleDeleteRecursive:(NSMutableDictionary *)target source:(NSDictionary *)source path:(NSString *)path changes:(NSMutableDictionary<NSString *, NSDictionary *> *)changes {
     for (NSString *key in source) {
         id newValue = source[key];
-        [self handleDelete:target key:key newValue:newValue currentPath:@"" changes:[NSMutableDictionary dictionary] recursiveMerge:^(NSMutableDictionary * _Nonnull target, NSDictionary * _Nullable source, NSString * _Nonnull path, NSMutableDictionary<NSString *,NSDictionary *> * _Nonnull changes) {
-            [self handleDeleteRecursive:target source:source];
+        NSString *currentPath = path.length == 0 ? key : [NSString stringWithFormat:@"%@.%@", path, key];
+        [self handleDelete:target key:key newValue:newValue currentPath:currentPath changes:changes recursiveMerge:^(NSMutableDictionary * _Nonnull innerTarget, NSDictionary * _Nullable innerSource, NSString * _Nonnull innerPath, NSMutableDictionary<NSString *,NSDictionary *> * _Nonnull innerChanges) {
+            if (innerSource != nil) {
+                [self handleDeleteRecursive:innerTarget source:innerSource path:innerPath changes:innerChanges];
+            }
         }];
-    }
-}
-
-- (void)deleteArrayElements:(NSMutableDictionary *)parentJson key:(NSString *)key oldArray:(NSMutableArray *)oldArray newArray:(NSArray *)newArray basePath:(NSString *)basePath changes:(NSMutableDictionary<NSString *, NSDictionary *> *)changes {
-    NSMutableArray *indicesToDelete = [NSMutableArray array];
-    // Collect indices to delete
-    for (NSInteger i = 0; i < [newArray count]; i++) {
-        if ([CTProfileOperationUtils isDeleteMarker:newArray[i]] && i < [oldArray count]) {
-            [indicesToDelete addObject:@(i)];
-        }
-    }
-    if ([indicesToDelete count] == 0) return;
-    NSArray *oldArrayCopy = [CTArrayMergeUtils copyArray:oldArray];
-    NSMutableArray *mutableOldArray = [oldArray mutableCopy];
-    BOOL removedAny = NO;
-    // Sort indices in descending order to maintain correct indices during deletion
-    NSArray *sortedIndices = [indicesToDelete sortedArrayUsingComparator:^NSComparisonResult(NSNumber *obj1, NSNumber *obj2) {
-        return [obj2 compare:obj1]; // Descending order
-    }];
-    // Delete in reverse order to maintain correct indices
-    for (NSNumber *indexNum in sortedIndices) {
-        NSInteger index = [indexNum integerValue];
-        id oldElement = [oldArray objectAtIndex:index];
-        // Check is needed since BE can only delete leaf nodes
-        if (![oldElement isKindOfClass:[NSDictionary class]] && ![oldElement isKindOfClass:[NSArray class]]) {
-            [mutableOldArray removeObjectAtIndex:index];
-            removedAny = YES;
-        }
-    }
-    // Only report changes if we actually removed something
-    if (removedAny) {
-        [parentJson setObject:mutableOldArray forKey:key];
-        NSDictionary *change = @{
-            @"oldValue": oldArrayCopy,
-            @"newValue": mutableOldArray
-        };
-        [changes setObject:change forKey:basePath];
-        [self.changeTracker recordChange:basePath oldValue:oldArrayCopy newValue:mutableOldArray changes:changes];
     }
 }
 
@@ -544,16 +511,6 @@
     }
 }
 
-- (BOOL)handleOutOfBoundsIndex:(NSMutableArray *)oldArray newArray:(NSArray *)newArray index:(NSInteger)index operation:(CTProfileOperation)operation {
-    if (operation != CTProfileOperationSet) return NO;
-    id newElement = newArray[index];
-    while ([oldArray count] <= index) {
-        [oldArray addObject:[NSNull null]];
-    }
-    oldArray[index] = newElement;
-    return YES;
-}
-
 - (NSNumber *)applyNumberOperation:(NSNumber *)oldValue newValue:(NSNumber *)newValue operation:(CTProfileOperation)operation {
     switch (operation) {
         case CTProfileOperationIncrement:
@@ -644,10 +601,40 @@
 }
 @end
 
+/**
+ * Recursively rebuilds nested collections as mutable containers.
+ * Since CTLocalDataStore stores profiles with mutable containers at every level, each
+ * level must be copied.
+ * Leaf values are returned as-is since they are never mutated.
+ */
+static id CTDeepCopyOfValue(id value) {
+    if ([value isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *source = (NSDictionary *)value;
+        NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:source.count];
+        for (id key in source) {
+            result[key] = CTDeepCopyOfValue(source[key]);
+        }
+        return [result copy];
+    }
+    if ([value isKindOfClass:[NSArray class]]) {
+        NSArray *source = (NSArray *)value;
+        NSMutableArray *result = [NSMutableArray arrayWithCapacity:source.count];
+        for (id item in source) {
+            [result addObject:CTDeepCopyOfValue(item)];
+        }
+        return [result copy];
+    }
+    return value;
+}
+
 @implementation CTArrayMergeUtils
 
 + (NSArray *)copyArray:(NSArray *)array {
-    return [[NSArray alloc] initWithArray:array copyItems:YES];
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:array.count];
+    for (id item in array) {
+        [result addObject:CTDeepCopyOfValue(item)];
+    }
+    return [result copy];
 }
 
 + (BOOL)hasDeleteMarkerElements:(NSArray *)array {

--- a/CleverTapSDK/Validation/CTNestedJsonBuilder.m
+++ b/CleverTapSDK/Validation/CTNestedJsonBuilder.m
@@ -142,7 +142,6 @@ static NSRegularExpression *arrayIndexPattern;
             if (isLastSegment) {
                 dict[segment.key] = [self convertValue:value];
             } else {
-                CTPathSegment *nextSegment = segments[index + 1];
                 NSMutableDictionary *nested = dict[segment.key];
                 
                 if (![nested isKindOfClass:[NSMutableDictionary class]]) {

--- a/CleverTapSDK/Validation/CTNestedJsonBuilder.m
+++ b/CleverTapSDK/Validation/CTNestedJsonBuilder.m
@@ -198,9 +198,6 @@ static NSRegularExpression *arrayIndexPattern;
     if (value == nil) {
         return [NSNull null];
     }
-    if ([value isKindOfClass:[NSDictionary class]] || [value isKindOfClass:[NSArray class]]) {
-        return value;
-    }
     if ([value isKindOfClass:[NSDictionary class]]) {
         NSDictionary *dict = (NSDictionary *)value;
         NSMutableDictionary *result = [NSMutableDictionary dictionary];
@@ -209,7 +206,7 @@ static NSRegularExpression *arrayIndexPattern;
         }
         return result;
     }
-        if ([value isKindOfClass:[NSArray class]]) {
+    if ([value isKindOfClass:[NSArray class]]) {
         NSArray *array = (NSArray *)value;
         NSMutableArray *result = [NSMutableArray array];
         for (id item in array) {

--- a/CleverTapSDKTests/CTFlattenedEventDataTest.m
+++ b/CleverTapSDKTests/CTFlattenedEventDataTest.m
@@ -62,20 +62,4 @@
     XCTAssertEqual(first, second);
 }
 
-#pragma mark - isNoData
-
-- (void)test_isNoData_returnsTrueForNoData {
-    XCTAssertTrue([[CTFlattenedEventData noData] isNoData]);
-}
-
-- (void)test_isNoData_returnsFalseForProfileChanges {
-    CTFlattenedEventData *event = [CTFlattenedEventData profileChanges:@{}];
-    XCTAssertFalse([event isNoData]);
-}
-
-- (void)test_isNoData_returnsFalseForEventProperties {
-    CTFlattenedEventData *event = [CTFlattenedEventData eventProperties:@{}];
-    XCTAssertFalse([event isNoData]);
-}
-
 @end

--- a/CleverTapSDKTests/CTLocalDataStore+Tests.h
+++ b/CleverTapSDKTests/CTLocalDataStore+Tests.h
@@ -11,5 +11,8 @@
 @interface CTLocalDataStore (Tests)
 - (void)runOnBackgroundQueue:(void (^)(void))taskBlock;
 @property (nonatomic, readonly) dispatch_queue_t backgroundQueue;
+
+// Exposed so a test can clear the persisted profile between cases.
+- (NSString *)profileFileName;
 @end
 

--- a/CleverTapSDKTests/CTNestedJsonBuilderTest.m
+++ b/CleverTapSDKTests/CTNestedJsonBuilderTest.m
@@ -106,4 +106,40 @@
     XCTAssertEqualObjects(result[@""], @1);
 }
 
+#pragma mark - Collection values (recursive conversion)
+
+- (void)test_buildFromPath_dictionaryValue_isConvertedRecursively {
+    NSDictionary *nested = @{ @"inner": @[@1, @2], @"name": @"x" };
+    NSDictionary *result = [self.builder buildFromPath:@"outer" value:nested];
+
+    NSDictionary *outer = result[@"outer"];
+    XCTAssertEqualObjects(outer[@"name"], @"x");
+    XCTAssertEqualObjects(outer[@"inner"], (@[@1, @2]));
+    // The value is rebuilt into fresh mutable containers all the way down,
+    // not handed back by reference.
+    XCTAssertTrue([outer isKindOfClass:[NSMutableDictionary class]]);
+    XCTAssertTrue([outer[@"inner"] isKindOfClass:[NSMutableArray class]]);
+}
+
+- (void)test_buildFromPath_arrayValue_isConvertedRecursively {
+    NSArray *value = @[@{ @"k": @"v" }, @5];
+    NSDictionary *result = [self.builder buildFromPath:@"list" value:value];
+
+    NSArray *list = result[@"list"];
+    XCTAssertEqual(list.count, 2u);
+    XCTAssertTrue([list isKindOfClass:[NSMutableArray class]]);
+    NSDictionary *first = list[0];
+    XCTAssertEqualObjects(first[@"k"], @"v");
+    XCTAssertTrue([first isKindOfClass:[NSMutableDictionary class]]);
+}
+
+- (void)test_buildFromPath_collectionWithNSNull_preservesNSNull {
+    NSArray *value = @[[NSNull null], @1];
+    NSDictionary *result = [self.builder buildFromPath:@"list" value:value];
+
+    NSArray *list = result[@"list"];
+    XCTAssertEqualObjects(list[0], [NSNull null]);
+    XCTAssertEqualObjects(list[1], @1);
+}
+
 @end

--- a/CleverTapSDKTests/CTProfileDeleteOperationTests.m
+++ b/CleverTapSDKTests/CTProfileDeleteOperationTests.m
@@ -1,0 +1,127 @@
+//
+//  CTProfileDeleteOperationTests.m
+//  CleverTapSDKTests
+//
+//  Covers CTDeleteOperationHandler's handling of deletes that target a field inside an
+//  array element - the path exercised by profileRemoveValueForKey with an "items[0].key"
+//  style path.
+//
+//  CTProfileChangeTrackerTest only exercises the utility classes (CTArrayMergeUtils,
+//  CTJsonComparisonUtils, CTNumberOperationUtils, CTProfileOperationUtils), so the
+//  delete handler itself had no coverage before this.
+//
+
+#import <XCTest/XCTest.h>
+#import "CTLocalDataStore.h"
+#import "CTLocalDataStore+Tests.h"
+#import "CTPreferences.h"
+#import "CTConstants.h"
+#import "CleverTapInstanceConfig.h"
+#import "CTDeviceInfo.h"
+#import "CTDispatchQueueManager.h"
+
+@interface CTProfileDeleteOperationTests : XCTestCase
+@property (nonatomic, strong) CleverTapInstanceConfig *config;
+@property (nonatomic, strong) CTLocalDataStore *dataStore;
+@end
+
+@implementation CTProfileDeleteOperationTests
+
+- (void)setUp {
+    [super setUp];
+    // Each test gets its own accountId, so each gets its own profileFileName. Without
+    // this the tests share one file on disk and the async persistence kicked off by
+    // setProfileFieldWithKey: races tearDown's file removal and the next test's archive.
+    NSString *uniqueAccountId = [NSString stringWithFormat:@"profileDelete%@",
+                                 [[[NSUUID UUID] UUIDString] stringByReplacingOccurrencesOfString:@"-" withString:@""]];
+    self.config = [[CleverTapInstanceConfig alloc] initWithAccountId:uniqueAccountId
+                                                        accountToken:@"testToken"
+                                                       accountRegion:@"testRegion"];
+    CTDeviceInfo *deviceInfo = [[CTDeviceInfo alloc] initWithConfig:self.config andCleverTapID:@"profileDeleteDevice"];
+    CTDispatchQueueManager *queueManager = [[CTDispatchQueueManager alloc] initWithConfig:self.config];
+    self.dataStore = [[CTLocalDataStore alloc] initWithConfig:self.config
+                                               profileValues:[NSMutableDictionary new]
+                                               andDeviceInfo:deviceInfo
+                                        dispatchQueueManager:queueManager];
+}
+
+- (void)tearDown {
+    // Let any in-flight background persistence finish before removing the file,
+    // otherwise the write races the delete.
+    [self drainBackgroundQueue];
+    [CTPreferences unarchiveFromFile:[self.dataStore profileFileName]
+                             ofTypes:[NSSet setWithObject:[NSDictionary class]]
+                          removeFile:YES];
+    self.dataStore = nil;
+    self.config = nil;
+    [super tearDown];
+}
+
+- (void)drainBackgroundQueue {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Drain datastore background queue"];
+    dispatch_async(self.dataStore.backgroundQueue, ^{
+        [self.dataStore runOnBackgroundQueue:^{
+            [expectation fulfill];
+        }];
+    });
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+#pragma mark - Deleting a field inside an array element
+
+- (void)test_deleteFieldFromArrayElement_appliesAndRecordsChange {
+    [self drainBackgroundQueue];
+
+    [self.dataStore setProfileFieldWithKey:@"items" andValue:@[ @{ @"a": @1, @"b": @2 } ]];
+
+    NSDictionary *changes = [self.dataStore processProfileTree:@"items[0].a"
+                                                         value:kCLTAP_DELETE_MARKER
+                                                       command:CTProfileOperationDelete];
+
+    NSArray *stored = [self.dataStore getProfileFieldForKey:@"items"];
+    XCTAssertEqual(stored.count, 1u, @"The element itself must survive a field level delete");
+    XCTAssertNil(stored[0][@"a"], @"'a' should have been deleted from the array element");
+    XCTAssertEqualObjects(stored[0][@"b"], @2, @"Sibling keys must be untouched");
+    XCTAssertGreaterThan(changes.count, 0u, @"A real deletion must be recorded");
+}
+
+// The next two pin deliberate Android parity rather than ideal behaviour. Android's
+// DeleteOperationHandler.deleteFromArrayElements sets arrayModified unconditionally once
+// it enters the object/object branch, so a no-op or refused delete still reports an
+// array level change. iOS matches that on purpose. If Android is ever fixed, these two
+// expectations flip on both platforms together.
+
+- (void)test_deleteAbsentFieldFromArrayElement_leavesDataIntact {
+    [self drainBackgroundQueue];
+
+    [self.dataStore setProfileFieldWithKey:@"items" andValue:@[ @{ @"a": @1 } ]];
+
+    NSDictionary *changes = [self.dataStore processProfileTree:@"items[0].doesNotExist"
+                                                         value:kCLTAP_DELETE_MARKER
+                                                       command:CTProfileOperationDelete];
+
+    NSArray *stored = [self.dataStore getProfileFieldForKey:@"items"];
+    XCTAssertEqual(stored.count, 1u, @"The element must survive");
+    XCTAssertEqualObjects(stored[0][@"a"], @1, @"Nothing should have been removed");
+    XCTAssertGreaterThan(changes.count, 0u,
+                         @"Android parity: a no-op delete still records an array level change");
+}
+
+- (void)test_deleteNonLeafFieldFromArrayElement_isRefused {
+    [self drainBackgroundQueue];
+
+    [self.dataStore setProfileFieldWithKey:@"items" andValue:@[ @{ @"nested": @{ @"x": @1 } } ]];
+
+    NSDictionary *changes = [self.dataStore processProfileTree:@"items[0].nested"
+                                                         value:kCLTAP_DELETE_MARKER
+                                                       command:CTProfileOperationDelete];
+
+    NSArray *stored = [self.dataStore getProfileFieldForKey:@"items"];
+    XCTAssertNotNil(stored[0][@"nested"],
+                    @"deleteValue: refuses non leaf values, the backend can only delete leaves");
+    XCTAssertEqualObjects(stored[0][@"nested"][@"x"], @1, @"The nested object must be untouched");
+    XCTAssertGreaterThan(changes.count, 0u,
+                         @"Android parity: a refused delete still records an array level change");
+}
+
+@end

--- a/CleverTapSDKTests/CleverTap+Tests.h
+++ b/CleverTapSDKTests/CleverTap+Tests.h
@@ -7,6 +7,8 @@
 #import "CTDomainFactory.h"
 #import "CTQueueType.h"
 
+@class CTFlattenedEventData;
+
 @interface CleverTap (Tests)
 
 @property (nonatomic, strong) CTDeviceInfo * deviceInfo;
@@ -28,6 +30,7 @@
 - (NSDictionary *)getBatchHeader;
 - (void)pushValidationResults:(NSArray<CTValidationResult *> * _Nonnull )results;
 - (void)queueEvent:(NSDictionary *)event withType:(CleverTapEventType)type;
+- (void)evaluateOnEvent:(NSDictionary *)event withType:(CleverTapEventType)eventType flattenedEventData:(CTFlattenedEventData *)flattenedEventData;
 - (void)setUserSetLocation:(CLLocationCoordinate2D)location;
 + (BOOL)isPersonalizationEnabled;
 - (id)getProperty:(NSString *)propertyName;

--- a/CleverTapSDKTests/CleverTap+Tests.h
+++ b/CleverTapSDKTests/CleverTap+Tests.h
@@ -30,6 +30,7 @@
 - (NSDictionary *)getBatchHeader;
 - (void)pushValidationResults:(NSArray<CTValidationResult *> * _Nonnull )results;
 - (void)queueEvent:(NSDictionary *)event withType:(CleverTapEventType)type;
+- (void)queueEvent:(NSDictionary *)event withType:(CleverTapEventType)type flattenedEventData:(CTFlattenedEventData *)flattenedEventData;
 - (void)evaluateOnEvent:(NSDictionary *)event withType:(CleverTapEventType)eventType flattenedEventData:(CTFlattenedEventData *)flattenedEventData;
 - (void)setUserSetLocation:(CLLocationCoordinate2D)location;
 + (BOOL)isPersonalizationEnabled;

--- a/CleverTapSDKTests/CleverTapInstanceTests.m
+++ b/CleverTapSDKTests/CleverTapInstanceTests.m
@@ -2472,6 +2472,38 @@
     [mockEvaluationManager stopMocking];
 }
 
+// When a custom event property has the same name as an app field, the event
+// property wins. The fix adds event properties after app fields, honouring the
+// "event properties last, so custom properties are not overriden" contract.
+- (void)test_customEvent_evaluation_customProperty_overrides_app_field {
+    CTInAppEvaluationManager *evaluationManager = self.cleverTapInstance.inAppEvaluationManager;
+    XCTAssertNotNil(evaluationManager);
+    id mockEvaluationManager = OCMPartialMock(evaluationManager);
+
+    NSString *eventName = @"AppFieldSameNameEvent";
+    // SDK Version is always set by generateAppFields (as a number). Send an
+    // event property with the same key but a distinct sentinel value.
+    NSString *sentinel = @"custom-sdk-version-sentinel";
+    NSDictionary *props = @{ CLTAP_SDK_VERSION: sentinel, @"Prop1": @"Value1" };
+    NSDictionary *event = @{
+        CLTAP_EVENT_NAME: eventName,
+        CLTAP_EVENT_DATA: props
+    };
+    CTFlattenedEventData *flattened = [CTFlattenedEventData eventProperties:props];
+
+    OCMExpect([mockEvaluationManager evaluateOnEvent:eventName withProps:[OCMArg checkWithBlock:^BOOL(NSDictionary *evaluatedProps) {
+        // When the names are the same, the custom value wins over the app field.
+        return [evaluatedProps[CLTAP_SDK_VERSION] isEqual:sentinel] && [evaluatedProps[@"Prop1"] isEqual:@"Value1"];
+    }]]);
+
+    [self.cleverTapInstance evaluateOnEvent:event
+                                   withType:CleverTapEventTypeRaised
+                         flattenedEventData:flattened];
+
+    OCMVerifyAll(mockEvaluationManager);
+    [mockEvaluationManager stopMocking];
+}
+
 #pragma mark - Profile Evaluation Input Shape
 
 // Profile attribute changes must use only flattened profile changes.

--- a/CleverTapSDKTests/CleverTapInstanceTests.m
+++ b/CleverTapSDKTests/CleverTapInstanceTests.m
@@ -17,6 +17,14 @@
 #import "CTConstants.h"
 #import "CTFlattenedEventData.h"
 #import "CTInAppEvaluationManager.h"
+#import "CTInAppDisplayManager.h"
+#import "CleverTapInternal.h"
+#import "CTMultiDelegateManager.h"
+#if __has_include(<CleverTapSDK/CleverTapSDK-Swift.h>)
+#import <CleverTapSDK/CleverTapSDK-Swift.h>
+#else
+#import "CleverTapSDK-Swift.h"
+#endif
 #import "CTValidationConfig.h"
 #import "CleverTapUTMDetail.h"
 #import <CleverTapSDK/CleverTapSyncDelegate.h>
@@ -2502,6 +2510,36 @@
 
     OCMVerifyAll(mockEvaluationManager);
     [mockEvaluationManager stopMocking];
+}
+
+#pragma mark - Switch User In-App Scheduler Cancellation
+
+// A delayed or inaction in-app scheduled for one user must not fire for the
+// next. On a user switch the display manager, registered as a switch-user
+// delegate, cancels both schedulers before the device id changes.
+- (void)test_deviceIdWillChange_cancels_delayed_and_inaction_schedulers {
+    CTInAppDisplayManager *displayManager = self.cleverTapInstance.inAppDisplayManager;
+    XCTAssertNotNil(displayManager);
+
+    id delayScheduler = [displayManager valueForKey:@"inAppDelayManager"];
+    id inActionScheduler = [displayManager valueForKey:@"inAppInActionManager"];
+    XCTAssertNotNil(delayScheduler);
+    XCTAssertNotNil(inActionScheduler);
+
+    id mockDelay = OCMPartialMock(delayScheduler);
+    id mockInAction = OCMPartialMock(inActionScheduler);
+    OCMExpect([mockDelay cancelAllSchedulingWithCompletion:[OCMArg any]]);
+    OCMExpect([mockInAction cancelAllSchedulingWithCompletion:[OCMArg any]]);
+
+    // Broadcasting through the real delegate manager also proves the display
+    // manager is registered as a switch-user delegate.
+    CTMultiDelegateManager *delegateManager = [self.cleverTapInstance valueForKey:@"delegateManager"];
+    [delegateManager notifyDelegatesDeviceIdWillChange];
+
+    OCMVerifyAll(mockDelay);
+    OCMVerifyAll(mockInAction);
+    [mockDelay stopMocking];
+    [mockInAction stopMocking];
 }
 
 #pragma mark - Profile Evaluation Input Shape

--- a/CleverTapSDKTests/CleverTapInstanceTests.m
+++ b/CleverTapSDKTests/CleverTapInstanceTests.m
@@ -15,6 +15,8 @@
 #import "CleverTap+Tests.h"
 #import <OCMock/OCMock.h>
 #import "CTConstants.h"
+#import "CTFlattenedEventData.h"
+#import "CTInAppEvaluationManager.h"
 #import "CTValidationConfig.h"
 #import "CleverTapUTMDetail.h"
 #import <CleverTapSDK/CleverTapSyncDelegate.h>
@@ -2439,6 +2441,105 @@
     NSString *ctid = [self.cleverTapInstance profileGetCleverTapID];
     XCTAssertGreaterThan(ctid.length, 0U,
                          @"profileGetCleverTapID should return a non-empty string");
+}
+
+#pragma mark - App Fields In Event Evaluation
+
+// A custom event must be evaluated against app fields merged with the event's
+// own properties, not the event properties alone.
+- (void)test_customEvent_evaluation_includes_app_fields {
+    CTInAppEvaluationManager *evaluationManager = self.cleverTapInstance.inAppEvaluationManager;
+    XCTAssertNotNil(evaluationManager);
+    id mockEvaluationManager = OCMPartialMock(evaluationManager);
+
+    NSString *eventName = @"AppFieldsMergeEvent";
+    NSDictionary *event = @{
+        CLTAP_EVENT_NAME: eventName,
+        CLTAP_EVENT_DATA: @{@"Prop1": @"Value1"}
+    };
+    CTFlattenedEventData *flattened = [CTFlattenedEventData eventProperties:@{@"Prop1": @"Value1"}];
+
+    OCMExpect([mockEvaluationManager evaluateOnEvent:eventName withProps:[OCMArg checkWithBlock:^BOOL(NSDictionary *props) {
+        // SDK Version is always populated by generateAppFields.
+        return props[CLTAP_SDK_VERSION] != nil && [props[@"Prop1"] isEqual:@"Value1"];
+    }]]);
+
+    [self.cleverTapInstance evaluateOnEvent:event
+                                   withType:CleverTapEventTypeRaised
+                         flattenedEventData:flattened];
+
+    OCMVerifyAll(mockEvaluationManager);
+    [mockEvaluationManager stopMocking];
+}
+
+#pragma mark - Profile Evaluation Input Shape
+
+// Profile attribute changes must use only flattened profile changes.
+// Merging app fields introduces bare values where {oldValue, newValue}
+// dictionaries are expected, causing toNestedMap: to subscript a string.
+- (void)test_profileEvent_evaluation_passes_flattened_profile_changes_only {
+    CTInAppEvaluationManager *evaluationManager = self.cleverTapInstance.inAppEvaluationManager;
+    XCTAssertNotNil(evaluationManager);
+    id mockEvaluationManager = OCMPartialMock(evaluationManager);
+
+    NSDictionary *profileChanges = @{
+        @"Customer Type": @{@"oldValue": @"Premium", @"newValue": @"Gold"}
+    };
+    NSDictionary *event = @{@"profile": @{@"Customer Type": @"Gold"}};
+    CTFlattenedEventData *flattened = [CTFlattenedEventData profileChanges:profileChanges];
+
+    OCMExpect([mockEvaluationManager evaluateOnUserAttributeChange:[OCMArg checkWithBlock:^BOOL(NSDictionary *changes) {
+        // No app field may leak into the outer map.
+        if (changes[CLTAP_SDK_VERSION] != nil || changes[CLTAP_APP_VERSION] != nil) {
+            return NO;
+        }
+        // Every value must still be a change dictionary.
+        for (id value in [changes allValues]) {
+            if (![value isKindOfClass:[NSDictionary class]]) {
+                return NO;
+            }
+        }
+        return [changes isEqualToDictionary:profileChanges];
+    }]]);
+
+    [self.cleverTapInstance evaluateOnEvent:event
+                                   withType:CleverTapEventTypeProfile
+                         flattenedEventData:flattened];
+
+    OCMVerifyAll(mockEvaluationManager);
+    [mockEvaluationManager stopMocking];
+}
+
+#pragma mark - Charged Event Evaluation Contract
+
+// Locks down the current contract: app fields + charge details form the
+// details map, while items are passed separately.
+- (void)test_chargedEvent_evaluation_includes_app_fields_and_charge_details {
+    CTInAppEvaluationManager *evaluationManager = self.cleverTapInstance.inAppEvaluationManager;
+    XCTAssertNotNil(evaluationManager);
+    id mockEvaluationManager = OCMPartialMock(evaluationManager);
+
+    NSArray *items = @[@{@"Category": @"Books"}];
+    NSDictionary *event = @{
+        CLTAP_EVENT_NAME: CLTAP_CHARGED_EVENT,
+        CLTAP_EVENT_DATA: @{
+            @"Amount": @50,
+            CLTAP_CHARGED_EVENT_ITEMS: items
+        }
+    };
+
+    OCMExpect([mockEvaluationManager evaluateOnChargedEvent:[OCMArg checkWithBlock:^BOOL(NSDictionary *details) {
+        return details[CLTAP_SDK_VERSION] != nil && [details[@"Amount"] isEqual:@50];
+    }] andItems:[OCMArg checkWithBlock:^BOOL(NSArray *actualItems) {
+        return [actualItems isEqualToArray:items];
+    }]]);
+
+    [self.cleverTapInstance evaluateOnEvent:event
+                                   withType:CleverTapEventTypeRaised
+                         flattenedEventData:[CTFlattenedEventData noData]];
+
+    OCMVerifyAll(mockEvaluationManager);
+    [mockEvaluationManager stopMocking];
 }
 
 @end

--- a/CleverTapSDKTests/CleverTapInstanceTests.m
+++ b/CleverTapSDKTests/CleverTapInstanceTests.m
@@ -2612,4 +2612,108 @@
     [mockEvaluationManager stopMocking];
 }
 
+
+#pragma mark - Event Evaluation Property Plumbing
+
+// Push and in-app Notification Clicked/Viewed, inbox, display unit and geofence
+// events are queued through the 2-arg `queueEvent:withType:`. That convenience must
+// flatten the event's own data rather than passing `noData`, otherwise wzrk_id /
+// wzrk_pivot never reach the trigger matcher and campaign-id and variant targeting
+// cannot match. These first three tests pin that guarantee at the producer.
+
+- (void)test_queueEvent_suppliesFlattenedEventData_notNoData {
+    id mockInstance = OCMPartialMock(self.cleverTapInstance);
+
+    NSDictionary *event = @{
+        CLTAP_EVENT_NAME: CLTAP_NOTIFICATION_CLICKED_EVENT_NAME,
+        CLTAP_EVENT_DATA: @{
+            @"wzrk_id": @"1699999999_20240101",
+            @"wzrk_pivot": @"variant_a"
+        }
+    };
+
+    OCMExpect([mockInstance queueEvent:event
+                              withType:CleverTapEventTypeRaised
+                    flattenedEventData:[OCMArg checkWithBlock:^BOOL(CTFlattenedEventData *data) {
+        NSDictionary *props = data.eventProperties;
+        return props != nil
+            && [props[@"wzrk_id"] isEqual:@"1699999999_20240101"]
+            && [props[@"wzrk_pivot"] isEqual:@"variant_a"];
+    }]]);
+
+    [self.cleverTapInstance queueEvent:event withType:CleverTapEventTypeRaised];
+
+    OCMVerifyAll(mockInstance);
+    [mockInstance stopMocking];
+}
+
+// Nested event properties are flattened to dot-notation on the way in, so nested
+// targeting works and the shape matches `recordEvent:withProps:` and Android.
+- (void)test_queueEvent_flattensNestedEventProps {
+    id mockInstance = OCMPartialMock(self.cleverTapInstance);
+
+    NSDictionary *event = @{
+        CLTAP_EVENT_NAME: @"NestedPropsEvent",
+        CLTAP_EVENT_DATA: @{ @"details": @{ @"traits": @{ @"items": @{ @"x": @1 } } } }
+    };
+
+    OCMExpect([mockInstance queueEvent:event
+                              withType:CleverTapEventTypeRaised
+                    flattenedEventData:[OCMArg checkWithBlock:^BOOL(CTFlattenedEventData *data) {
+        return [data.eventProperties[@"details.traits.items.x"] isEqual:@1];
+    }]]);
+
+    [self.cleverTapInstance queueEvent:event withType:CleverTapEventTypeRaised];
+
+    OCMVerifyAll(mockInstance);
+    [mockInstance stopMocking];
+}
+
+// `recordEvent:` with no properties builds an event without an `evtData` key. That
+// must still produce an (empty) property set rather than no-data, so the event stays
+// evaluable against the app fields.
+- (void)test_queueEvent_withoutEventData_suppliesEmptyProperties {
+    id mockInstance = OCMPartialMock(self.cleverTapInstance);
+
+    NSDictionary *event = @{ CLTAP_EVENT_NAME: @"NoPropsEvent" };
+
+    OCMExpect([mockInstance queueEvent:event
+                              withType:CleverTapEventTypeRaised
+                    flattenedEventData:[OCMArg checkWithBlock:^BOOL(CTFlattenedEventData *data) {
+        return data.eventProperties != nil && data.eventProperties.count == 0;
+    }]]);
+
+    XCTAssertNoThrow([self.cleverTapInstance queueEvent:event withType:CleverTapEventTypeRaised]);
+
+    OCMVerifyAll(mockInstance);
+    [mockInstance stopMocking];
+}
+
+// The supplied flattened properties are the source of truth - the raw event data is
+// never re-read on top of them. The existing app-field tests above use the same value
+// in both places, so this is the only case that can tell the two apart.
+- (void)test_suppliedFlattenedProps_are_not_overridden_by_raw_event_data {
+    CTInAppEvaluationManager *evaluationManager = self.cleverTapInstance.inAppEvaluationManager;
+    XCTAssertNotNil(evaluationManager);
+    id mockEvaluationManager = OCMPartialMock(evaluationManager);
+
+    NSString *eventName = @"SuppliedFlattenedEvent";
+    NSDictionary *event = @{
+        CLTAP_EVENT_NAME: eventName,
+        CLTAP_EVENT_DATA: @{ @"Prop1": @"raw" }
+    };
+    CTFlattenedEventData *flattened = [CTFlattenedEventData eventProperties:@{ @"Prop1": @"flattened" }];
+
+    OCMExpect([mockEvaluationManager evaluateOnEvent:eventName withProps:[OCMArg checkWithBlock:^BOOL(NSDictionary *props) {
+        return [props[@"Prop1"] isEqual:@"flattened"];
+    }]]);
+
+    [self.cleverTapInstance evaluateOnEvent:event
+                                   withType:CleverTapEventTypeRaised
+                         flattenedEventData:flattened];
+
+    OCMVerifyAll(mockEvaluationManager);
+    [mockEvaluationManager stopMocking];
+}
+
 @end

--- a/CleverTapSDKTests/InAppSchedulerTests.swift
+++ b/CleverTapSDKTests/InAppSchedulerTests.swift
@@ -147,6 +147,22 @@ class InAppSchedulerTests: XCTestCase {
 
     // MARK: - Timer completion
 
+    // MARK: - Cancel all scheduling
+
+    // On a user switch the schedulers are told to cancel everything, so a timer
+    // set up for the previous user can't fire for the next one.
+    func testCancelAllScheduling_cancelsActiveTimers() {
+        timerManager.scheduleTimer(id: "10", delay: 60) { _ in }
+        timerManager.scheduleTimer(id: "20", delay: 60) { _ in }
+        XCTAssertEqual(timerManager.getActiveTimerCount(), 2)
+
+        let cancelled = expectation(description: "cancelled")
+        scheduler.cancelAllScheduling { cancelled.fulfill() }
+        waitForExpectations(timeout: 2)
+
+        XCTAssertEqual(timerManager.getActiveTimerCount(), 0)
+    }
+
     func testSchedule_timerFires_invokesCallbackWithErrorWhenDataMissing() {
         // retrieveAfterTimer returns nil in the stub, so the success path reports
         // "Data not found" rather than silently dropping the callback.

--- a/CleverTapSDKTests/InAppSchedulerTests.swift
+++ b/CleverTapSDKTests/InAppSchedulerTests.swift
@@ -1,0 +1,163 @@
+//
+//  InAppSchedulerTests.swift
+//  CleverTapSDKTests
+//
+//  Copyright © 2026 CleverTap. All rights reserved.
+//
+
+import XCTest
+@testable import CleverTapSDK
+
+// MARK: - Stubs
+
+private final class StubStorageStrategy: NSObject, InAppSchedulingStrategy {
+    var prepareResult = true
+    var prepareCallCount = 0
+    var receivedInApps: [[String: Any]] = []
+    var onPrepare: (() -> Void)?
+
+    func prepareForScheduling(inApps: [[String: Any]]) -> Bool {
+        prepareCallCount += 1
+        receivedInApps = inApps
+        onPrepare?()
+        return prepareResult
+    }
+
+    func retrieveAfterTimer(id: String) -> [String: Any]? { return nil }
+
+    func clearAll() {}
+}
+
+private final class StubDataExtractor: NSObject, InAppDataExtractor {
+    func extractDelay(inApp: [String: Any]) -> TimeInterval {
+        return (inApp[InAppDelayConstants.INAPP_DELAY_AFTER_TRIGGER] as? NSNumber)?.doubleValue ?? 0
+    }
+
+    func createSuccessResult(id: String, data: [String: Any]) -> Any { return "success:\(id)" }
+    func createErrorResult(id: String, message: String) -> Any { return "error:\(id):\(message)" }
+    func createDiscardedResult(id: String) -> Any { return "discarded:\(id)" }
+}
+
+// MARK: - Tests
+
+class InAppSchedulerTests: XCTestCase {
+
+    private var timerManager: InAppTimerManager!
+    private var storage: StubStorageStrategy!
+    private var extractor: StubDataExtractor!
+    private var scheduler: CTInAppScheduler!
+
+    override func setUp() {
+        super.setUp()
+        timerManager = InAppTimerManager(tagSuffix: "Test")
+        storage = StubStorageStrategy()
+        extractor = StubDataExtractor()
+        scheduler = CTInAppScheduler(timerManager: timerManager,
+                                     storageStrategy: storage,
+                                     dataExtractor: extractor)
+    }
+
+    override func tearDown() {
+        timerManager.cancelAllTimers()
+        super.tearDown()
+    }
+
+    private func inApp(id: Any, delay: Any) -> [String: Any] {
+        return [InAppDelayConstants.INAPP_ID_IN_PAYLOAD: id,
+                InAppDelayConstants.INAPP_DELAY_AFTER_TRIGGER: delay]
+    }
+
+    // MARK: - Preparation failure path
+
+    // Ids are stringified rather than cast, so a numeric ti must still produce a
+    // callback. A String-only cast here would emit nothing at all.
+    func testSchedule_preparationFails_emitsOneErrorPerSchedulableInApp_withNumericIds() {
+        storage.prepareResult = false
+        let expectation = self.expectation(description: "callbacks")
+        expectation.expectedFulfillmentCount = 2
+
+        var results: [String] = []
+        let lock = NSLock()
+        scheduler.schedule(inApps: [inApp(id: NSNumber(value: 10), delay: 30),
+                                    inApp(id: NSNumber(value: 20), delay: 60)]) { result in
+            lock.lock()
+            results.append(result as? String ?? "nil")
+            lock.unlock()
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results.contains("error:10:Preparation failed"), "got \(results)")
+        XCTAssertTrue(results.contains("error:20:Preparation failed"), "got \(results)")
+    }
+
+    // MARK: - Only schedulable in-apps reach the storage strategy
+
+    func testSchedule_prepareReceivesOnlyInAppsThatWillGetATimer() {
+        let expectation = self.expectation(description: "prepare called")
+        storage.onPrepare = { expectation.fulfill() }
+
+        scheduler.schedule(inApps: [inApp(id: NSNumber(value: 10), delay: 30),
+                                    inApp(id: NSNumber(value: 20), delay: 0),
+                                    inApp(id: NSNumber(value: 30), delay: -5),
+                                    inApp(id: "", delay: 30)]) { _ in }
+
+        waitForExpectations(timeout: 2)
+        // Only id 10 has a positive delay and a usable id. Storing the others
+        // would leave entries nothing ever retrieves.
+        XCTAssertEqual(storage.receivedInApps.count, 1)
+        let storedId = storage.receivedInApps.first?[InAppDelayConstants.INAPP_ID_IN_PAYLOAD] as? NSNumber
+        XCTAssertEqual(storedId, NSNumber(value: 10))
+    }
+
+    func testSchedule_noSchedulableInApps_doesNotCallPrepare() {
+        scheduler.schedule(inApps: [inApp(id: NSNumber(value: 10), delay: 0),
+                                    inApp(id: NSNumber(value: 20), delay: -1)]) { _ in }
+
+        // No expectation to wait on, so drain the scheduler's queue via a
+        // separate call whose completion we can observe.
+        let drained = self.expectation(description: "queue drained")
+        storage.onPrepare = { drained.fulfill() }
+        scheduler.schedule(inApps: [inApp(id: NSNumber(value: 99), delay: 30)]) { _ in }
+        waitForExpectations(timeout: 2)
+
+        // Exactly one prepare, from the second call only.
+        XCTAssertEqual(storage.prepareCallCount, 1)
+        XCTAssertEqual(storage.receivedInApps.count, 1)
+    }
+
+    // MARK: - Already scheduled in-apps are filtered
+
+    func testSchedule_alreadyScheduledId_isNotPreparedAgain() {
+        // Occupy the id with a long-running timer.
+        timerManager.scheduleTimer(id: "10", delay: 60) { _ in }
+
+        let expectation = self.expectation(description: "prepare called")
+        storage.onPrepare = { expectation.fulfill() }
+
+        scheduler.schedule(inApps: [inApp(id: NSNumber(value: 10), delay: 30),
+                                    inApp(id: NSNumber(value: 20), delay: 30)]) { _ in }
+
+        waitForExpectations(timeout: 2)
+        XCTAssertEqual(storage.receivedInApps.count, 1)
+        let storedId = storage.receivedInApps.first?[InAppDelayConstants.INAPP_ID_IN_PAYLOAD] as? NSNumber
+        XCTAssertEqual(storedId, NSNumber(value: 20), "the already-scheduled id 10 should be filtered out")
+    }
+
+    // MARK: - Timer completion
+
+    func testSchedule_timerFires_invokesCallbackWithErrorWhenDataMissing() {
+        // retrieveAfterTimer returns nil in the stub, so the success path reports
+        // "Data not found" rather than silently dropping the callback.
+        let expectation = self.expectation(description: "timer fired")
+        var result: String?
+        scheduler.schedule(inApps: [inApp(id: NSNumber(value: 10), delay: 0.2)]) { value in
+            result = value as? String
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3)
+        XCTAssertEqual(result, "error:10:Data not found")
+    }
+}

--- a/CleverTapSDKTests/InAppSelectionStrategyTests.swift
+++ b/CleverTapSDKTests/InAppSelectionStrategyTests.swift
@@ -63,4 +63,31 @@ class InAppSelectionStrategyTests: XCTestCase {
         let result = strategy.selectInApps([inApp1, inApp2], suppressionHandler: { _ in false })
         XCTAssertEqual(result.count, 2)
     }
+
+    // Grouping is by delay, not by id: in-apps sharing a delay compete for one slot.
+    func testDelayed_selectInApps_sameDelay_selectsOnlyOne() {
+        let inApp1: NSDictionary = ["ti": NSNumber(value: 10), "delayAfterTrigger": 30]
+        let inApp2: NSDictionary = ["ti": NSNumber(value: 20), "delayAfterTrigger": 30]
+        let inApp3: NSDictionary = ["ti": NSNumber(value: 30), "delayAfterTrigger": 60]
+        let result = strategy.selectInApps([inApp1, inApp2, inApp3], suppressionHandler: { _ in false })
+        // One for delay 30, one for delay 60.
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.first(where: { ($0["delayAfterTrigger"] as? NSNumber)?.intValue == 30 })?["ti"] as? NSNumber,
+                       NSNumber(value: 10), "The first in-app in the delay group should win")
+    }
+
+    // suppressionHandler records suppression as a side effect, so it must be
+    // invoked exactly once per in-app it is asked about.
+    func testDelayed_selectInApps_invokesSuppressionHandlerOncePerInApp() {
+        let inApp1: NSDictionary = ["ti": NSNumber(value: 10), "delayAfterTrigger": 30]
+        let inApp2: NSDictionary = ["ti": NSNumber(value: 20), "delayAfterTrigger": 60]
+        var callCounts: [Int: Int] = [:]
+        _ = strategy.selectInApps([inApp1, inApp2], suppressionHandler: { inApp in
+            let id = (inApp["ti"] as? NSNumber)?.intValue ?? -1
+            callCounts[id, default: 0] += 1
+            return false
+        })
+        XCTAssertEqual(callCounts[10], 1)
+        XCTAssertEqual(callCounts[20], 1)
+    }
 }

--- a/CleverTapSDKTests/InApps/CTInAppEvaluationManagerTest.m
+++ b/CleverTapSDKTests/InApps/CTInAppEvaluationManagerTest.m
@@ -425,6 +425,104 @@
     XCTAssertEqualObjects((@[@1, @1, @1]), self.evaluationManager.evaluatedServerSideInAppIdsForProfile);
 }
 
+#pragma mark App Fields In User Attribute Evaluation
+
+// App fields must be merged into the properties used to evaluate a profile
+// attribute change, so a campaign can trigger on an app field (e.g. Version)
+// alongside a profileAttrName.
+- (void)testEvaluateUserAttributeIncludesAppFields {
+    self.evaluationManager.appLaunchedProperties = @{ CLTAP_APP_VERSION: @"1.2.3" };
+    self.helper.inAppStore.serverSideInApps = @[
+    @{
+        @"ti": @1,
+        @"whenTriggers": @[@{
+            @"eventProperties": @[@{
+                @"propertyName": CLTAP_APP_VERSION,
+                @"propertyValue": @"1.2.3",
+            }],
+            @"profileAttrName": @"Customer Type",
+        }]
+    }];
+
+    NSDictionary *profile = @{
+        @"Customer Type": @{
+            @"newValue": @"Gold",
+            @"oldValue": @"Premium"
+        }
+    };
+    [self.evaluationManager evaluateOnUserAttributeChange:profile];
+    XCTAssertEqualObjects((@[@1]), self.evaluationManager.evaluatedServerSideInAppIdsForProfile);
+}
+
+// Control for the test above: with no app fields available, an app field
+// trigger must not match.
+- (void)testEvaluateUserAttributeWithoutAppFieldsDoesNotMatchAppFieldTrigger {
+    self.evaluationManager.appLaunchedProperties = @{};
+    self.helper.inAppStore.serverSideInApps = @[
+    @{
+        @"ti": @1,
+        @"whenTriggers": @[@{
+            @"eventProperties": @[@{
+                @"propertyName": CLTAP_APP_VERSION,
+                @"propertyValue": @"1.2.3",
+            }],
+            @"profileAttrName": @"Customer Type",
+        }]
+    }];
+
+    NSDictionary *profile = @{
+        @"Customer Type": @{
+            @"newValue": @"Gold",
+            @"oldValue": @"Premium"
+        }
+    };
+    [self.evaluationManager evaluateOnUserAttributeChange:profile];
+    XCTAssertEqual(self.evaluationManager.evaluatedServerSideInAppIdsForProfile.count, 0);
+}
+
+// Conditions are AND-ed: app field and attribute newValue must match,
+// and attribute values must survive the merge.
+- (void)testEvaluateUserAttributeMatchesAppFieldAndAttributeValue {
+    self.evaluationManager.appLaunchedProperties = @{ CLTAP_APP_VERSION: @"1.2.3" };
+    self.helper.inAppStore.serverSideInApps = @[
+    @{
+        @"ti": @1,
+        @"whenTriggers": @[@{
+            @"eventProperties": @[@{
+                @"propertyName": CLTAP_APP_VERSION,
+                @"propertyValue": @"1.2.3",
+            }, @{
+                @"propertyName": @"newValue",
+                @"propertyValue": @"Gold",
+            }],
+            @"profileAttrName": @"Customer Type",
+        }]
+    },
+    @{
+        // Same app field, but the attribute value does not match.
+        @"ti": @2,
+        @"whenTriggers": @[@{
+            @"eventProperties": @[@{
+                @"propertyName": CLTAP_APP_VERSION,
+                @"propertyValue": @"1.2.3",
+            }, @{
+                @"propertyName": @"newValue",
+                @"propertyValue": @"Silver",
+            }],
+            @"profileAttrName": @"Customer Type",
+        }]
+    }];
+
+    NSDictionary *profile = @{
+        @"Customer Type": @{
+            @"newValue": @"Gold",
+            @"oldValue": @"Premium"
+        }
+    };
+    [self.evaluationManager evaluateOnUserAttributeChange:profile];
+    XCTAssertEqualObjects((@[@1]), self.evaluationManager.evaluatedServerSideInAppIdsForProfile);
+}
+
 - (void)testEvaluateCharged {
     self.helper.inAppStore.serverSideInApps = @[
     @{

--- a/CleverTapSDKTests/InApps/CTInAppEvaluationManagerTest.m
+++ b/CleverTapSDKTests/InApps/CTInAppEvaluationManagerTest.m
@@ -523,6 +523,49 @@
     XCTAssertEqualObjects((@[@1]), self.evaluationManager.evaluatedServerSideInAppIdsForProfile);
 }
 
+#pragma mark App Fields In Custom Event Evaluation
+
+// A custom event campaign can trigger on an app field (e.g. Version) merged
+// into the event props. Mirrors the user-attribute app-field coverage for the
+// custom-event path. The merge itself happens in CleverTap
+// evaluateOnEvent:withType:flattenedEventData: before this call, so here the
+// app field is supplied directly in props.
+- (void)testEvaluateEventIncludesAppFields {
+    self.helper.inAppStore.serverSideInApps = @[
+    @{
+        @"ti": @1,
+        @"whenTriggers": @[@{
+            @"eventName": @"AppFieldEvent",
+            @"eventProperties": @[@{
+                @"propertyName": CLTAP_APP_VERSION,
+                @"propertyValue": @"1.2.3",
+            }],
+        }]
+    }];
+
+    [self.evaluationManager evaluateOnEvent:@"AppFieldEvent" withProps:@{ CLTAP_APP_VERSION: @"1.2.3" }];
+    XCTAssertEqualObjects((@[@1]), self.evaluationManager.evaluatedServerSideInAppIds);
+}
+
+// Control for the test above: with the app field absent from the props, the
+// same app-field trigger must not match.
+- (void)testEvaluateEventWithoutAppFieldDoesNotMatchAppFieldTrigger {
+    self.helper.inAppStore.serverSideInApps = @[
+    @{
+        @"ti": @1,
+        @"whenTriggers": @[@{
+            @"eventName": @"AppFieldEvent",
+            @"eventProperties": @[@{
+                @"propertyName": CLTAP_APP_VERSION,
+                @"propertyValue": @"1.2.3",
+            }],
+        }]
+    }];
+
+    [self.evaluationManager evaluateOnEvent:@"AppFieldEvent" withProps:@{}];
+    XCTAssertEqual(self.evaluationManager.evaluatedServerSideInAppIds.count, 0);
+}
+
 - (void)testEvaluateCharged {
     self.helper.inAppStore.serverSideInApps = @[
     @{

--- a/CleverTapSDKTests/InApps/CTInAppStoreTest.m
+++ b/CleverTapSDKTests/InApps/CTInAppStoreTest.m
@@ -125,6 +125,10 @@
     return [self.store storageKeyWithSuffix:CLTAP_PREFS_INAPP_KEY_SS];
 }
 
+- (NSString *)storageKeyDelayedCS {
+    return [self.store storageKeyWithSuffix:CLTAP_PREFS_DELAYED_INAPP_KEY_CS];
+}
+
 #pragma mark Tests
 - (void)testStoreClientSideInApps {
     XCTAssertNil([CTPreferences getObjectForKey:[self storageKeyCS]]);
@@ -283,6 +287,33 @@
     XCTAssertEqualObjects([self.store serverSideInApps], self.inApps);
 }
 #pragma clang diagnostic pop
+
+// Switching away from CS must also drop the delayed CS in-apps. They are read by
+// evaluateDelayedClientSide: on every event, so one left behind can still display
+// while the account is in SS mode. Matches Android, whose SERVER_SIDE_MODE and
+// NO_MODE branches both call removeClientSideDelayedInApps().
+- (void)testSetModeRemovesDelayedClientSideInApps {
+    // CS mode keeps them - only the server-side stores are cleared.
+    [self.store storeDelayedClientSideInApps:self.inApps];
+    [self.store setMode:@"CS"];
+    XCTAssertNotNil([CTPreferences getObjectForKey:[self storageKeyDelayedCS]]);
+
+    // SS mode clears them.
+    [self.store storeDelayedClientSideInApps:self.inApps];
+    [self.store setMode:@"SS"];
+    XCTAssertNil([CTPreferences getObjectForKey:[self storageKeyDelayedCS]]);
+    XCTAssertEqual([[self.store delayedClientSideInApps] count], 0);
+
+    // No mode clears them too.
+    [self.store storeDelayedClientSideInApps:self.inApps];
+    [self.store setMode:nil];
+    XCTAssertNil([CTPreferences getObjectForKey:[self storageKeyDelayedCS]]);
+
+    // An unrecognised mode takes the same branch as no mode.
+    [self.store storeDelayedClientSideInApps:self.inApps];
+    [self.store setMode:@"Invalid"];
+    XCTAssertNil([CTPreferences getObjectForKey:[self storageKeyDelayedCS]]);
+}
 
 - (void)testSetModeRemovesInApps {
     [self.store storeServerSideInApps:self.inApps];

--- a/CleverTapSDKTests/InactionInAppStorageStrategyTests.swift
+++ b/CleverTapSDKTests/InactionInAppStorageStrategyTests.swift
@@ -62,6 +62,52 @@ class InactionInAppStorageStrategyTests: XCTestCase {
         XCTAssertNil(retrieved)
     }
 
+    // retrieveAfterTimer is a dequeue: InAppScheduler calls it and throws the
+    // result away on the error and discarded paths purely to drop the entry.
+    func testRetrieveAfterTimer_hit_removesFromCache() {
+        let inApp: [String: Any] = ["ti": "myId", "type": "interstitial"]
+        _ = strategy.prepareForScheduling(inApps: [inApp])
+        XCTAssertEqual(strategy.getCacheSize(), 1)
+
+        XCTAssertNotNil(strategy.retrieveAfterTimer(id: "myId"))
+        XCTAssertEqual(strategy.getCacheSize(), 0)
+        XCTAssertNil(strategy.retrieveAfterTimer(id: "myId"))
+    }
+
+    func testRetrieveAfterTimer_hit_leavesOtherEntriesInPlace() {
+        let inApps: [[String: Any]] = [
+            ["ti": "id1", "type": "interstitial"],
+            ["ti": "id2", "type": "cover"]
+        ]
+        _ = strategy.prepareForScheduling(inApps: inApps)
+
+        XCTAssertNotNil(strategy.retrieveAfterTimer(id: "id1"))
+        XCTAssertEqual(strategy.getCacheSize(), 1)
+        XCTAssertNotNil(strategy.retrieveAfterTimer(id: "id2"))
+        XCTAssertEqual(strategy.getCacheSize(), 0)
+    }
+
+    func testRetrieveAfterTimer_miss_leavesCacheUntouched() {
+        _ = strategy.prepareForScheduling(inApps: [["ti": "id1", "type": "interstitial"]])
+
+        XCTAssertNil(strategy.retrieveAfterTimer(id: "nonexistent"))
+        XCTAssertEqual(strategy.getCacheSize(), 1)
+    }
+
+    // Writes used to bypass cacheQueue entirely, so a concurrent read could hit
+    // the dictionary mid-mutation. Mutating a Swift Dictionary while another
+    // thread reads it can crash rather than just return stale data.
+    func testConcurrentPrepareAndRetrieve_doesNotCrash() {
+        DispatchQueue.concurrentPerform(iterations: 200) { i in
+            if i % 2 == 0 {
+                _ = self.strategy.prepareForScheduling(inApps: [["ti": "id\(i)", "type": "interstitial"]])
+            } else {
+                _ = self.strategy.retrieveAfterTimer(id: "id\(i - 1)")
+                _ = self.strategy.getCacheSize()
+            }
+        }
+    }
+
     func testClearAll_emptiesCache() {
         let inApps: [[String: Any]] = [
             ["ti": "id1", "type": "interstitial"],


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event and in-app evaluation by preserving event properties and app-launch fields.
  * Prevented in-apps scheduled for a previous device or user from displaying after switching users.
  * Improved delayed in-app scheduling, selection, cancellation, and cleanup behavior.
  * Improved profile updates involving nested objects and array elements.
  * Prevented invalid in-app mode responses from changing the current mode.
* **Refactor**
  * Removed the no-data status method from the event data interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->