### PR TITLE
[SDK-6093] Content fetch on app launch improvement

### DIFF
--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -132,6 +132,10 @@ extern NSString *const kSessionId;
 #define CLTAP_CONTENT_FETCH_ITEM_EVENT_NAME @"eventName"
 #define CLTAP_CONTENT_FETCH_ITEM_RESPONSE_KEY @"responseKey"
 #define CLTAP_CONTENT_FETCH_ITEM_TGT_ID @"tgtId"
+// SDK-internal marker, never sent or received. Tags a payload built from a content_fetch item's
+// selection rules, which can be evaluated and sorted but must never be displayed — it carries
+// only the rules that decide a winner, no content.
+#define CLTAP_INAPP_SYNTHETIC_CANDIDATE @"__ct_synthetic_candidate"
 // How long an app-launch in-app is held waiting for the content fetch to return a competing
 // candidate. A UX bound, not a correctness one — deliberately far below the content fetch's own
 // limits (CLTAP_REQUEST_TIME_OUT_INTERVAL, plus 5s if it waits for a concurrency slot), since

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -128,6 +128,10 @@ extern NSString *const kSessionId;
 #define CLTAP_PING_TICK_INTERVAL 1
 #define CLTAP_LOCATION_PING_INTERVAL_SECONDS 10
 #define CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY @"content_fetch"
+// Keys within a single `content_fetch` array item
+#define CLTAP_CONTENT_FETCH_ITEM_EVENT_NAME @"eventName"
+#define CLTAP_CONTENT_FETCH_ITEM_RESPONSE_KEY @"responseKey"
+#define CLTAP_CONTENT_FETCH_ITEM_TGT_ID @"tgtId"
 #define CLTAP_INBOX_MSG_JSON_RESPONSE_KEY @"inbox_notifs"
 #define CLTAP_INBOX_V2_RESPONSE_KEY @"inbox_notifs_v2"
 #define CLTAP_NOTIFICATION_DELETED_EVENT_NAME @"Notification Deleted"

--- a/CleverTapSDK/CTConstants.h
+++ b/CleverTapSDK/CTConstants.h
@@ -132,6 +132,19 @@ extern NSString *const kSessionId;
 #define CLTAP_CONTENT_FETCH_ITEM_EVENT_NAME @"eventName"
 #define CLTAP_CONTENT_FETCH_ITEM_RESPONSE_KEY @"responseKey"
 #define CLTAP_CONTENT_FETCH_ITEM_TGT_ID @"tgtId"
+// How long an app-launch in-app is held waiting for the content fetch to return a competing
+// candidate. A UX bound, not a correctness one — deliberately far below the content fetch's own
+// limits (CLTAP_REQUEST_TIME_OUT_INTERVAL, plus 5s if it waits for a concurrency slot), since
+// matching those would delay the in-app by up to 15s. A response arriving after this has fired
+// is dropped instead of shown, so a slow fetch cannot produce a second in-app.
+//
+// TODO: 3.0 is a placeholder pending team discussion. It was chosen against an observed ~2s
+// round trip on staging, which is a single data point. The value only trades off how often the
+// personalized in-app wins versus the app-launch one — shorter falls back more often, longer
+// delays display more often — and cannot cause a double in-app either way. Worth deciding with
+// real latency numbers, and whether it should be server-driven or SDK-configurable rather than
+// a compile-time constant.
+#define CLTAP_INAPP_ARBITRATION_TIMEOUT_SECONDS 3.0
 #define CLTAP_INBOX_MSG_JSON_RESPONSE_KEY @"inbox_notifs"
 #define CLTAP_INBOX_V2_RESPONSE_KEY @"inbox_notifs_v2"
 #define CLTAP_NOTIFICATION_DELETED_EVENT_NAME @"Notification Deleted"

--- a/CleverTapSDK/CTContentFetchManager.h
+++ b/CleverTapSDK/CTContentFetchManager.h
@@ -16,6 +16,42 @@ NS_ASSUME_NONNULL_BEGIN
 @class CleverTapInstanceConfig;
 @class CTDispatchQueueManager;
 
+/*!
+ A single entry of the `content_fetch` array.
+
+ Items are self-describing: each names the event that triggered the fetch, the response key its
+ result will arrive under, and the campaign it targets. Parsing them lets callers know what to
+ expect from the `/content` response before it arrives.
+ */
+@interface CTContentFetchItem : NSObject
+
+/// Event that triggered the fetch, e.g. `App Launched`.
+@property (nonatomic, copy, readonly, nullable) NSString *eventName;
+
+/// Response key the fetched content will arrive under, e.g. `inapp_notifs_applaunched`.
+@property (nonatomic, copy, readonly, nullable) NSString *responseKey;
+
+/*!
+ Campaign id being targeted.
+
+ Same identity as an in-app payload's `ti`, but `tgtId` arrives as a number while `ti` may be a
+ number or a string. Normalized to a string here so the two can be compared directly.
+ */
+@property (nonatomic, copy, readonly, nullable) NSString *targetId;
+
+/*!
+ The unparsed item.
+
+ Preserved verbatim because this is what gets sent back as the event data of the outbound content
+ fetch request — the wire format must not change.
+ */
+@property (nonatomic, copy, readonly) NSDictionary *rawItem;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (nullable instancetype)initWithJSON:(NSDictionary *)json;
+
+@end
+
 @interface CTContentFetchManager : NSObject <CTSwitchUserDelegate>
 
 @property (nonatomic, weak) id<CTContentFetchManagerDelegate> delegate;
@@ -38,6 +74,17 @@ NS_ASSUME_NONNULL_BEGIN
  * @param jsonResp The JSON response dictionary
  */
 - (void)handleContentFetch:(NSDictionary *)jsonResp;
+
+/**
+ * Parse the `content_fetch` array of a response into typed items.
+ *
+ * Read-only — nothing is enqueued or sent. Use `handleContentFetch:` to actually fetch.
+ * Lets a caller inspect what the `/content` response will contain while still parsing `/a1`.
+ *
+ * @param jsonResp The JSON response dictionary
+ * @return Parsed items, or an empty array if the key is absent, malformed, or empty.
+ */
++ (NSArray<CTContentFetchItem *> *)contentFetchItemsFromResponse:(NSDictionary *)jsonResp;
 
 @end
 

--- a/CleverTapSDK/CTContentFetchManager.h
+++ b/CleverTapSDK/CTContentFetchManager.h
@@ -76,6 +76,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleContentFetch:(NSDictionary *)jsonResp;
 
 /**
+ * Process content fetch information from response, notifying when this batch has finished.
+ *
+ * @param jsonResp The JSON response dictionary
+ * @param completion Invoked exactly once, when every request of this batch has settled —
+ * success, HTTP error, concurrency timeout, or abandonment during a user switch. It is never
+ * skipped and never invoked twice, so a caller that waits on it cannot hang. Invoked on an
+ * arbitrary queue, after the response has been handed to the delegate; serialize if needed.
+ */
+- (void)handleContentFetch:(NSDictionary *)jsonResp
+                completion:(nullable dispatch_block_t)completion;
+
+/**
  * Parse the `content_fetch` array of a response into typed items.
  *
  * Read-only — nothing is enqueued or sent. Use `handleContentFetch:` to actually fetch.

--- a/CleverTapSDK/CTContentFetchManager.h
+++ b/CleverTapSDK/CTContentFetchManager.h
@@ -47,6 +47,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, readonly) NSDictionary *rawItem;
 
+/*!
+ The item rendered as an in-app payload for speculative evaluation, or nil if it cannot be.
+
+ Carries only the *selection* rules — the keys that decide which of several candidates wins —
+ plus `ti` derived from `tgtId`. Deliberately never the content, so this can be evaluated and
+ sorted but not displayed. It is tagged `CLTAP_INAPP_SYNTHETIC_CANDIDATE` and rejected at the
+ boundaries of the display path.
+
+ @note Returns nil unless the item carries a `priority`. Without it `sortByPriority:` would
+ silently default to 1 and mispredict any campaign that actually sets a priority — a wrong answer
+ that looks like a right one. Better to have no prediction than a confidently wrong one.
+
+ @note Today's payload carries none of these rules, so this returns nil and speculative
+ evaluation is inert until the backend sends them.
+ */
+@property (nonatomic, copy, readonly, nullable) NSDictionary *syntheticInAppPayload;
+
 - (instancetype)init NS_UNAVAILABLE;
 - (nullable instancetype)initWithJSON:(NSDictionary *)json;
 

--- a/CleverTapSDK/CTContentFetchManager.m
+++ b/CleverTapSDK/CTContentFetchManager.m
@@ -42,7 +42,63 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
 
 @end
 
+@implementation CTContentFetchItem
+
+- (instancetype)initWithJSON:(NSDictionary *)json {
+    if (![json isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
+    self = [super init];
+    if (self) {
+        _rawItem = [json copy];
+
+        id eventName = json[CLTAP_CONTENT_FETCH_ITEM_EVENT_NAME];
+        if ([eventName isKindOfClass:[NSString class]]) {
+            _eventName = [eventName copy];
+        }
+
+        id responseKey = json[CLTAP_CONTENT_FETCH_ITEM_RESPONSE_KEY];
+        if ([responseKey isKindOfClass:[NSString class]]) {
+            _responseKey = [responseKey copy];
+        }
+
+        // `tgtId` arrives as a number, but the `ti` it will be compared against may be either a
+        // number or a string. Normalize the same way CTInAppNotification does, so the two match.
+        id targetId = json[CLTAP_CONTENT_FETCH_ITEM_TGT_ID];
+        if ([targetId isKindOfClass:[NSNumber class]] || [targetId isKindOfClass:[NSString class]]) {
+            NSString *normalized = [NSString stringWithFormat:@"%@", targetId];
+            if (normalized.length > 0) {
+                _targetId = normalized;
+            }
+        }
+    }
+    return self;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<CTContentFetchItem: event=%@ responseKey=%@ tgtId=%@>",
+            self.eventName, self.responseKey, self.targetId];
+}
+
+@end
+
 @implementation CTContentFetchManager
+
++ (NSArray<CTContentFetchItem *> *)contentFetchItemsFromResponse:(NSDictionary *)jsonResp {
+    NSArray *contentFetch = jsonResp[CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY];
+    if (![contentFetch isKindOfClass:[NSArray class]] || contentFetch.count == 0) {
+        return @[];
+    }
+
+    NSMutableArray<CTContentFetchItem *> *items = [[NSMutableArray alloc] initWithCapacity:contentFetch.count];
+    for (id item in contentFetch) {
+        CTContentFetchItem *parsed = [[CTContentFetchItem alloc] initWithJSON:item];
+        if (parsed) {
+            [items addObject:parsed];
+        }
+    }
+    return items;
+}
 
 - (instancetype)initWithConfig:(CleverTapInstanceConfig *)config
                  requestSender:(CTRequestSender *)requestSender
@@ -75,16 +131,17 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
 }
 
 - (void)handleContentFetch:(NSDictionary *)jsonResp {
-    NSArray *contentFetch = jsonResp[CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY];
-    if (!contentFetch || ![contentFetch isKindOfClass:[NSArray class]] || contentFetch.count == 0) {
+    NSArray<CTContentFetchItem *> *contentFetch = [[self class] contentFetchItemsFromResponse:jsonResp];
+    if (contentFetch.count == 0) {
         return;
     }
     
     NSMutableArray *events = [[NSMutableArray alloc] init];
-    for (NSDictionary *contentFetchItem in contentFetch) {
+    for (CTContentFetchItem *contentFetchItem in contentFetch) {
+        // Send the item back verbatim — the outbound wire format must not change.
         NSMutableDictionary *event = [NSMutableDictionary dictionaryWithDictionary:@{
             CLTAP_EVENT_NAME: CLTAP_CONTENT_FETCH_EVENT,
-            CLTAP_EVENT_DATA: contentFetchItem
+            CLTAP_EVENT_DATA: contentFetchItem.rawItem
         }];
         
         // Call delegate to add event metadata

--- a/CleverTapSDK/CTContentFetchManager.m
+++ b/CleverTapSDK/CTContentFetchManager.m
@@ -40,6 +40,9 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
 @property (nonatomic, strong) NSMutableSet *inFlightRequestIndices;
 @property (nonatomic, assign) NSUInteger completedBatches;
 
+/// Per-batch completion blocks keyed by queue index. Guarded by `queueLock`.
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, dispatch_block_t> *batchCompletions;
+
 @end
 
 @implementation CTContentFetchItem
@@ -125,14 +128,21 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
         
         self.allRequestsGroup = dispatch_group_create();
         self.inFlightRequestIndices = [[NSMutableSet alloc] init];
+        self.batchCompletions = [[NSMutableDictionary alloc] init];
     }
     
     return self;
 }
 
 - (void)handleContentFetch:(NSDictionary *)jsonResp {
+    [self handleContentFetch:jsonResp completion:nil];
+}
+
+- (void)handleContentFetch:(NSDictionary *)jsonResp completion:(dispatch_block_t)completion {
     NSArray<CTContentFetchItem *> *contentFetch = [[self class] contentFetchItemsFromResponse:jsonResp];
     if (contentFetch.count == 0) {
+        // Nothing to fetch, but the contract is that completion always runs exactly once.
+        if (completion) completion();
         return;
     }
     
@@ -153,6 +163,9 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
     [self.contentFetchQueue addObject:events];
     CleverTapLogDebug(self.config.logLevel, @"%@: Added content fetch with %ld events", self, [events count]);
     NSUInteger batchIndex = self.contentFetchQueue.count - 1;
+    if (completion) {
+        self.batchCompletions[@(batchIndex)] = completion;
+    }
     [self.queueLock unlock];
     
     [self fetchContentAtIndex:batchIndex];
@@ -167,10 +180,21 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
         self.contentFetchQueue[i] = [NSNull null];
         self.completedBatches++;
     }
-    
+
+    // Take the completion before cleanup, which resets the queue and therefore the indices.
+    dispatch_block_t completion = self.batchCompletions[@(i)];
+    if (completion) {
+        [self.batchCompletions removeObjectForKey:@(i)];
+    }
+
     [self cleanupIfAllCompleted];
     
     [self.queueLock unlock];
+
+    // Invoke outside the lock — the block is caller-supplied and may re-enter.
+    if (completion) {
+        completion();
+    }
 }
 
 - (void)cleanupIfAllCompleted {
@@ -201,8 +225,20 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
         NSArray *batch;
         [self.queueLock lock];
         if (i >= self.contentFetchQueue.count || self.contentFetchQueue[i] == [NSNull null]) {
-            [self.queueLock unlock];
+            // The batch is gone — already completed, or the queue was cleared by a user switch.
+            // Release its bookkeeping and run any registered completion, so a caller waiting on
+            // this batch is not left hanging. Deliberately not markCompletedAtIndex:, which would
+            // re-run cleanup and signal an "all batches completed" transition that did not happen.
             [self.inFlightRequestIndices removeObject:@(i)];
+            dispatch_block_t completion = self.batchCompletions[@(i)];
+            if (completion) {
+                [self.batchCompletions removeObjectForKey:@(i)];
+            }
+            [self.queueLock unlock];
+
+            if (completion) {
+                completion();
+            }
             dispatch_group_leave(self.allRequestsGroup);
             return;
         }
@@ -356,7 +392,15 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
         [self.contentFetchQueue removeAllObjects];
         [self.inFlightRequestIndices removeAllObjects];
         self.completedBatches = 0;
+        // Anything still registered here timed out above and its batch is being abandoned. Run
+        // the blocks anyway — a caller waiting on one must not be left hanging by a user switch.
+        NSArray<dispatch_block_t> *abandoned = [self.batchCompletions.allValues copy];
+        [self.batchCompletions removeAllObjects];
         [self.queueLock unlock];
+
+        for (dispatch_block_t completion in abandoned) {
+            completion();
+        }
     }];
 }
 

--- a/CleverTapSDK/CTContentFetchManager.m
+++ b/CleverTapSDK/CTContentFetchManager.m
@@ -78,6 +78,38 @@ static const NSTimeInterval kDEFAULT_USER_SWITCH_TIMEOUT = 120.0; // 2 minutes
     return self;
 }
 
+- (NSDictionary *)syntheticInAppPayload {
+    // `priority` is the primary discriminator. Without it there is nothing to predict with — see
+    // the note on the property.
+    if (!self.targetId || self.rawItem[CLTAP_INAPP_PRIORITY] == nil) {
+        return nil;
+    }
+
+    NSMutableDictionary *payload = [NSMutableDictionary dictionary];
+    payload[CLTAP_INAPP_ID] = self.targetId;
+    payload[CLTAP_INAPP_SYNTHETIC_CANDIDATE] = @YES;
+
+    // Copy across only the rules that decide a winner, and only those actually present. Keys the
+    // backend has not sent yet are simply absent, which keeps this forward-compatible.
+    NSArray<NSString *> *selectionKeys = @[
+        CLTAP_INAPP_PRIORITY,
+        CLTAP_INAPP_IS_SUPPRESSED,
+        CLTAP_DELAY_AFTER_TRIGGER,
+        CLTAP_INAPP_TRIGGERS,
+        CLTAP_INAPP_FC_LIMITS,
+        CLTAP_INAPP_OCCURRENCE_LIMITS,
+        CLTAP_INAPP_TEMPLATE_NAME
+    ];
+    for (NSString *key in selectionKeys) {
+        id value = self.rawItem[key];
+        if (value) {
+            payload[key] = value;
+        }
+    }
+
+    return payload;
+}
+
 - (NSString *)description {
     return [NSString stringWithFormat:@"<CTContentFetchItem: event=%@ responseKey=%@ tgtId=%@>",
             self.eventName, self.responseKey, self.targetId];

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2511,6 +2511,10 @@ static BOOL sharedInstanceErrorLogged;
 
 #if !CLEVERTAP_NO_DISPLAY_UNIT_SUPPORT
 - (void)handleDisplayUnitResponse:(id)jsonResp {
+    [self handleDisplayUnitResponse:jsonResp source:CTResponseSourceApp];
+}
+
+- (void)handleDisplayUnitResponse:(id)jsonResp source:(CTResponseSource)source {
     NSArray *displayUnitJSON = jsonResp[CLTAP_DISPLAY_UNIT_JSON_RESPONSE_KEY];
     if ([displayUnitJSON isKindOfClass:[NSArray class]] && displayUnitJSON.count > 0) {
         if (self.isUserSwitching) {
@@ -2519,14 +2523,86 @@ static BOOL sharedInstanceErrorLogged;
         }
         NSArray<CleverTapDisplayUnit *> *displayUnits = [self _parseDisplayUnitsFromJSONArray:displayUnitJSON];
         if (displayUnits.count > 0) {
+            __weak typeof(self) weakSelf = self;
             [self initializeDisplayUnitWithCallback:^(BOOL success) {
-                if (success) {
-                    [self.displayUnitCache updateDisplayUnits:displayUnits];
-                    [self _notifyDisplayUnitsUpdated];
-                }
+                if (!success) return;
+                // Merging is a read-modify-write across two separately-locked cache calls, and up
+                // to CLTAP_CONTENT_FETCH concurrent /content responses can land at once — two
+                // interleaved merges would lose units. Serialize the whole sequence rather than
+                // relying on where the callback happens to be delivered.
+                [weakSelf.dispatchQueueManager runSerialAsync:^{
+                    __strong typeof(weakSelf) strongSelf = weakSelf;
+                    if (!strongSelf) return;
+
+                    NSArray<CleverTapDisplayUnit *> *unitsToStore = displayUnits;
+                    if (source == CTResponseSourceContentFetch) {
+                        // updateDisplayUnits: replaces the cache, and a content fetch response
+                        // carries only the personalized subset — storing it as-is would drop
+                        // everything /a1 delivered. Merge here rather than in the cache: the
+                        // CleverTapDisplayUnitCache protocol is public and its contract is
+                        // "replace", so a host-supplied cache must keep behaving that way.
+                        unitsToStore = [strongSelf mergeDisplayUnits:displayUnits
+                                                                into:[strongSelf.displayUnitCache getAllDisplayUnits]];
+                    }
+                    [strongSelf.displayUnitCache updateDisplayUnits:unitsToStore];
+
+                    // Deliver on main. The callback above is invoked via runSyncMainQueue, so
+                    // displayUnitsUpdated: has always arrived on the main thread — hosts do UI
+                    // work in it, and moving it to the serial queue would break them.
+                    [CTUtils runSyncMainQueue:^{
+                        [strongSelf _notifyDisplayUnitsUpdated];
+                    }];
+                }];
             }];
         }
     }
+}
+
+/*!
+ Merge freshly fetched display units over the ones already cached.
+
+ Existing order is preserved and a unit with a matching `unitID` is replaced in place, so a
+ personalized version supersedes its placeholder without jumping position in a carousel. Units
+ with no counterpart are appended.
+
+ @note `unitID` is never nil — `CleverTapDisplayUnit` substitutes the sentinel `0_0` when a
+ payload has no `wzrk_id`. Several such units therefore share an id and collapse to the last one
+ seen. That only matters for malformed payloads, and matching them by identity instead would
+ grow the cache without bound across responses.
+ */
+- (NSArray<CleverTapDisplayUnit *> *)mergeDisplayUnits:(NSArray<CleverTapDisplayUnit *> *)incoming
+                                                  into:(NSArray<CleverTapDisplayUnit *> *)existing {
+    if (existing.count == 0) {
+        return incoming;
+    }
+
+    NSMutableArray<CleverTapDisplayUnit *> *merged = [existing mutableCopy];
+    NSMutableDictionary<NSString *, NSNumber *> *indexByUnitId = [NSMutableDictionary dictionary];
+    [merged enumerateObjectsUsingBlock:^(CleverTapDisplayUnit *unit, NSUInteger idx, BOOL *stop) {
+        if (unit.unitID) {
+            indexByUnitId[unit.unitID] = @(idx);
+        }
+    }];
+
+    NSUInteger replaced = 0;
+    for (CleverTapDisplayUnit *unit in incoming) {
+        NSNumber *existingIndex = unit.unitID ? indexByUnitId[unit.unitID] : nil;
+        if (existingIndex) {
+            merged[existingIndex.unsignedIntegerValue] = unit;
+            replaced++;
+        } else {
+            if (unit.unitID) {
+                indexByUnitId[unit.unitID] = @(merged.count);
+            }
+            [merged addObject:unit];
+        }
+    }
+
+    CleverTapLogDebug(self.config.logLevel,
+                      @"%@: Merged %lu content fetch display unit(s) into %lu cached (%lu replaced, %lu added)",
+                      self, (unsigned long)incoming.count, (unsigned long)existing.count,
+                      (unsigned long)replaced, (unsigned long)(incoming.count - replaced));
+    return merged;
 }
 #endif
 
@@ -2684,7 +2760,7 @@ static BOOL sharedInstanceErrorLogged;
 #endif
                 
 #if !CLEVERTAP_NO_DISPLAY_UNIT_SUPPORT
-                [self handleDisplayUnitResponse:jsonResp];
+                [self handleDisplayUnitResponse:jsonResp source:source];
 #endif
                 
                 [self handleFeatureFlagsResponse:jsonResp];

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2659,7 +2659,16 @@ static BOOL sharedInstanceErrorLogged;
                         CleverTapLogDebug(self.config.logLevel, @"%@: Ignoring %@ in a content fetch response", self, CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY);
                     }
                 } else if (!self.isUserSwitching) {
-                    [self.contentFetchManager handleContentFetch:jsonResp];
+                    // An app-launch arbitration window needs to know when this batch has settled.
+                    // The completion runs exactly once — including on HTTP failure and on user
+                    // switch — so a window can never be left open, which would otherwise suppress
+                    // app-launch in-apps for the rest of the session.
+                    __weak typeof(self) weakSelf = self;
+                    [self.contentFetchManager handleContentFetch:jsonResp completion:^{
+#if !CLEVERTAP_NO_INAPP_SUPPORT
+                        [weakSelf.inAppEvaluationManager appLaunchedArbitrationContentFetchDidComplete];
+#endif
+                    }];
                 } else if (jsonResp[CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY]) {
                     CleverTapLogDebug(self.config.logLevel, @"%@: Content fetch response will not be handled due to user switch", self);
                 }

--- a/CleverTapSDK/CleverTap.m
+++ b/CleverTapSDK/CleverTap.m
@@ -2615,6 +2615,12 @@ static BOOL sharedInstanceErrorLogged;
 #endif
 
 - (void)parseResponse:(NSData *)responseData responseEncrypted:(BOOL)responseEncrypted {
+    [self parseResponse:responseData responseEncrypted:responseEncrypted source:CTResponseSourceApp];
+}
+
+- (void)parseResponse:(NSData *)responseData
+    responseEncrypted:(BOOL)responseEncrypted
+               source:(CTResponseSource)source {
     if (responseData) {
         @try {
             if (responseEncrypted) {
@@ -2641,11 +2647,18 @@ static BOOL sharedInstanceErrorLogged;
                 }
                 
 #if !CLEVERTAP_NO_INAPP_SUPPORT
-                [self handleInAppResponse:jsonResp];
+                [self handleInAppResponse:jsonResp source:source];
 #endif
                 
 #if !defined(CLEVERTAP_TVOS)
-                if (!self.isUserSwitching) {
+                if (source == CTResponseSourceContentFetch) {
+                    // A content fetch response must not trigger another content fetch. There is no
+                    // depth bound anywhere in the chain, so a response echoing the key back would
+                    // loop indefinitely.
+                    if (jsonResp[CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY]) {
+                        CleverTapLogDebug(self.config.logLevel, @"%@: Ignoring %@ in a content fetch response", self, CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY);
+                    }
+                } else if (!self.isUserSwitching) {
                     [self.contentFetchManager handleContentFetch:jsonResp];
                 } else if (jsonResp[CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY]) {
                     CleverTapLogDebug(self.config.logLevel, @"%@: Content fetch response will not be handled due to user switch", self);
@@ -5769,7 +5782,7 @@ static BOOL sharedInstanceErrorLogged;
 }
 
 - (void)contentFetchManager:(CTContentFetchManager *)manager didReceiveResponse:(NSData *)data {
-    [self parseResponse:data responseEncrypted:NO];
+    [self parseResponse:data responseEncrypted:NO source:CTResponseSourceContentFetch];
 }
 
 - (void)contentFetchManager:(CTContentFetchManager *)manager addMetadataToEvent:(NSMutableDictionary *)event ofType:(CleverTapEventType)eventType {

--- a/CleverTapSDK/CleverTapInternal.h
+++ b/CleverTapSDK/CleverTapInternal.h
@@ -25,6 +25,19 @@ typedef NS_ENUM(NSInteger, CleverTapEventType) {
     CleverTapEventTypeFetch,
 };
 
+/*!
+ Identifies which endpoint a response being parsed came from.
+
+ The `/content` response is re-fed through the same handler chain as `/a1`, so handlers that
+ must behave differently for the two need to know the origin.
+ */
+typedef NS_ENUM(NSInteger, CTResponseSource) {
+    /// Response to an event batch POST to `/a1`.
+    CTResponseSourceApp,
+    /// Response to a content fetch POST to `/content`.
+    CTResponseSourceContentFetch,
+};
+
 #if !CLEVERTAP_NO_INAPP_SUPPORT
 @property (strong, nonatomic, nullable) CleverTapFetchInAppsBlock fetchInAppsBlock;
 @property (nonatomic, strong, readonly) CTInAppDisplayManager * _Nullable inAppDisplayManager;

--- a/CleverTapSDK/InApps/CTInAppEvaluationManager.h
+++ b/CleverTapSDK/InApps/CTInAppEvaluationManager.h
@@ -71,8 +71,15 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param targetIds Campaign ids the content fetch is expected to return. Recorded for diagnostics
  only — the window closes on the fetch's completion signal, not on these arriving.
+
+ @param syntheticCandidates Selection rules for those in-apps, from
+ `CTContentFetchItem.syntheticInAppPayload`. When supplied, the window can often be skipped
+ entirely: if the app-launch winner already outranks all of them, it displays immediately rather
+ than waiting. Pass nil or an empty array to always wait — required unless rules are available
+ for *every* expected in-app, since predicting from a partial set could miss the actual winner.
  */
-- (void)openAppLaunchedArbitrationWithTargetIds:(NSArray<NSString *> *)targetIds;
+- (void)openAppLaunchedArbitrationWithTargetIds:(NSArray<NSString *> *)targetIds
+                            syntheticCandidates:(nullable NSArray<NSDictionary *> *)syntheticCandidates;
 
 /*!
  Report that the content fetch for this launch has settled.

--- a/CleverTapSDK/InApps/CTInAppEvaluationManager.h
+++ b/CleverTapSDK/InApps/CTInAppEvaluationManager.h
@@ -41,6 +41,53 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)evaluateOnAppLaunchedServerSide:(NSArray *)appLaunchedNotifs;
 - (void)evaluateOnAppLaunchedDelayedServerSide:(NSArray *)appLaunchedNotifs;
 - (void)evaluateOnAppLaunchedInActionServerSide:(NSArray *)appLaunchedNotifs;
+
+#pragma mark - App Launched arbitration
+
+/*!
+ How long to hold the app-launch in-app waiting for the content fetch, in seconds.
+
+ This is a UX bound, not a correctness one, and is deliberately far shorter than the content
+ fetch's own limits (10s request, 15s including the wait for a concurrency slot). Matching those
+ would delay the in-app by up to 15s on a slow network.
+
+ Correctness comes from `appLaunchedArbitrationContentFetchDidComplete` instead: a response that
+ arrives after this timeout has fired is dropped rather than shown, so a slow fetch can never
+ produce a second in-app. Exposed mainly for tests.
+ */
+@property (nonatomic, assign) NSTimeInterval appLaunchedArbitrationTimeout;
+
+/*!
+ Defer app-launch in-app display until the content fetch spawned by this response resolves.
+
+ The `/content` response is re-fed through the same handler chain as `/a1`, so without a window
+ each response runs its own independent selection and one in-app is shown per response. While a
+ window is open, `evaluateOnAppLaunchedServerSide:` buffers its winner instead of queueing it;
+ on close a single merged selection runs across every buffered winner, so exactly one in-app is
+ shown for the launch.
+
+ Buffering the per-response winner rather than every eligible candidate is equivalent: the
+ comparator is a total order, so max(max(A), max(B)) == max(A ∪ B).
+
+ @param targetIds Campaign ids the content fetch is expected to return. Recorded for diagnostics
+ only — the window closes on the fetch's completion signal, not on these arriving.
+ */
+- (void)openAppLaunchedArbitrationWithTargetIds:(NSArray<NSString *> *)targetIds;
+
+/*!
+ Report that the content fetch for this launch has settled.
+
+ Displays the merged winner if the timeout has not already done so, then ends the window
+ entirely so subsequent responses are handled normally again.
+
+ Must be called for every window that was opened, on success and on failure alike — otherwise
+ app-launch in-apps stay suppressed for the rest of the session. The content fetch completion
+ block guarantees this by running exactly once in all cases.
+
+ Safe to call with no window open, and idempotent.
+ */
+- (void)appLaunchedArbitrationContentFetchDidComplete;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CleverTapSDK/InApps/CTInAppEvaluationManager.m
+++ b/CleverTapSDK/InApps/CTInAppEvaluationManager.m
@@ -24,6 +24,37 @@
 #import "CleverTapSDK-Swift.h"
 #endif
 
+/*!
+ Deferred app-launch state for one `/a1` response and the content fetch it spawned.
+
+ File-private: the window is an implementation detail of how this manager defers an evaluation,
+ not a collaborator anything else needs to see.
+ */
+@interface CTInAppArbitrationCycle : NSObject
+
+/// Winners buffered so far — one per response handled while the window was open.
+@property (nonatomic, strong) NSMutableArray<NSDictionary *> *candidates;
+
+/// Campaign ids the content fetch said it would return. Diagnostics only.
+@property (nonatomic, copy) NSArray<NSString *> *expectedTargetIds;
+
+/// Set on close, so a late completion and the timeout cannot both arbitrate.
+@property (nonatomic, assign) BOOL closed;
+
+@end
+
+@implementation CTInAppArbitrationCycle
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _candidates = [NSMutableArray array];
+    }
+    return self;
+}
+
+@end
+
 @interface CTInAppEvaluationManager()
 
 @property (nonatomic, strong) NSMutableArray *evaluatedServerSideInAppIds;
@@ -47,6 +78,13 @@
 - (void)evaluateClientSide:(NSArray<CTEventAdapter *> *)events;
 - (NSMutableArray *)evaluate:(CTEventAdapter *)event withInApps:(NSArray *)inApps;
 
+/// Guards `appLaunchedArbitrationCycle`. Mutated from the network thread, the content fetch
+/// queue and the timeout, so every access is synchronized on this.
+@property (nonatomic, strong) NSObject *arbitrationLock;
+
+/// The open arbitration window, or nil when in-apps display immediately as before.
+@property (nonatomic, strong) CTInAppArbitrationCycle *appLaunchedArbitrationCycle;
+
 @end
 
 @implementation CTInAppEvaluationManager
@@ -64,7 +102,10 @@
         self.deviceId = deviceId;
         self.impressionManager = impressionManager;
         self.inAppDisplayManager = inAppDisplayManager;
-        
+
+        self.arbitrationLock = [NSObject new];
+        self.appLaunchedArbitrationTimeout = CLTAP_INAPP_ARBITRATION_TIMEOUT_SECONDS;
+
         self.evaluatedServerSideInAppIds = [NSMutableArray new];
         NSArray *savedEvaluatedServerSideInAppIds = [CTPreferences getObjectForKey:[self storageKeyWithSuffix:CLTAP_INAPP_SS_EVAL_STORAGE_KEY]];
         if (savedEvaluatedServerSideInAppIds) {
@@ -169,7 +210,130 @@
     NSMutableArray *eligibleInApps = [self evaluate:event withInApps:appLaunchedNotifs];
     // Server-side evaluations do **NOT** update TTL
     NSArray<NSDictionary *> *ssInApps = [self selectAndProcessEligibleInApps: eligibleInApps withStrategy:[ImmediateInAppSelectionStrategy shared] withTTL: false];
+    // While a window is open this winner competes against the content fetch result instead of
+    // displaying now. See openAppLaunchedArbitrationWithTargetIds:.
+    if ([self bufferAppLaunchedCandidatesIfArbitrating:ssInApps]) {
+        return;
+    }
     [self.inAppDisplayManager _addInAppNotificationsToQueue:ssInApps];
+}
+
+#pragma mark - App Launched arbitration
+
+- (void)openAppLaunchedArbitrationWithTargetIds:(NSArray<NSString *> *)targetIds {
+    CTInAppArbitrationCycle *cycle = [[CTInAppArbitrationCycle alloc] init];
+    cycle.expectedTargetIds = [targetIds copy];
+
+    @synchronized (self.arbitrationLock) {
+        if (self.appLaunchedArbitrationCycle && !self.appLaunchedArbitrationCycle.closed) {
+            // A window is already open for a previous response. Leave it in place — closing it
+            // here would display its winner and then immediately open a second window, which is
+            // the multi-response behaviour we are trying to remove.
+            CleverTapLogStaticDebug(@"App Launched arbitration already open, not opening another");
+            return;
+        }
+        self.appLaunchedArbitrationCycle = cycle;
+    }
+
+    CleverTapLogStaticDebug(@"Opened App Launched arbitration, expecting %lu content target(s): %@",
+                            (unsigned long)targetIds.count, targetIds);
+
+    // Backstop only. The content fetch completion normally closes the window well before this.
+    __weak typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.appLaunchedArbitrationTimeout * NSEC_PER_SEC)),
+                   dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+
+        // Only time out the window this timer was scheduled for — a later one must not be cut short.
+        BOOL isStillCurrent = NO;
+        @synchronized (strongSelf.arbitrationLock) {
+            isStillCurrent = (strongSelf.appLaunchedArbitrationCycle == cycle && !cycle.closed);
+        }
+        if (isStillCurrent) {
+            CleverTapLogStaticDebug(@"App Launched arbitration timed out after %.1fs, showing best candidate so far",
+                                    strongSelf.appLaunchedArbitrationTimeout);
+            [strongSelf closeAppLaunchedArbitration];
+        }
+    });
+}
+
+- (void)appLaunchedArbitrationContentFetchDidComplete {
+    // Show the merged winner unless the timeout already did.
+    [self closeAppLaunchedArbitration];
+
+    // Nothing further can arrive for this launch, so stop suppressing and return to normal.
+    @synchronized (self.arbitrationLock) {
+        self.appLaunchedArbitrationCycle = nil;
+    }
+}
+
+- (void)closeAppLaunchedArbitration {
+    NSArray<NSDictionary *> *candidates = nil;
+
+    @synchronized (self.arbitrationLock) {
+        CTInAppArbitrationCycle *cycle = self.appLaunchedArbitrationCycle;
+        if (!cycle || cycle.closed) {
+            // No window, or the completion and the timeout raced and the other one won.
+            return;
+        }
+        cycle.closed = YES;
+        candidates = [cycle.candidates copy];
+        // Deliberately not cleared here. The cycle stays in place, closed, so that a content
+        // response arriving after a timeout is suppressed rather than displayed as a second
+        // in-app. It is cleared by appLaunchedArbitrationContentFetchDidComplete.
+    }
+
+    if (candidates.count == 0) {
+        CleverTapLogStaticDebug(@"Closed App Launched arbitration with no eligible candidates");
+        return;
+    }
+
+    // One merged selection across every buffered winner, so exactly one in-app is shown for the
+    // launch. Reuses the normal path so the sort, suppression and reporting stay identical.
+    NSMutableArray *merged = [candidates mutableCopy];
+    NSArray<NSDictionary *> *winner = [self selectAndProcessEligibleInApps:merged
+                                                              withStrategy:[ImmediateInAppSelectionStrategy shared]
+                                                                   withTTL:false];
+    CleverTapLogStaticDebug(@"Closed App Launched arbitration, %lu candidate(s) merged, showing %@",
+                            (unsigned long)candidates.count,
+                            winner.firstObject ? [CTInAppNotification inAppId:winner.firstObject] : @"none");
+
+    [self.inAppDisplayManager _addInAppNotificationsToQueue:winner];
+}
+
+/*!
+ Buffer a response's winner if a window is open, or drop it if the launch's slot is already spent.
+
+ @return YES when the caller must not queue the in-apps for display.
+ */
+- (BOOL)bufferAppLaunchedCandidatesIfArbitrating:(NSArray<NSDictionary *> *)inApps {
+    @synchronized (self.arbitrationLock) {
+        CTInAppArbitrationCycle *cycle = self.appLaunchedArbitrationCycle;
+        if (!cycle) {
+            return NO;
+        }
+
+        if (cycle.closed) {
+            // The window timed out and an in-app has already been shown for this launch. This
+            // response lost the race — display it now and the user sees two in-apps, which is
+            // the bug the window exists to prevent. Drop it.
+            if (inApps.count > 0) {
+                CleverTapLogStaticDebug(@"Dropping %lu late App Launched candidate(s), arbitration already closed",
+                                        (unsigned long)inApps.count);
+            }
+            return YES;
+        }
+
+        // An empty selection still counts as handled — nothing was eligible in this response, and
+        // falling through would call the display queue with an empty array.
+        if (inApps.count > 0) {
+            [cycle.candidates addObjectsFromArray:inApps];
+            CleverTapLogStaticDebug(@"Buffered %lu App Launched candidate(s) for arbitration, %lu total",
+                                    (unsigned long)inApps.count, (unsigned long)cycle.candidates.count);
+        }
+        return YES;
+    }
 }
 
 - (void)evaluateOnAppLaunchedDelayedServerSide:(NSArray<NSDictionary *> *)appLaunchedNotifs {

--- a/CleverTapSDK/InApps/CTInAppEvaluationManager.m
+++ b/CleverTapSDK/InApps/CTInAppEvaluationManager.m
@@ -55,6 +55,39 @@
 
 @end
 
+/*!
+ A trigger counter that reports a fixed number above the live one, without writing anything.
+
+ Needed because the real evaluation increments a campaign's trigger count *before* limits are
+ checked, so `onEvery` / `onExactly` compare against N+1. A dry run must not persist that
+ increment, but reading the raw N would flip those limits' result — silently mispredicting
+ exactly the campaigns that use trigger-based limits. Offsetting the read reproduces what the
+ real path would see while leaving storage untouched.
+ */
+@interface CTOffsetTriggerCounter : NSObject <CTTriggerCounting>
+- (instancetype)initWithCounter:(id<CTTriggerCounting>)counter offset:(NSUInteger)offset;
+@end
+
+@implementation CTOffsetTriggerCounter {
+    id<CTTriggerCounting> _counter;
+    NSUInteger _offset;
+}
+
+- (instancetype)initWithCounter:(id<CTTriggerCounting>)counter offset:(NSUInteger)offset {
+    self = [super init];
+    if (self) {
+        _counter = counter;
+        _offset = offset;
+    }
+    return self;
+}
+
+- (NSUInteger)getTriggers:(NSString *)campaignId {
+    return [_counter getTriggers:campaignId] + _offset;
+}
+
+@end
+
 @interface CTInAppEvaluationManager()
 
 @property (nonatomic, strong) NSMutableArray *evaluatedServerSideInAppIds;
@@ -291,7 +324,7 @@
 
     // One merged selection across every buffered winner, so exactly one in-app is shown for the
     // launch. Reuses the normal path so the sort, suppression and reporting stay identical.
-    NSMutableArray *merged = [candidates mutableCopy];
+    NSMutableArray *merged = [[self class] withoutSyntheticCandidates:candidates];
     NSArray<NSDictionary *> *winner = [self selectAndProcessEligibleInApps:merged
                                                               withStrategy:[ImmediateInAppSelectionStrategy shared]
                                                                    withTTL:false];
@@ -327,13 +360,34 @@
 
         // An empty selection still counts as handled — nothing was eligible in this response, and
         // falling through would call the display queue with an empty array.
-        if (inApps.count > 0) {
-            [cycle.candidates addObjectsFromArray:inApps];
+        NSArray<NSDictionary *> *displayable = [[self class] withoutSyntheticCandidates:inApps];
+        if (displayable.count > 0) {
+            [cycle.candidates addObjectsFromArray:displayable];
             CleverTapLogStaticDebug(@"Buffered %lu App Launched candidate(s) for arbitration, %lu total",
-                                    (unsigned long)inApps.count, (unsigned long)cycle.candidates.count);
+                                    (unsigned long)displayable.count, (unsigned long)cycle.candidates.count);
         }
         return YES;
     }
+}
+
+/*!
+ Strip payloads built for speculative evaluation only.
+
+ A synthetic candidate carries selection rules but no content, so displaying one would render an
+ empty in-app. They should never reach here — this is a boundary check on the display path, not
+ flow control, so anything filtered out is logged as a programming error.
+ */
++ (NSMutableArray<NSDictionary *> *)withoutSyntheticCandidates:(NSArray<NSDictionary *> *)inApps {
+    NSMutableArray<NSDictionary *> *displayable = [NSMutableArray arrayWithCapacity:inApps.count];
+    for (NSDictionary *inApp in inApps) {
+        if ([inApp[CLTAP_INAPP_SYNTHETIC_CANDIDATE] boolValue]) {
+            CleverTapLogStaticDebug(@"Refusing to display synthetic candidate %@ — it has no content",
+                                    [CTInAppNotification inAppId:inApp]);
+            continue;
+        }
+        [displayable addObject:inApp];
+    }
+    return displayable;
 }
 
 - (void)evaluateOnAppLaunchedDelayedServerSide:(NSArray<NSDictionary *> *)appLaunchedNotifs {
@@ -476,7 +530,28 @@
 }
 
 - (NSMutableArray *)evaluate:(CTEventAdapter *)event withInApps:(NSArray *)inApps {
+    return [self evaluate:event withInApps:inApps recordTriggers:YES];
+}
+
+/*!
+ Evaluate in-apps against an event, optionally without recording trigger counts.
+
+ @param recordTriggers `YES` for a real evaluation. `NO` for a dry run — used to predict whether
+ a candidate would qualify without mutating persisted state, so the same campaign can be
+ evaluated for real later without its trigger count being counted twice.
+
+ A dry run is not simply "skip the increment". The real path increments *before* checking limits,
+ so `onEvery` / `onExactly` compare against N+1; reading the raw N would flip their result. The
+ offsetting counter reproduces that view without writing it.
+ */
+- (NSMutableArray *)evaluate:(CTEventAdapter *)event
+                  withInApps:(NSArray *)inApps
+              recordTriggers:(BOOL)recordTriggers {
     NSMutableArray *eligibleInApps = [NSMutableArray new];
+    id<CTTriggerCounting> triggerCounter = recordTriggers
+        ? self.triggerManager
+        : [[CTOffsetTriggerCounter alloc] initWithCounter:self.triggerManager offset:1];
+
     for (NSDictionary *inApp in inApps) {
         NSString *campaignId = [CTInAppNotification inAppId:inApp];
         if (!campaignId) {
@@ -493,8 +568,10 @@
         CleverTapLogStaticDebug(@"Triggers matched for event %@ against inApp %@",[event eventName], campaignId);
         
         // In-app matches the trigger, increment trigger count
-        [self.triggerManager incrementTrigger:campaignId];
-        
+        if (recordTriggers) {
+            [self.triggerManager incrementTrigger:campaignId];
+        }
+
         // Match limits
         NSArray *frequencyLimits = inApp[CLTAP_INAPP_FC_LIMITS];
         NSArray *occurrenceLimits = inApp[CLTAP_INAPP_OCCURRENCE_LIMITS];
@@ -502,7 +579,7 @@
         [whenLimits addObjectsFromArray:frequencyLimits];
         [whenLimits addObjectsFromArray:occurrenceLimits];
         BOOL matchesLimits = [self.limitsMatcher matchWhenLimits:whenLimits forCampaignId:campaignId
-                                           withImpressionManager:self.impressionManager andTriggerManager:self.triggerManager];
+                                           withImpressionManager:self.impressionManager andTriggerManager:triggerCounter];
         if (matchesLimits) {
             CleverTapLogStaticDebug(@"Limits matched for event %@ against inApp %@",[event eventName], campaignId);
             [eligibleInApps addObject:inApp];

--- a/CleverTapSDK/InApps/CTInAppEvaluationManager.m
+++ b/CleverTapSDK/InApps/CTInAppEvaluationManager.m
@@ -38,8 +38,24 @@
 /// Campaign ids the content fetch said it would return. Diagnostics only.
 @property (nonatomic, copy) NSArray<NSString *> *expectedTargetIds;
 
+/*!
+ Selection rules for the in-apps the content fetch will return, as synthetic payloads.
+
+ Empty when the backend has not sent enough to predict with, in which case the window simply
+ waits for the real response instead.
+ */
+@property (nonatomic, copy) NSArray<NSDictionary *> *syntheticCandidates;
+
 /// Set on close, so a late completion and the timeout cannot both arbitrate.
 @property (nonatomic, assign) BOOL closed;
+
+/*!
+ The in-app actually shown for this launch, once one has been.
+
+ Kept only to detect a mispredicted fast path: if a real content candidate later arrives that
+ would have outranked this, the synthetic rules disagreed with the delivered payload.
+ */
+@property (nonatomic, copy) NSDictionary *shownCandidate;
 
 @end
 
@@ -243,19 +259,109 @@
     NSMutableArray *eligibleInApps = [self evaluate:event withInApps:appLaunchedNotifs];
     // Server-side evaluations do **NOT** update TTL
     NSArray<NSDictionary *> *ssInApps = [self selectAndProcessEligibleInApps: eligibleInApps withStrategy:[ImmediateInAppSelectionStrategy shared] withTTL: false];
+    // If the content fetch cannot outrank this winner, there is nothing to wait for.
+    if ([self appLaunchedFastPathBeatsContentFetch:ssInApps forEvent:event]) {
+        [self.inAppDisplayManager _addInAppNotificationsToQueue:ssInApps];
+        return;
+    }
+
     // While a window is open this winner competes against the content fetch result instead of
-    // displaying now. See openAppLaunchedArbitrationWithTargetIds:.
+    // displaying now. See openAppLaunchedArbitrationWithTargetIds:syntheticCandidates:.
     if ([self bufferAppLaunchedCandidatesIfArbitrating:ssInApps]) {
         return;
     }
     [self.inAppDisplayManager _addInAppNotificationsToQueue:ssInApps];
 }
 
+/*!
+ Decide whether the app-launch winner can be shown now instead of waiting for the content fetch.
+
+ Only possible when the content fetch told us the selection rules of everything it will return
+ (see `CTContentFetchItem.syntheticInAppPayload`). Without them this returns NO and the window
+ waits, which is the behaviour when the backend sends no rules at all.
+
+ The synthetic candidates are evaluated as a **dry run** — they must not record trigger counts,
+ because the real payload is evaluated again when `/content` arrives.
+
+ @return YES when the caller should display `appLaunchedWinners` immediately. The window is
+ marked closed in that case, so the content response is dropped rather than shown as a second
+ in-app.
+ */
+- (BOOL)appLaunchedFastPathBeatsContentFetch:(NSArray<NSDictionary *> *)appLaunchedWinners
+                                    forEvent:(CTEventAdapter *)event {
+    NSArray<NSDictionary *> *synthetics = nil;
+    @synchronized (self.arbitrationLock) {
+        CTInAppArbitrationCycle *cycle = self.appLaunchedArbitrationCycle;
+        if (!cycle || cycle.closed || cycle.syntheticCandidates.count == 0) {
+            return NO;
+        }
+        synthetics = cycle.syntheticCandidates;
+    }
+
+    // Nothing to show now, so the content result is the only possibility — wait for it.
+    if (appLaunchedWinners.count == 0) {
+        return NO;
+    }
+
+    NSMutableArray *eligibleSynthetics = [self evaluate:event withInApps:synthetics recordTriggers:NO];
+    if (eligibleSynthetics.count == 0) {
+        CleverTapLogStaticDebug(@"No content fetch candidate can qualify, showing App Launched in-app without waiting");
+        [self markAppLaunchedArbitrationShown:appLaunchedWinners.firstObject];
+        return YES;
+    }
+
+    // Same comparator as the real selection, but resolve the winner inline rather than through
+    // selectAndProcessEligibleInApps: — that reports suppressions to the server, and these
+    // candidates have not been delivered.
+    NSMutableArray *merged = [appLaunchedWinners mutableCopy];
+    [merged addObjectsFromArray:eligibleSynthetics];
+    [self sortByPriority:merged];
+
+    NSDictionary *predicted = nil;
+    for (NSDictionary *candidate in merged) {
+        if (![self shouldSuppress:candidate]) {
+            predicted = candidate;
+            break;
+        }
+    }
+
+    if (!predicted || [predicted[CLTAP_INAPP_SYNTHETIC_CANDIDATE] boolValue]) {
+        // A content candidate is predicted to win, so waiting for the real payload is worthwhile.
+        CleverTapLogStaticDebug(@"Content fetch candidate %@ predicted to outrank App Launched in-app, waiting",
+                                predicted ? [CTInAppNotification inAppId:predicted] : @"none");
+        return NO;
+    }
+
+    CleverTapLogStaticDebug(@"App Launched in-app %@ outranks every content fetch candidate, showing without waiting",
+                            [CTInAppNotification inAppId:predicted]);
+    [self markAppLaunchedArbitrationShown:appLaunchedWinners.firstObject];
+    return YES;
+}
+
+/*!
+ Record that an in-app has been shown for this launch without going through the buffered path.
+
+ Leaves the cycle in place but closed, so a content response arriving afterwards is suppressed
+ rather than displayed as a second in-app.
+ */
+- (void)markAppLaunchedArbitrationShown:(NSDictionary *)shown {
+    @synchronized (self.arbitrationLock) {
+        CTInAppArbitrationCycle *cycle = self.appLaunchedArbitrationCycle;
+        if (!cycle || cycle.closed) {
+            return;
+        }
+        cycle.closed = YES;
+        cycle.shownCandidate = shown;
+    }
+}
+
 #pragma mark - App Launched arbitration
 
-- (void)openAppLaunchedArbitrationWithTargetIds:(NSArray<NSString *> *)targetIds {
+- (void)openAppLaunchedArbitrationWithTargetIds:(NSArray<NSString *> *)targetIds
+                            syntheticCandidates:(NSArray<NSDictionary *> *)syntheticCandidates {
     CTInAppArbitrationCycle *cycle = [[CTInAppArbitrationCycle alloc] init];
     cycle.expectedTargetIds = [targetIds copy];
+    cycle.syntheticCandidates = [syntheticCandidates copy];
 
     @synchronized (self.arbitrationLock) {
         if (self.appLaunchedArbitrationCycle && !self.appLaunchedArbitrationCycle.closed) {
@@ -332,6 +438,13 @@
                             (unsigned long)candidates.count,
                             winner.firstObject ? [CTInAppNotification inAppId:winner.firstObject] : @"none");
 
+    // Recorded so a candidate arriving after this close can be compared against what was shown.
+    @synchronized (self.arbitrationLock) {
+        if (self.appLaunchedArbitrationCycle) {
+            self.appLaunchedArbitrationCycle.shownCandidate = winner.firstObject;
+        }
+    }
+
     [self.inAppDisplayManager _addInAppNotificationsToQueue:winner];
 }
 
@@ -348,12 +461,13 @@
         }
 
         if (cycle.closed) {
-            // The window timed out and an in-app has already been shown for this launch. This
-            // response lost the race — display it now and the user sees two in-apps, which is
-            // the bug the window exists to prevent. Drop it.
+            // An in-app has already been shown for this launch — either the fast path showed one
+            // without waiting, or the window timed out. This response lost: displaying it now
+            // would give the user two in-apps, the bug the window exists to prevent. Drop it.
             if (inApps.count > 0) {
                 CleverTapLogStaticDebug(@"Dropping %lu late App Launched candidate(s), arbitration already closed",
                                         (unsigned long)inApps.count);
+                [self logIfMispredicted:inApps.firstObject against:cycle.shownCandidate];
             }
             return YES;
         }
@@ -367,6 +481,28 @@
                                     (unsigned long)displayable.count, (unsigned long)cycle.candidates.count);
         }
         return YES;
+    }
+}
+
+/*!
+ Warn when a dropped content candidate would have outranked the in-app already shown.
+
+ Only reachable via the fast path, and only if the selection rules in the `content_fetch` item
+ disagreed with the payload `/content` actually delivered — a backend contract violation. The
+ user has already been shown the wrong in-app by this point, so this is a diagnostic rather than
+ something recoverable.
+ */
+- (void)logIfMispredicted:(NSDictionary *)dropped against:(NSDictionary *)shown {
+    if (!dropped || !shown) {
+        return;
+    }
+
+    NSMutableArray *pair = [@[dropped, shown] mutableCopy];
+    [self sortByPriority:pair];
+    if (pair.firstObject == dropped) {
+        CleverTapLogStaticDebug(@"Content fetch candidate %@ outranks the already-shown %@ — the "
+                                "selection rules sent with content_fetch disagree with the delivered payload",
+                                [CTInAppNotification inAppId:dropped], [CTInAppNotification inAppId:shown]);
     }
 }
 

--- a/CleverTapSDK/InApps/CTInAppTriggerManager.h
+++ b/CleverTapSDK/InApps/CTInAppTriggerManager.h
@@ -11,7 +11,21 @@
 NS_ASSUME_NONNULL_BEGIN
 @class CTMultiDelegateManager;
 
-@interface CTInAppTriggerManager : NSObject <CTSwitchUserDelegate>
+/*!
+ Read-only access to a campaign's trigger count.
+
+ Exists so limit matching can be pointed at something other than the live, persisted counter. A
+ speculative evaluation must not write a trigger count, but it still has to evaluate limits
+ against the count the real path *would* see — the real path increments before checking limits,
+ so `onEvery` / `onExactly` compare against N+1.
+ */
+@protocol CTTriggerCounting <NSObject>
+
+- (NSUInteger)getTriggers:(NSString *)campaignId;
+
+@end
+
+@interface CTInAppTriggerManager : NSObject <CTSwitchUserDelegate, CTTriggerCounting>
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithAccountId:(NSString *)accountId

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.h
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.h
@@ -11,7 +11,18 @@
 
 @interface CleverTap(InAppsResponseHandler)
 
+/// Equivalent to `handleInAppResponse:source:` with `CTResponseSourceApp`.
 - (void)handleInAppResponse:(NSDictionary *)jsonResp;
+
+/*!
+ Handle the in-app keys of a response.
+
+ @param jsonResp The JSON response dictionary
+ @param source Which endpoint the response came from. The `/content` response passes through
+ this same handler, and some keys must be treated differently depending on the origin.
+ */
+- (void)handleInAppResponse:(NSDictionary *)jsonResp source:(CTResponseSource)source;
+
 - (void)triggerFetchInApps:(BOOL)success;
 
 @end

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -50,11 +50,16 @@
     }
 
     NSMutableArray<NSString *> *targetIds = [NSMutableArray array];
+    NSMutableArray<NSDictionary *> *syntheticCandidates = [NSMutableArray array];
     for (CTContentFetchItem *item in items) {
         BOOL isAppLaunched = [item.eventName isEqualToString:CLTAP_APP_LAUNCHED_EVENT];
         BOOL isInAppKey = [item.responseKey isEqualToString:CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY];
         if (isAppLaunched && isInAppKey && item.targetId) {
             [targetIds addObject:item.targetId];
+            NSDictionary *synthetic = item.syntheticInAppPayload;
+            if (synthetic) {
+                [syntheticCandidates addObject:synthetic];
+            }
         }
     }
 
@@ -62,7 +67,18 @@
         return;
     }
 
-    [self.inAppEvaluationManager openAppLaunchedArbitrationWithTargetIds:targetIds];
+    // All or nothing. Predicting from a partial set could miss the campaign that would actually
+    // have won, so unless every expected in-app came with its selection rules, wait for the real
+    // response instead. Today no payload carries them, so this is always the empty case.
+    BOOL canPredict = (syntheticCandidates.count == targetIds.count);
+    if (!canPredict && syntheticCandidates.count > 0) {
+        CleverTapLogDebug(self.config.logLevel,
+                          @"%@: Only %lu of %lu content fetch items carry selection rules, cannot predict — will wait",
+                          self, (unsigned long)syntheticCandidates.count, (unsigned long)targetIds.count);
+    }
+
+    [self.inAppEvaluationManager openAppLaunchedArbitrationWithTargetIds:targetIds
+                                                    syntheticCandidates:(canPredict ? syntheticCandidates : nil)];
 #endif
 }
 

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -24,6 +24,10 @@
 @implementation CleverTap(InAppsResponseHandler)
 
 - (void)handleInAppResponse:(NSDictionary *)jsonResp {
+    [self handleInAppResponse:jsonResp source:CTResponseSourceApp];
+}
+
+- (void)handleInAppResponse:(NSDictionary *)jsonResp source:(CTResponseSource)source {
 #if !CLEVERTAP_NO_INAPP_SUPPORT
     if (self.config.analyticsOnly || [CTUIUtils runningInsideAppExtension]) {
         return;
@@ -93,7 +97,13 @@
     // CS in-apps (inapp_notifs_cs)
     // Only process when the key is present in the response. When present (even as an
     // empty array), always store so that stopped campaigns are cleared from preferences.
-    if (jsonResp[CLTAP_INAPP_CS_JSON_RESPONSE_KEY]) {
+    if (jsonResp[CLTAP_INAPP_CS_JSON_RESPONSE_KEY] && source == CTResponseSourceContentFetch) {
+        // storeClientSideInApps: replaces the whole store, and the clear-on-empty behaviour above
+        // means an empty array would wipe every client-side campaign — persisted, so it would
+        // survive until the next /a1. A content fetch response is not expected to carry this key;
+        // ignore it rather than clobber the store from a partial response.
+        CleverTapLogDebug(self.config.logLevel, @"%@: Ignoring %@ in a content fetch response", self, CLTAP_INAPP_CS_JSON_RESPONSE_KEY);
+    } else if (jsonResp[CLTAP_INAPP_CS_JSON_RESPONSE_KEY]) {
         ImmediateAndDelayed *partitionedClientSideInApps = [InAppDurationPartitioner partitionImmediateDelayedInApps:jsonResp[CLTAP_INAPP_CS_JSON_RESPONSE_KEY]];
 
         NSArray *immediateInApps = partitionedClientSideInApps.immediateInApps;

--- a/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
+++ b/CleverTapSDK/InApps/CleverTap+InAppsResponseHandler.m
@@ -15,6 +15,9 @@
 #import "CleverTapInternal.h"
 #import "CTUtils.h"
 #import "CTCustomTemplatesManager-Internal.h"
+#if !defined(CLEVERTAP_TVOS)
+#import "CTContentFetchManager.h"
+#endif
 #if __has_include(<CleverTapSDK/CleverTapSDK-Swift.h>)
 #import <CleverTapSDK/CleverTapSDK-Swift.h>
 #else
@@ -25,6 +28,42 @@
 
 - (void)handleInAppResponse:(NSDictionary *)jsonResp {
     [self handleInAppResponse:jsonResp source:CTResponseSourceApp];
+}
+
+/*!
+ Open an app-launch arbitration window if this response's `content_fetch` will bring back more
+ app-launch in-apps.
+
+ Two conditions must hold, and both come from fields already present in the payload:
+
+ - `responseKey` names an in-app key. A content fetch for inbox or display units must not delay
+   an in-app.
+ - `eventName` is `App Launched`. Other events are out of scope: for them the server-side path
+   uses `inapp_notifs`, which has no selection step at all, so there is no "show exactly one"
+   guarantee to protect.
+ */
+- (void)openAppLaunchedArbitrationIfNeeded:(NSDictionary *)jsonResp {
+#if !defined(CLEVERTAP_TVOS)
+    NSArray<CTContentFetchItem *> *items = [CTContentFetchManager contentFetchItemsFromResponse:jsonResp];
+    if (items.count == 0) {
+        return;
+    }
+
+    NSMutableArray<NSString *> *targetIds = [NSMutableArray array];
+    for (CTContentFetchItem *item in items) {
+        BOOL isAppLaunched = [item.eventName isEqualToString:CLTAP_APP_LAUNCHED_EVENT];
+        BOOL isInAppKey = [item.responseKey isEqualToString:CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY];
+        if (isAppLaunched && isInAppKey && item.targetId) {
+            [targetIds addObject:item.targetId];
+        }
+    }
+
+    if (targetIds.count == 0) {
+        return;
+    }
+
+    [self.inAppEvaluationManager openAppLaunchedArbitrationWithTargetIds:targetIds];
+#endif
 }
 
 - (void)handleInAppResponse:(NSDictionary *)jsonResp source:(CTResponseSource)source {
@@ -58,6 +97,13 @@
     if ([partitionedLegacyMetaInApps hasInActionInApps]) {
         // Schedule in-action timers
         [self.inAppDisplayManager scheduleInActionInApps:partitionedLegacyMetaInApps.inActionInApps];
+    }
+
+    // Defer app-launch display if this response also asked for a content fetch that will return
+    // more app-launch in-apps. Must happen before the evaluation below so the winner is buffered
+    // rather than shown. No-op unless such a fetch is actually pending.
+    if (source == CTResponseSourceApp) {
+        [self openAppLaunchedArbitrationIfNeeded:jsonResp];
     }
 
     // App launch SS in-apps (inapp_notifs_applaunched -> NORMAL/DELAYED in-app campaigns WITH/WITHOUT advance display rules on app launched event)

--- a/CleverTapSDK/InApps/Matchers/CTLimitsMatcher.h
+++ b/CleverTapSDK/InApps/Matchers/CTLimitsMatcher.h
@@ -15,8 +15,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CTLimitsMatcher : NSObject
 
+/*!
+ @param triggerManager Source of trigger counts for `onEvery` / `onExactly` limits. Normally the
+ live `CTInAppTriggerManager`; a dry run passes an offsetting counter so limits are evaluated
+ against the count the real path would have written, without writing it.
+ */
 - (BOOL)matchWhenLimits:(NSArray *)whenLimits forCampaignId:(NSString *)campaignId
-  withImpressionManager:(CTImpressionManager *)impressionManager andTriggerManager:(CTInAppTriggerManager *)triggerManager;
+  withImpressionManager:(CTImpressionManager *)impressionManager andTriggerManager:(id<CTTriggerCounting>)triggerManager;
 
 @end
 

--- a/CleverTapSDK/InApps/Matchers/CTLimitsMatcher.m
+++ b/CleverTapSDK/InApps/Matchers/CTLimitsMatcher.m
@@ -10,7 +10,7 @@
 
 @implementation CTLimitsMatcher
 
-- (BOOL)matchWhenLimits:(NSArray *)whenLimits forCampaignId:(NSString *)campaignId withImpressionManager:(CTImpressionManager *)impressionManager andTriggerManager:(CTInAppTriggerManager *)triggerManager {
+- (BOOL)matchWhenLimits:(NSArray *)whenLimits forCampaignId:(NSString *)campaignId withImpressionManager:(CTImpressionManager *)impressionManager andTriggerManager:(id<CTTriggerCounting>)triggerManager {
     if (![campaignId isKindOfClass:[NSString class]] || [campaignId length] == 0) {
         return NO;
     }

--- a/CleverTapSDKTests/CTDisplayUnitControllerTest.m
+++ b/CleverTapSDKTests/CTDisplayUnitControllerTest.m
@@ -8,8 +8,10 @@
 #import <XCTest/XCTest.h>
 #import "CTDisplayUnitController.h"
 #import "CleverTap+DisplayUnit.h"
+#import "CleverTap+Tests.h"
+#import "BaseTestCase.h"
 
-@interface CTDisplayUnitControllerTest : XCTestCase
+@interface CTDisplayUnitControllerTest : BaseTestCase
 @property (nonatomic, strong) CTDisplayUnitController *controller;
 @end
 
@@ -72,6 +74,104 @@
     CleverTapDisplayUnit *u3 = [[CleverTapDisplayUnit alloc] initWithJSON:@{@"wzrk_id": @"u3"}];
     [self.controller updateDisplayUnits:@[u2, u3]];
     XCTAssertEqual(self.controller.displayUnits.count, 2u);
+}
+
+#pragma mark - Content fetch merge
+
+/*
+ updateDisplayUnits: replaces, which is correct for /a1 but would drop everything already
+ cached if applied to a /content response — that carries only the personalized subset. The
+ merge runs in CleverTap before the cache call, so a host-supplied CleverTapDisplayUnitCache
+ keeps its documented replace contract.
+ */
+
+- (CleverTapDisplayUnit *)unitWithId:(NSString *)unitId type:(NSString *)type {
+    return [[CleverTapDisplayUnit alloc] initWithJSON:@{ @"wzrk_id": unitId, @"type": type }];
+}
+
+- (NSArray<NSString *> *)unitIdsOf:(NSArray<CleverTapDisplayUnit *> *)units {
+    NSMutableArray *ids = [NSMutableArray array];
+    for (CleverTapDisplayUnit *unit in units) {
+        [ids addObject:unit.unitID ?: @"<nil>"];
+    }
+    return ids;
+}
+
+- (void)test_mergeDisplayUnits_appendsNewUnitsAndKeepsExisting {
+    CleverTap *ct = self.cleverTapInstance;
+    NSArray *existing = @[[self unitWithId:@"a" type:@"banner"], [self unitWithId:@"b" type:@"banner"]];
+    NSArray *incoming = @[[self unitWithId:@"c" type:@"banner"]];
+
+    NSArray *merged = [ct mergeDisplayUnits:incoming into:existing];
+
+    // The whole point: /a1's units must survive a content fetch response.
+    XCTAssertEqualObjects([self unitIdsOf:merged], (@[@"a", @"b", @"c"]));
+}
+
+- (void)test_mergeDisplayUnits_replacesMatchingUnitInPlace {
+    CleverTap *ct = self.cleverTapInstance;
+    NSArray *existing = @[[self unitWithId:@"a" type:@"banner"],
+                          [self unitWithId:@"b" type:@"banner"],
+                          [self unitWithId:@"c" type:@"banner"]];
+    NSArray *incoming = @[[self unitWithId:@"b" type:@"personalized"]];
+
+    NSArray *merged = [ct mergeDisplayUnits:incoming into:existing];
+
+    // Position preserved, so a personalized unit does not jump to the end of a carousel.
+    XCTAssertEqualObjects([self unitIdsOf:merged], (@[@"a", @"b", @"c"]));
+    XCTAssertEqualObjects(((CleverTapDisplayUnit *)merged[1]).type, @"personalized");
+}
+
+- (void)test_mergeDisplayUnits_withEmptyExisting_returnsIncoming {
+    CleverTap *ct = self.cleverTapInstance;
+    NSArray *incoming = @[[self unitWithId:@"a" type:@"banner"]];
+
+    XCTAssertEqualObjects([self unitIdsOf:[ct mergeDisplayUnits:incoming into:@[]]], (@[@"a"]));
+    XCTAssertEqualObjects([self unitIdsOf:[ct mergeDisplayUnits:incoming into:nil]], (@[@"a"]));
+}
+
+- (void)test_mergeDisplayUnits_mixedReplaceAndAppend {
+    CleverTap *ct = self.cleverTapInstance;
+    NSArray *existing = @[[self unitWithId:@"a" type:@"banner"], [self unitWithId:@"b" type:@"banner"]];
+    NSArray *incoming = @[[self unitWithId:@"b" type:@"personalized"],
+                          [self unitWithId:@"c" type:@"personalized"]];
+
+    NSArray *merged = [ct mergeDisplayUnits:incoming into:existing];
+
+    XCTAssertEqualObjects([self unitIdsOf:merged], (@[@"a", @"b", @"c"]));
+    XCTAssertEqual(merged.count, 3u);
+}
+
+/*
+ A payload with no wzrk_id gets the sentinel unitID "0_0" from CleverTapDisplayUnit, so several
+ such units share an id and collapse to the last seen. Documenting the real behaviour rather
+ than asserting an invented one — matching them by object identity instead would grow the cache
+ without bound across responses.
+ */
+- (void)test_mergeDisplayUnits_unitsWithoutWzrkIdShareSentinelAndCollapse {
+    CleverTap *ct = self.cleverTapInstance;
+    CleverTapDisplayUnit *noId1 = [[CleverTapDisplayUnit alloc] initWithJSON:@{ @"type": @"banner" }];
+    CleverTapDisplayUnit *noId2 = [[CleverTapDisplayUnit alloc] initWithJSON:@{ @"type": @"personalized" }];
+    XCTAssertEqualObjects(noId1.unitID, @"0_0");
+    XCTAssertEqualObjects(noId2.unitID, @"0_0");
+
+    NSArray *merged = [ct mergeDisplayUnits:@[noId2] into:@[[self unitWithId:@"a" type:@"banner"], noId1]];
+
+    XCTAssertEqual(merged.count, 2u);
+    XCTAssertEqualObjects([self unitIdsOf:merged], (@[@"a", @"0_0"]));
+    XCTAssertEqualObjects(((CleverTapDisplayUnit *)merged[1]).type, @"personalized",
+                          @"the later unit replaces the earlier one sharing the sentinel id");
+}
+
+- (void)test_mergeDisplayUnits_repeatedMergesDoNotDuplicate {
+    CleverTap *ct = self.cleverTapInstance;
+    NSArray *existing = @[[self unitWithId:@"a" type:@"banner"]];
+    NSArray *incoming = @[[self unitWithId:@"b" type:@"banner"]];
+
+    NSArray *once = [ct mergeDisplayUnits:incoming into:existing];
+    NSArray *twice = [ct mergeDisplayUnits:incoming into:once];
+
+    XCTAssertEqualObjects([self unitIdsOf:twice], (@[@"a", @"b"]));
 }
 
 @end

--- a/CleverTapSDKTests/CleverTap+Tests.h
+++ b/CleverTapSDKTests/CleverTap+Tests.h
@@ -33,6 +33,7 @@
 - (void)queueEvent:(NSDictionary *)event withType:(CleverTapEventType)type flattenedEventData:(CTFlattenedEventData *)flattenedEventData;
 - (void)evaluateOnEvent:(NSDictionary *)event withType:(CleverTapEventType)eventType flattenedEventData:(CTFlattenedEventData *)flattenedEventData;
 - (void)setUserSetLocation:(CLLocationCoordinate2D)location;
+- (NSArray *)mergeDisplayUnits:(NSArray *)incoming into:(NSArray *)existing;
 + (BOOL)isPersonalizationEnabled;
 - (id)getProperty:(NSString *)propertyName;
 - (void)flushQueue;

--- a/CleverTapSDKTests/ContentFetch/CTContentFetchManagerTests.m
+++ b/CleverTapSDKTests/ContentFetch/CTContentFetchManagerTests.m
@@ -821,4 +821,223 @@
     XCTAssertEqual(self.contentFetchManager.contentFetchQueue.count, 0);
 }
 
+#pragma mark - CTContentFetchItem Parsing Tests
+
+- (NSDictionary *)responseWithItems:(NSArray *)items {
+    return @{ CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY: items };
+}
+
+- (void)testContentFetchItemsParsesFields {
+    NSArray<CTContentFetchItem *> *items = [CTContentFetchManager contentFetchItemsFromResponse:
+        [self responseWithItems:@[@{
+            CLTAP_CONTENT_FETCH_ITEM_EVENT_NAME: CLTAP_APP_LAUNCHED_EVENT,
+            CLTAP_CONTENT_FETCH_ITEM_RESPONSE_KEY: CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY,
+            CLTAP_CONTENT_FETCH_ITEM_TGT_ID: @1787567474
+        }]]];
+
+    XCTAssertEqual(items.count, 1);
+    XCTAssertEqualObjects(items.firstObject.eventName, CLTAP_APP_LAUNCHED_EVENT);
+    XCTAssertEqualObjects(items.firstObject.responseKey, CLTAP_INAPP_SS_APP_LAUNCHED_JSON_RESPONSE_KEY);
+}
+
+/*!
+ `tgtId` arrives as a number but is compared against an in-app's `ti`, which may be a number or
+ a string. If normalization broke, the arbitration window would never match its expected
+ targets and would silently rely on the timeout instead.
+ */
+- (void)testContentFetchItemsNormalizesTargetIdToString {
+    NSArray<CTContentFetchItem *> *fromNumber = [CTContentFetchManager contentFetchItemsFromResponse:
+        [self responseWithItems:@[@{ CLTAP_CONTENT_FETCH_ITEM_TGT_ID: @1787567474 }]]];
+    NSArray<CTContentFetchItem *> *fromString = [CTContentFetchManager contentFetchItemsFromResponse:
+        [self responseWithItems:@[@{ CLTAP_CONTENT_FETCH_ITEM_TGT_ID: @"1787567474" }]]];
+
+    XCTAssertEqualObjects(fromNumber.firstObject.targetId, @"1787567474");
+    XCTAssertEqualObjects(fromString.firstObject.targetId, @"1787567474");
+}
+
+- (void)testContentFetchItemsWithMissingFieldsYieldsNils {
+    NSArray<CTContentFetchItem *> *items = [CTContentFetchManager contentFetchItemsFromResponse:
+        [self responseWithItems:@[@{ @"unrelated": @"value" }]]];
+
+    XCTAssertEqual(items.count, 1);
+    XCTAssertNil(items.firstObject.eventName);
+    XCTAssertNil(items.firstObject.responseKey);
+    XCTAssertNil(items.firstObject.targetId);
+}
+
+- (void)testContentFetchItemsSkipsMalformedEntries {
+    NSArray<CTContentFetchItem *> *items = [CTContentFetchManager contentFetchItemsFromResponse:
+        [self responseWithItems:@[
+            @"not a dictionary",
+            @[@"neither is this"],
+            @{ CLTAP_CONTENT_FETCH_ITEM_TGT_ID: @1 }
+        ]]];
+
+    XCTAssertEqual(items.count, 1, @"non-dictionary entries must be skipped, not crash");
+    XCTAssertEqualObjects(items.firstObject.targetId, @"1");
+}
+
+- (void)testContentFetchItemsWithAbsentOrEmptyKeyIsEmpty {
+    XCTAssertEqual([CTContentFetchManager contentFetchItemsFromResponse:@{}].count, 0);
+    XCTAssertEqual([CTContentFetchManager contentFetchItemsFromResponse:[self responseWithItems:@[]]].count, 0);
+    XCTAssertEqual([CTContentFetchManager contentFetchItemsFromResponse:
+        @{ CLTAP_CONTENT_FETCH_JSON_RESPONSE_KEY: @"not an array" }].count, 0);
+}
+
+- (void)testContentFetchItemPreservesRawItemVerbatim {
+    NSDictionary *raw = @{
+        CLTAP_CONTENT_FETCH_ITEM_TGT_ID: @1,
+        @"extraServerField": @"must survive"
+    };
+    NSArray<CTContentFetchItem *> *items = [CTContentFetchManager contentFetchItemsFromResponse:
+        [self responseWithItems:@[raw]]];
+
+    // The outbound request echoes rawItem back, so the wire format must not be altered.
+    XCTAssertEqualObjects(items.firstObject.rawItem, raw);
+}
+
+#pragma mark - Synthetic Payload Tests
+
+- (CTContentFetchItem *)itemWithJSON:(NSDictionary *)json {
+    return [CTContentFetchManager contentFetchItemsFromResponse:
+        [self responseWithItems:@[json]]].firstObject;
+}
+
+/*!
+ Without a priority, `sortByPriority:` would silently default to 1 and mispredict any campaign
+ that sets one — a wrong answer that looks like a right one. No prediction is preferable.
+ */
+- (void)testSyntheticPayloadIsNilWithoutPriority {
+    CTContentFetchItem *item = [self itemWithJSON:@{
+        CLTAP_CONTENT_FETCH_ITEM_TGT_ID: @300,
+        CLTAP_INAPP_TRIGGERS: @[@{ @"eventName": CLTAP_APP_LAUNCHED_EVENT }]
+    }];
+
+    XCTAssertNil(item.syntheticInAppPayload);
+}
+
+- (void)testSyntheticPayloadIsNilWithoutTargetId {
+    CTContentFetchItem *item = [self itemWithJSON:@{ CLTAP_INAPP_PRIORITY: @50 }];
+
+    XCTAssertNil(item.syntheticInAppPayload);
+}
+
+- (void)testSyntheticPayloadCarriesSelectionRulesOnly {
+    CTContentFetchItem *item = [self itemWithJSON:@{
+        CLTAP_CONTENT_FETCH_ITEM_TGT_ID: @300,
+        CLTAP_INAPP_PRIORITY: @50,
+        CLTAP_INAPP_IS_SUPPRESSED: @NO,
+        CLTAP_DELAY_AFTER_TRIGGER: @0,
+        CLTAP_INAPP_TRIGGERS: @[@{ @"eventName": CLTAP_APP_LAUNCHED_EVENT }],
+        CLTAP_INAPP_FC_LIMITS: @[],
+        CLTAP_INAPP_OCCURRENCE_LIMITS: @[],
+        // Content, which must not be copied across — a synthetic payload is never displayed.
+        @"message": @{ @"text": @"should not be copied" },
+        @"media": @{ @"url": @"http://example.com/x.png" }
+    }];
+
+    NSDictionary *payload = item.syntheticInAppPayload;
+    XCTAssertNotNil(payload);
+    XCTAssertEqualObjects(payload[CLTAP_INAPP_ID], @"300", @"ti must come from tgtId");
+    XCTAssertEqualObjects(payload[CLTAP_INAPP_PRIORITY], @50);
+    XCTAssertEqualObjects(payload[CLTAP_INAPP_TRIGGERS], @[@{ @"eventName": CLTAP_APP_LAUNCHED_EVENT }]);
+    XCTAssertTrue([payload[CLTAP_INAPP_SYNTHETIC_CANDIDATE] boolValue],
+                  @"must be tagged so the display path can reject it");
+    XCTAssertNil(payload[@"message"]);
+    XCTAssertNil(payload[@"media"]);
+}
+
+- (void)testSyntheticPayloadOmitsAbsentSelectionKeys {
+    CTContentFetchItem *item = [self itemWithJSON:@{
+        CLTAP_CONTENT_FETCH_ITEM_TGT_ID: @300,
+        CLTAP_INAPP_PRIORITY: @50
+    }];
+
+    NSDictionary *payload = item.syntheticInAppPayload;
+    XCTAssertNotNil(payload);
+    // Keys the backend has not sent are simply absent, keeping this forward-compatible.
+    XCTAssertNil(payload[CLTAP_INAPP_TRIGGERS]);
+    XCTAssertNil(payload[CLTAP_INAPP_TEMPLATE_NAME]);
+}
+
+#pragma mark - Batch Completion Contract Tests
+
+/*!
+ An arbitration window suppresses app-launch in-apps until the fetch reports completion, so a
+ missed signal would suppress them for the rest of the session. These cover the paths that
+ previously dropped a batch with no signal at all.
+ */
+- (void)testCompletionRunsOnSuccessfulResponse {
+    [self stubRequestsSuccess];
+
+    XCTestExpectation *completed = [self expectationWithDescription:@"completion runs"];
+    [self.contentFetchManager handleContentFetch:[self responseWithItems:@[@{ @"test": @"data" }]]
+                                     completion:^{ [completed fulfill]; }];
+
+    [self waitForExpectations:@[completed] timeout:5.0];
+}
+
+- (void)testCompletionRunsOnHTTPError {
+    [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return [request.URL.absoluteString containsString:@"content"];
+    } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+        return [HTTPStubsResponse responseWithJSONObject:@{} statusCode:500 headers:nil];
+    }];
+
+    XCTestExpectation *completed = [self expectationWithDescription:@"completion runs on failure"];
+    [self.contentFetchManager handleContentFetch:[self responseWithItems:@[@{ @"test": @"data" }]]
+                                     completion:^{ [completed fulfill]; }];
+
+    [self waitForExpectations:@[completed] timeout:5.0];
+}
+
+- (void)testCompletionRunsWhenContentFetchKeyAbsent {
+    XCTestExpectation *completed = [self expectationWithDescription:@"completion runs with nothing to fetch"];
+    [self.contentFetchManager handleContentFetch:@{} completion:^{ [completed fulfill]; }];
+
+    [self waitForExpectations:@[completed] timeout:1.0];
+}
+
+- (void)testCompletionRunsExactlyOnce {
+    [self stubRequestsSuccess];
+
+    __block NSInteger completionCount = 0;
+    XCTestExpectation *completed = [self expectationWithDescription:@"completion runs"];
+    [self.contentFetchManager handleContentFetch:[self responseWithItems:@[@{ @"test": @"data" }]]
+                                     completion:^{
+        completionCount++;
+        [completed fulfill];
+    }];
+    [self waitForExpectations:@[completed] timeout:5.0];
+
+    // Re-driving an already-completed batch must not fire the completion a second time.
+    [self.contentFetchManager fetchContentAtIndex:0];
+
+    XCTestExpectation *drained = [self expectationWithDescription:@"queue drained"];
+    dispatch_barrier_async(self.contentFetchManager.concurrentQueue, ^{ [drained fulfill]; });
+    [self waitForExpectations:@[drained] timeout:5.0];
+
+    XCTAssertEqual(completionCount, 1);
+}
+
+- (void)testCompletionRunsWhenAbandonedByUserSwitch {
+    // Responses slower than the user switch will wait for, so the batch is abandoned mid-flight.
+    self.contentFetchManager.userSwitchTimeout = 1.0;
+    [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        return [request.URL.absoluteString containsString:@"content"];
+    } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+        HTTPStubsResponse *response = [HTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:nil];
+        response.requestTime = 6.0;
+        return response;
+    }];
+
+    XCTestExpectation *completed = [self expectationWithDescription:@"completion runs on user switch"];
+    [self.contentFetchManager handleContentFetch:[self responseWithItems:@[@{ @"test": @"data" }]]
+                                     completion:^{ [completed fulfill]; }];
+
+    [self.contentFetchManager deviceIdWillChange];
+
+    [self waitForExpectations:@[completed] timeout:15.0];
+}
+
 @end

--- a/CleverTapSDKTests/InApps/CTInAppEvaluationManager+Tests.h
+++ b/CleverTapSDKTests/InApps/CTInAppEvaluationManager+Tests.h
@@ -19,6 +19,7 @@
 @property (nonatomic, strong) NSDictionary *appLaunchedProperties;
 - (void)sortByPriority:(NSMutableArray *)inApps;
 - (NSMutableArray *)evaluate:(CTEventAdapter *)event withInApps:(NSArray *)inApps;
+- (NSMutableArray *)evaluate:(CTEventAdapter *)event withInApps:(NSArray *)inApps recordTriggers:(BOOL)recordTriggers;
 - (BOOL)shouldSuppress:(NSDictionary *)inApp;
 - (void)suppress:(NSDictionary *)inApp;
 - (NSString *)generateWzrkId:(NSString *)ti;

--- a/CleverTapSDKTests/InApps/CTInAppEvaluationManagerTest.m
+++ b/CleverTapSDKTests/InApps/CTInAppEvaluationManagerTest.m
@@ -1111,4 +1111,352 @@
     XCTAssertEqualObjects(@{ @"ti": @"1" }, inAppNoOffset);
 }
 
+#pragma mark App Launched Arbitration Helpers
+
+/// An app-launch in-app that always matches the App Launched event and has no limits.
+- (NSDictionary *)appLaunchedInAppWithId:(NSInteger)ti priority:(NSInteger)priority {
+    return @{
+        @"ti": @(ti),
+        @"priority": @(priority),
+        @"whenTriggers": @[@{ @"eventName": CLTAP_APP_LAUNCHED_EVENT }]
+    };
+}
+
+/// The same shape, tagged as built from content_fetch selection rules.
+- (NSDictionary *)syntheticInAppWithId:(NSInteger)ti priority:(NSInteger)priority {
+    NSMutableDictionary *inApp = [[self appLaunchedInAppWithId:ti priority:priority] mutableCopy];
+    inApp[CLTAP_INAPP_SYNTHETIC_CANDIDATE] = @YES;
+    return inApp;
+}
+
+- (NSArray<NSNumber *> *)queuedInAppIds {
+    NSMutableArray *ids = [NSMutableArray array];
+    for (NSDictionary *inApp in self.mockDisplayManager.inappNotifs) {
+        [ids addObject:@([[CTInAppNotification inAppId:inApp] integerValue])];
+    }
+    return ids;
+}
+
+#pragma mark App Launched Arbitration Tests
+
+- (void)testArbitrationNotOpenShowsImmediately {
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:1],
+        [self appLaunchedInAppWithId:200 priority:1]
+    ]];
+
+    // No window, so today's behaviour: the winner displays right away.
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+}
+
+- (void)testArbitrationBuffersUntilContentFetchCompletes {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"] syntheticCandidates:nil];
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:1]
+    ]];
+
+    XCTAssertEqual(self.mockDisplayManager.inappNotifs.count, 0,
+                   @"the in-app must be held while the content fetch is pending");
+
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+}
+
+/// The bug this whole feature exists for: two responses, each with its own winner, must still
+/// produce exactly one in-app.
+- (void)testArbitrationMergesBothResponsesAndShowsExactlyOne {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300", @"400"] syntheticCandidates:nil];
+
+    // /a1 response — its winner is 100 (equal priority, lower ti).
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:1],
+        [self appLaunchedInAppWithId:200 priority:1]
+    ]];
+    // /content response — 300 has a higher priority than anything in /a1.
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:300 priority:50],
+        [self appLaunchedInAppWithId:400 priority:1]
+    ]];
+
+    XCTAssertEqual(self.mockDisplayManager.inappNotifs.count, 0);
+
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+
+    // One in-app, and the highest priority across both responses — not one per response.
+    XCTAssertEqualObjects(@[@300], [self queuedInAppIds]);
+}
+
+- (void)testArbitrationAppLaunchedWinsMergeOnPriority {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"] syntheticCandidates:nil];
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:80]
+    ]];
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:300 priority:10]
+    ]];
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+}
+
+- (void)testArbitrationTimeoutShowsBestCandidateSoFar {
+    self.evaluationManager.appLaunchedArbitrationTimeout = 0.2;
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"] syntheticCandidates:nil];
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:1]
+    ]];
+    XCTAssertEqual(self.mockDisplayManager.inappNotifs.count, 0);
+
+    XCTestExpectation *shown = [self expectationWithDescription:@"timeout shows buffered candidate"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [shown fulfill];
+    });
+    [self waitForExpectations:@[shown] timeout:3.0];
+
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+}
+
+/// A slow fetch must not produce a second in-app after the timeout has already shown one.
+- (void)testArbitrationDropsCandidateArrivingAfterTimeout {
+    self.evaluationManager.appLaunchedArbitrationTimeout = 0.2;
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"] syntheticCandidates:nil];
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:1]
+    ]];
+
+    XCTestExpectation *timedOut = [self expectationWithDescription:@"window times out"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [timedOut fulfill];
+    });
+    [self waitForExpectations:@[timedOut] timeout:3.0];
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+
+    // The content response finally lands, with a candidate that would have won.
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:300 priority:100]
+    ]];
+
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds],
+                          @"a late candidate must be dropped, not shown as a second in-app");
+
+    // Completion tears the window down; still no second in-app.
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+}
+
+- (void)testArbitrationAfterCompletionBehavesNormallyAgain {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"] syntheticCandidates:nil];
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:1]
+    ]];
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+
+    // Window is gone, so a later response displays immediately as it would without the feature.
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:500 priority:1]
+    ]];
+    XCTAssertEqualObjects((@[@100, @500]), [self queuedInAppIds]);
+}
+
+- (void)testArbitrationCompletionWithNoCandidatesShowsNothing {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"] syntheticCandidates:nil];
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+
+    XCTAssertEqual(self.mockDisplayManager.inappNotifs.count, 0);
+}
+
+- (void)testArbitrationSecondOpenDoesNotDisplaceTheFirst {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"] syntheticCandidates:nil];
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:1]
+    ]];
+
+    // Opening again must not close the first window, which would show its winner and then start
+    // arbitrating a second time — the multi-in-app behaviour being removed.
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"400"] syntheticCandidates:nil];
+    XCTAssertEqual(self.mockDisplayManager.inappNotifs.count, 0);
+
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+}
+
+/*!
+ Synthetic payloads carry selection rules but no content, so displaying one would render an
+ empty in-app.
+
+ In production they only ever reach the dry-run path, never a response array — this covers the
+ display-boundary guard in case one ever leaks. Losing the slot is the accepted outcome; the
+ point is that nothing contentless is shown.
+ */
+- (void)testArbitrationNeverDisplaysSyntheticCandidate {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"] syntheticCandidates:nil];
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self syntheticInAppWithId:300 priority:100]
+    ]];
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+
+    XCTAssertEqual(self.mockDisplayManager.inappNotifs.count, 0,
+                   @"a synthetic candidate must never reach the display queue");
+}
+
+#pragma mark Dry Run Evaluation Tests
+
+- (void)testDryRunDoesNotRecordTriggers {
+    NSString *campaignId = @"1";
+    CTEventAdapter *event = [[CTEventAdapter alloc] initWithEventName:CLTAP_APP_LAUNCHED_EVENT
+                                                     eventProperties:@{}
+                                                         andLocation:kCLLocationCoordinate2DInvalid];
+    NSArray *inApps = @[[self appLaunchedInAppWithId:1 priority:1]];
+
+    NSUInteger before = [self.evaluationManager.triggerManager getTriggers:campaignId];
+    [self.evaluationManager evaluate:event withInApps:inApps recordTriggers:NO];
+    XCTAssertEqual([self.evaluationManager.triggerManager getTriggers:campaignId], before);
+
+    [self.evaluationManager evaluate:event withInApps:inApps recordTriggers:YES];
+    XCTAssertEqual([self.evaluationManager.triggerManager getTriggers:campaignId], before + 1);
+}
+
+/*!
+ The off-by-one guard.
+
+ The real path increments a campaign's trigger count *before* checking limits, so onExactly
+ compares against N+1. A dry run that read the raw N would disagree at every N — this asserts
+ the two stay in lockstep.
+ */
+- (void)testDryRunMatchesRealPathForOnExactlyLimit {
+    NSString *campaignId = @"1";
+    NSArray *inApps = @[@{
+        @"ti": @1,
+        @"priority": @1,
+        @"whenTriggers": @[@{ @"eventName": CLTAP_APP_LAUNCHED_EVENT }],
+        @"occurrenceLimits": @[@{ @"type": @"onExactly", @"limit": @3 }]
+    }];
+    CTEventAdapter *event = [[CTEventAdapter alloc] initWithEventName:CLTAP_APP_LAUNCHED_EVENT
+                                                     eventProperties:@{}
+                                                         andLocation:kCLLocationCoordinate2DInvalid];
+
+    for (NSUInteger initial = 0; initial <= 4; initial++) {
+        [self.evaluationManager.triggerManager removeTriggers:campaignId];
+        for (NSUInteger i = 0; i < initial; i++) {
+            [self.evaluationManager.triggerManager incrementTrigger:campaignId];
+        }
+
+        NSArray *dryRun = [self.evaluationManager evaluate:event withInApps:inApps recordTriggers:NO];
+        NSArray *real = [self.evaluationManager evaluate:event withInApps:inApps recordTriggers:YES];
+
+        XCTAssertEqual(dryRun.count, real.count,
+                       @"dry run disagreed with the real path at trigger count %lu",
+                       (unsigned long)initial);
+    }
+}
+
+- (void)testDryRunMatchesRealPathForOnEveryLimit {
+    NSString *campaignId = @"1";
+    NSArray *inApps = @[@{
+        @"ti": @1,
+        @"priority": @1,
+        @"whenTriggers": @[@{ @"eventName": CLTAP_APP_LAUNCHED_EVENT }],
+        @"occurrenceLimits": @[@{ @"type": @"onEvery", @"limit": @2 }]
+    }];
+    CTEventAdapter *event = [[CTEventAdapter alloc] initWithEventName:CLTAP_APP_LAUNCHED_EVENT
+                                                     eventProperties:@{}
+                                                         andLocation:kCLLocationCoordinate2DInvalid];
+
+    for (NSUInteger initial = 0; initial <= 5; initial++) {
+        [self.evaluationManager.triggerManager removeTriggers:campaignId];
+        for (NSUInteger i = 0; i < initial; i++) {
+            [self.evaluationManager.triggerManager incrementTrigger:campaignId];
+        }
+
+        NSArray *dryRun = [self.evaluationManager evaluate:event withInApps:inApps recordTriggers:NO];
+        NSArray *real = [self.evaluationManager evaluate:event withInApps:inApps recordTriggers:YES];
+
+        XCTAssertEqual(dryRun.count, real.count,
+                       @"dry run disagreed with the real path at trigger count %lu",
+                       (unsigned long)initial);
+    }
+}
+
+#pragma mark Fast Path Tests
+
+- (void)testFastPathShowsImmediatelyWhenAppLaunchedOutranksContent {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"]
+                                               syntheticCandidates:@[[self syntheticInAppWithId:300 priority:10]]];
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:80]
+    ]];
+
+    // No wait needed — nothing the fetch returns can outrank priority 80.
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+
+    // And the real content response is then dropped rather than shown as a second in-app.
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:300 priority:10]
+    ]];
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds]);
+}
+
+- (void)testFastPathWaitsWhenContentOutranksAppLaunched {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"]
+                                               syntheticCandidates:@[[self syntheticInAppWithId:300 priority:90]]];
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:10]
+    ]];
+
+    XCTAssertEqual(self.mockDisplayManager.inappNotifs.count, 0,
+                   @"a higher-priority content candidate is predicted, so the window must wait");
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:300 priority:90]
+    ]];
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+
+    XCTAssertEqualObjects(@[@300], [self queuedInAppIds]);
+}
+
+- (void)testFastPathShowsImmediatelyWhenNoContentCandidateQualifies {
+    // The synthetic candidate cannot qualify — its trigger does not match App Launched.
+    NSDictionary *ineligible = @{
+        @"ti": @300,
+        @"priority": @100,
+        @"whenTriggers": @[@{ @"eventName": @"Some Other Event" }],
+        CLTAP_INAPP_SYNTHETIC_CANDIDATE: @YES
+    };
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"]
+                                               syntheticCandidates:@[ineligible]];
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:100 priority:1]
+    ]];
+
+    XCTAssertEqualObjects(@[@100], [self queuedInAppIds],
+                          @"waiting cannot change the outcome, so show without waiting");
+}
+
+- (void)testFastPathWaitsWhenNoAppLaunchedCandidateIsEligible {
+    [self.evaluationManager openAppLaunchedArbitrationWithTargetIds:@[@"300"]
+                                               syntheticCandidates:@[[self syntheticInAppWithId:300 priority:1]]];
+
+    // Nothing to show now, so the content result is the only possibility.
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[]];
+    XCTAssertEqual(self.mockDisplayManager.inappNotifs.count, 0);
+
+    [self.evaluationManager evaluateOnAppLaunchedServerSide:@[
+        [self appLaunchedInAppWithId:300 priority:1]
+    ]];
+    [self.evaluationManager appLaunchedArbitrationContentFetchDidComplete];
+    XCTAssertEqualObjects(@[@300], [self queuedInAppIds]);
+}
+
 @end


### PR DESCRIPTION
- Show only one In-App on app launch when content_fetch is present
- Content response for native display now merges by unitID, /a1 response still replaces it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved app-launch in-app selection across app and content-fetch responses.
  * Added a brief arbitration window to choose the best eligible in-app and suppress late candidates.
  * Improved display-unit updates by merging content-fetch results while preserving order and replacing matching units.
  * Added more reliable content-fetch completion handling.

* **Bug Fixes**
  * Prevented client-side in-apps from being stored when received through content fetches.
  * Improved handling of malformed content-fetch entries and duplicate display units.

* **Tests**
  * Added coverage for arbitration, timeouts, merging, parsing, and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->